### PR TITLE
Replace goal target effect with completion policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ files or typing into a dashboard.
 
 ## What it does
 
-You define a goal: an objective metric (with a direction and target effect)
-plus a set of constraints (other instruments that must pass or stay within
-bounds). Claude Code or Codex, driven by two embedded agent contracts, then
-loops:
+You define a goal: an objective metric, a set of constraints, and optionally
+a success threshold plus continuation policy. Claude Code or Codex, driven by
+two embedded agent contracts, then loops:
 
 ```mermaid
 sequenceDiagram
@@ -227,6 +226,7 @@ goal is active is bound to it via `goal_id`.
 
 ```sh
 autoresearch goal set   --objective-instrument host_timing --objective-direction decrease \
+                        --success-threshold 0.20 --on-success ask_human \
                         --constraint-max 'size_flash=131072' --constraint-require 'host_test=pass'
 autoresearch goal conclude --summary "demonstrated 18% gain"
 autoresearch goal new   --from G-0001 --trigger C-0012 \
@@ -240,7 +240,7 @@ Goals are markdown with YAML frontmatter, stored as `.research/goals/G-NNNN.md`:
 
 ```yaml
 ---
-schema_version: 2
+schema_version: 3
 id: G-0001
 status: active
 created_at: 2026-04-12T10:00:00Z
@@ -248,7 +248,9 @@ objective:
   instrument: host_timing
   target: dsp_fir
   direction: decrease
-  target_effect: 0.20
+completion:
+  threshold: 0.20
+  on_threshold: ask_human
 constraints:
   - instrument: size_flash
     max: 131072

--- a/examples/cortex-m4-synth/goal.md
+++ b/examples/cortex-m4-synth/goal.md
@@ -3,7 +3,9 @@ objective:
   instrument: timing
   target: dsp_fir
   direction: decrease
-  target_effect: 0.20
+completion:
+  threshold: 0.20
+  on_threshold: ask_human
 constraints:
   - instrument: binary_size
     max: 131072

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -94,21 +94,21 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 // ---- snapshot capture ----
 
 type dashboardSnapshot struct {
-	Project       string              `json:"project"`
-	Paused        bool                `json:"paused"`
-	PauseReason   string              `json:"pause_reason,omitempty"`
-	Mode          string              `json:"mode"`
-	Goal          *entity.Goal        `json:"goal,omitempty"`
-	Budgets       dashboardBudgets    `json:"budgets"`
-	Counts        map[string]int      `json:"counts"`
-	Tree          []*treeNode         `json:"tree"`
-	Frontier      []frontierRow       `json:"frontier"`
-	StalledFor    int                 `json:"stalled_for"`
+	Project          string              `json:"project"`
+	Paused           bool                `json:"paused"`
+	PauseReason      string              `json:"pause_reason,omitempty"`
+	Mode             string              `json:"mode"`
+	Goal             *entity.Goal        `json:"goal,omitempty"`
+	Budgets          dashboardBudgets    `json:"budgets"`
+	Counts           map[string]int      `json:"counts"`
+	Tree             []*treeNode         `json:"tree"`
+	Frontier         []frontierRow       `json:"frontier"`
+	StalledFor       int                 `json:"stalled_for"`
 	InFlight         []dashboardInFlight `json:"in_flight"`
 	StaleExperiments []dashboardStaleExp `json:"stale_experiments,omitempty"`
 	RecentLessons    []*entity.Lesson    `json:"recent_lessons,omitempty"`
-	RecentEvents  []store.Event       `json:"recent_events"`
-	CapturedAt    time.Time           `json:"captured_at"`
+	RecentEvents     []store.Event       `json:"recent_events"`
+	CapturedAt       time.Time           `json:"captured_at"`
 }
 
 type dashboardBudgets struct {
@@ -480,15 +480,8 @@ func renderDashboardGoal(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 		fmt.Fprintln(w, " "+a.bold("Goal:")+" "+a.dim("(no goal set — run `autoresearch goal set`)"))
 		return
 	}
-	obj := snap.Goal.Objective
-	line := " " + a.bold("Goal:") + " " + a.cyan(obj.Direction) + " " + a.cyan(obj.Instrument)
-	if obj.Target != "" {
-		line += " on " + obj.Target
-	}
-	if obj.TargetEffect > 0 {
-		line += fmt.Sprintf(" (target_effect=%g)", obj.TargetEffect)
-	}
-	fmt.Fprintln(w, line)
+	fmt.Fprintln(w, " "+a.bold("Goal:")+" "+a.cyan(formatGoalObjective(snap.Goal)))
+	fmt.Fprintln(w, " "+a.bold("Completion:")+" "+formatGoalCompletion(snap.Goal))
 	if len(snap.Goal.Constraints) > 0 {
 		fmt.Fprintln(w, " "+a.bold("Constraints:"))
 		for _, c := range snap.Goal.Constraints {

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -122,10 +122,13 @@ func TestRenderDashboard_FullState(t *testing.T) {
 	flash := 65536.0
 	snap.Goal = &entity.Goal{
 		Objective: entity.Objective{
-			Instrument:   "qemu_cycles",
-			Target:       "dsp_fir",
-			Direction:    "decrease",
-			TargetEffect: 0.20,
+			Instrument: "qemu_cycles",
+			Target:     "dsp_fir",
+			Direction:  "decrease",
+		},
+		Completion: &entity.Completion{
+			Threshold:   0.20,
+			OnThreshold: entity.GoalOnThresholdAskHuman,
 		},
 		Constraints: []entity.Constraint{
 			{Instrument: "size_flash", Max: &flash},
@@ -172,7 +175,8 @@ func TestRenderDashboard_FullState(t *testing.T) {
 	out := buf.String()
 
 	expectations := []string{
-		"Goal: decrease qemu_cycles on dsp_fir (target_effect=0.2)",
+		"Goal: decrease qemu_cycles on dsp_fir",
+		"Completion: threshold=0.2 -> ask_human",
 		"size_flash ≤ 65536",
 		"host_test require=pass",
 		"5/20 experiments",
@@ -238,8 +242,9 @@ func TestRenderDashboard_Colored(t *testing.T) {
 	flash := 65536.0
 	snap.Goal = &entity.Goal{
 		Objective: entity.Objective{
-			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease", TargetEffect: 0.2,
+			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease",
 		},
+		Completion:  &entity.Completion{Threshold: 0.2, OnThreshold: entity.GoalOnThresholdAskHuman},
 		Constraints: []entity.Constraint{{Instrument: "size_flash", Max: &flash}},
 	}
 	snap.Counts = map[string]int{"hypotheses": 1, "experiments": 1, "observations": 0, "conclusions": 0}

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -52,7 +52,9 @@ configured ` + "`budgets.frontier_stall_k`" + ` to decide when to stop the loop.
 			if err != nil {
 				return err
 			}
-			rows, stalledFor := computeFrontier(s, goal, concls)
+			obsByExp := loadObservationsByExperiment(s)
+			rows, stalledFor := computeFrontierFromObservations(goal, concls, obsByExp)
+			assessment := assessGoalCompletion(goal, concls, obsByExp)
 
 			cfg, err := s.Config()
 			if err != nil {
@@ -67,25 +69,38 @@ configured ` + "`budgets.frontier_stall_k`" + ` to decide when to stop the loop.
 						"direction":  goal.Objective.Direction,
 					},
 					"frontier":         rows,
+					"goal_assessment":  assessment,
 					"stalled_for":      stalledFor,
 					"frontier_stall_k": cfg.Budgets.FrontierStallK,
 					"stall_reached":    cfg.Budgets.FrontierStallK > 0 && stalledFor >= cfg.Budgets.FrontierStallK,
 				})
 			}
+			w.Textf("[goal: %s, objective: %s, %d supported conclusions]\n", goal.ID, formatGoalObjective(goal), len(rows))
+			w.Textln("")
 			if len(rows) == 0 {
 				w.Textln("(no supported+feasible conclusions yet)")
-				return nil
-			}
-			w.Textf("[goal: %s, objective: %s %s, %d supported conclusions]\n", goal.ID, goal.Objective.Direction, goal.Objective.Instrument, len(rows))
-			w.Textln("")
-			for i, r := range rows {
-				marker := "  "
-				if i == 0 {
-					marker = "* "
+				w.Textln("")
+			} else {
+				for i, r := range rows {
+					marker := "  "
+					if i == 0 {
+						marker = "* "
+					}
+					w.Textf("%s%s  %s  %s=%.6g\n", marker, r.Conclusion, r.Hypothesis, goal.Objective.Instrument, r.Value)
 				}
-				w.Textf("%s%s  %s  %s=%.6g\n", marker, r.Conclusion, r.Hypothesis, goal.Objective.Instrument, r.Value)
+				w.Textln("")
 			}
-			w.Textln("")
+			switch assessment.Mode {
+			case "threshold":
+				w.Textf("goal_assessment: threshold=%g -> %s", assessment.Threshold, assessment.OnThreshold)
+				if assessment.Met {
+					w.Textf(" (met by %s; recommended=%s)\n", assessment.MetByConclusion, assessment.RecommendedAction)
+				} else {
+					w.Textf(" (not yet met; recommended=%s)\n", assessment.RecommendedAction)
+				}
+			default:
+				w.Textln("goal_assessment: open-ended -> continue_until_stall (recommended=continue)")
+			}
 			w.Textf("stalled_for: %d", stalledFor)
 			if cfg.Budgets.FrontierStallK > 0 {
 				w.Textf(" (stall-k=%d)", cfg.Budgets.FrontierStallK)
@@ -139,54 +154,47 @@ type frontierRow struct {
 	DeltaFrac  float64 `json:"delta_frac"`
 }
 
+type frontierGoalAssessment struct {
+	Mode              string  `json:"mode"`
+	Threshold         float64 `json:"threshold,omitempty"`
+	OnThreshold       string  `json:"on_threshold,omitempty"`
+	Met               bool    `json:"met"`
+	MetByConclusion   string  `json:"met_by_conclusion,omitempty"`
+	RecommendedAction string  `json:"recommended_action"`
+}
+
+type frontierCandidate struct {
+	Conclusion *entity.Conclusion
+	Value      float64
+}
+
 // computeFrontier returns rows in best-first order for the objective and the
 // count of conclusions written since the last frontier improvement.
 func computeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) (rows []frontierRow, stalledFor int) {
-	rows = []frontierRow{} // always non-nil so --json emits [] not null
-	// Filter: supported + feasible (require-constraints satisfied).
-	requireByInst := map[string]string{}
-	for _, c := range goal.Constraints {
-		if c.Require != "" {
-			requireByInst[c.Instrument] = c.Require
-		}
-	}
+	return computeFrontierFromObservations(goal, concls, loadObservationsByExperiment(s))
+}
 
-	// Load all observations once and index by experiment ID. This replaces
-	// per-conclusion ListObservationsForExperiment calls that previously
-	// re-read and re-parsed every observation file K×4 times (twice per
-	// loop × two loops).
-	obsByExp := loadObservationsByExperiment(s)
+func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation) (rows []frontierRow, stalledFor int) {
+	rows = []frontierRow{} // always non-nil so --json emits [] not null
+	requireByInst := frontierRequireConstraints(goal)
 
 	for _, c := range concls {
-		if c.Verdict != entity.VerdictSupported {
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if !ok {
 			continue
 		}
-		if c.Effect.Instrument != goal.Objective.Instrument {
-			continue
-		}
-		if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
-			continue
-		}
-		value := candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
 		rows = append(rows, frontierRow{
 			Conclusion: c.ID,
 			Hypothesis: c.Hypothesis,
 			Candidate:  c.CandidateExp,
-			Value:      value,
+			Value:      val,
 			DeltaFrac:  c.Effect.DeltaFrac,
 		})
 	}
-	// Sort best-first.
 	sort.Slice(rows, func(i, j int) bool {
-		if goal.Objective.Direction == "decrease" {
-			return rows[i].Value < rows[j].Value
-		}
-		return rows[i].Value > rows[j].Value
+		return betterFrontierValue(goal.Objective.Direction, rows[i].Value, rows[j].Value)
 	})
 
-	// stalled_for: walk conclusions in chronological order, track the
-	// best-so-far, count how many supported conclusions written AFTER the
-	// last improvement.
 	sortedByTime := make([]*entity.Conclusion, len(concls))
 	copy(sortedByTime, concls)
 	sort.Slice(sortedByTime, func(i, j int) bool { return sortedByTime[i].CreatedAt.Before(sortedByTime[j].CreatedAt) })
@@ -194,33 +202,20 @@ func computeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclus
 	hasBest := false
 	var bestValue float64
 	for _, c := range sortedByTime {
-		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if !ok {
 			if hasBest {
 				stalledFor++
 			}
 			continue
 		}
-		if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
-			if hasBest {
-				stalledFor++
-			}
-			continue
-		}
-		val := candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
 		if !hasBest {
 			hasBest = true
 			bestValue = val
 			stalledFor = 0
 			continue
 		}
-		improved := false
-		if goal.Objective.Direction == "decrease" && val < bestValue {
-			improved = true
-		}
-		if goal.Objective.Direction == "increase" && val > bestValue {
-			improved = true
-		}
-		if improved {
+		if betterFrontierValue(goal.Objective.Direction, val, bestValue) {
 			bestValue = val
 			stalledFor = 0
 		} else {
@@ -228,6 +223,100 @@ func computeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclus
 		}
 	}
 	return rows, stalledFor
+}
+
+func frontierRequireConstraints(goal *entity.Goal) map[string]string {
+	requireByInst := map[string]string{}
+	if goal == nil {
+		return requireByInst
+	}
+	for _, c := range goal.Constraints {
+		if c.Require != "" {
+			requireByInst[c.Instrument] = c.Require
+		}
+	}
+	return requireByInst
+}
+
+func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string) (float64, bool) {
+	if goal == nil || c == nil {
+		return 0, false
+	}
+	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+		return 0, false
+	}
+	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
+		return 0, false
+	}
+	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument), true
+}
+
+func betterFrontierValue(direction string, candidate, incumbent float64) bool {
+	if direction == "decrease" {
+		return candidate < incumbent
+	}
+	return candidate > incumbent
+}
+
+func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation) frontierGoalAssessment {
+	if goal == nil || goal.IsOpenEnded() {
+		return frontierGoalAssessment{
+			Mode:              "open_ended",
+			Met:               false,
+			RecommendedAction: "continue",
+		}
+	}
+
+	assessment := frontierGoalAssessment{
+		Mode:              "threshold",
+		Threshold:         goal.Completion.Threshold,
+		OnThreshold:       goal.EffectiveOnThreshold(),
+		Met:               false,
+		RecommendedAction: "continue",
+	}
+
+	requireByInst := frontierRequireConstraints(goal)
+	var bestReviewed frontierCandidate
+	hasReviewed := false
+	for _, c := range concls {
+		if c == nil || c.ReviewedBy == "" {
+			continue
+		}
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if !ok {
+			continue
+		}
+		if !hasReviewed || betterFrontierValue(goal.Objective.Direction, val, bestReviewed.Value) {
+			bestReviewed = frontierCandidate{Conclusion: c, Value: val}
+			hasReviewed = true
+		}
+	}
+	if !hasReviewed {
+		return assessment
+	}
+	if meetsGoalThreshold(goal.Objective.Direction, bestReviewed.Conclusion.Effect.DeltaFrac, goal.Completion.Threshold) {
+		assessment.Met = true
+		assessment.MetByConclusion = bestReviewed.Conclusion.ID
+		switch assessment.OnThreshold {
+		case entity.GoalOnThresholdAskHuman:
+			assessment.RecommendedAction = "ask_human"
+		case entity.GoalOnThresholdStop:
+			assessment.RecommendedAction = "stop"
+		default:
+			assessment.RecommendedAction = "continue"
+		}
+	}
+	return assessment
+}
+
+func meetsGoalThreshold(direction string, deltaFrac, threshold float64) bool {
+	if threshold <= 0 {
+		return false
+	}
+	if direction == "decrease" {
+		return deltaFrac <= -threshold
+	}
+	return deltaFrac >= threshold
 }
 
 // loadObservationsByExperiment reads all observations once and returns them

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -27,6 +27,10 @@ by at least one matching observation in its candidate experiment. For v1
 we only filter on require-constraints; max/min are reported but not yet
 used to disqualify.
 
+` + "`goal_assessment`" + ` is stricter than the row filter: it only reports
+threshold satisfaction when a reviewed, supported conclusion reaches the
+goal threshold and its candidate satisfies every goal constraint.
+
 Orchestrators read ` + "`frontier --json`" + `'s ` + "`stalled_for`" + ` field against the
 configured ` + "`budgets.frontier_stall_k`" + ` to decide when to stop the loop.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -248,7 +252,7 @@ func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp ma
 	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
 		return 0, false
 	}
-	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument), true
+	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
 }
 
 func betterFrontierValue(direction string, candidate, incumbent float64) bool {
@@ -275,14 +279,20 @@ func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 		RecommendedAction: "continue",
 	}
 
-	requireByInst := frontierRequireConstraints(goal)
 	var bestReviewed frontierCandidate
 	hasReviewed := false
 	for _, c := range concls {
 		if c == nil || c.ReviewedBy == "" {
 			continue
 		}
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+			continue
+		}
+		obs := obsByExp[c.CandidateExp]
+		if !goalConstraintsSatisfied(obs, goal.Constraints) {
+			continue
+		}
+		val, ok := candidateObjectiveValue(obs, goal.Objective.Instrument)
 		if !ok {
 			continue
 		}
@@ -366,11 +376,48 @@ func requireSatisfied(obs []*entity.Observation, req map[string]string) bool {
 	return true
 }
 
-func candidateObjectiveValue(obs []*entity.Observation, instrument string) float64 {
-	for _, o := range obs {
-		if o.Instrument == instrument {
-			return o.Value
+func goalConstraintsSatisfied(obs []*entity.Observation, constraints []entity.Constraint) bool {
+	for _, c := range constraints {
+		if !goalConstraintSatisfied(obs, c) {
+			return false
 		}
 	}
-	return 0
+	return true
+}
+
+func goalConstraintSatisfied(obs []*entity.Observation, c entity.Constraint) bool {
+	for _, o := range obs {
+		if o.Instrument != c.Instrument {
+			continue
+		}
+		switch {
+		case c.Max != nil:
+			if o.Value <= *c.Max {
+				return true
+			}
+		case c.Min != nil:
+			if o.Value >= *c.Min {
+				return true
+			}
+		case c.Require != "":
+			switch c.Require {
+			case "pass":
+				if o.Pass != nil && *o.Pass {
+					return true
+				}
+			default:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func candidateObjectiveValue(obs []*entity.Observation, instrument string) (float64, bool) {
+	for _, o := range obs {
+		if o.Instrument == instrument {
+			return o.Value, true
+		}
+	}
+	return 0, false
 }

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -51,23 +51,25 @@ the circumstances (code, tooling, lessons) are different.`,
 }
 
 type goalFlags struct {
-	file            string
-	objInstrument   string
-	objTarget       string
-	objDirection    string
-	objTargetEffect float64
-	constraintMax   []string
-	constraintMin   []string
-	constraintReq   []string
-	steeringText    string
+	file             string
+	objInstrument    string
+	objTarget        string
+	objDirection     string
+	successThreshold float64
+	onSuccess        string
+	constraintMax    []string
+	constraintMin    []string
+	constraintReq    []string
+	steeringText     string
 }
 
 func addGoalBodyFlags(c *cobra.Command, f *goalFlags) {
-	c.Flags().StringVar(&f.file, "file", "", "path to goal.md (mutually exclusive with --objective-*)")
+	c.Flags().StringVar(&f.file, "file", "", "path to goal.md (mutually exclusive with goal-construction flags)")
 	c.Flags().StringVar(&f.objInstrument, "objective-instrument", "", "name of the registered instrument the objective targets")
 	c.Flags().StringVar(&f.objTarget, "objective-target", "", "what inside the target is being measured (optional, e.g. 'dsp_fir')")
 	c.Flags().StringVar(&f.objDirection, "objective-direction", "", "increase | decrease")
-	c.Flags().Float64Var(&f.objTargetEffect, "objective-target-effect", 0, "fractional effect the user aspires to (optional)")
+	c.Flags().Float64Var(&f.successThreshold, "success-threshold", 0, "fractional effect that counts as goal satisfaction (optional)")
+	c.Flags().StringVar(&f.onSuccess, "on-success", "", "what to do after the success threshold is met: ask_human | stop | continue_until_stall | continue_until_budget_cap")
 	c.Flags().StringArrayVar(&f.constraintMax, "constraint-max", nil, "max constraint as 'instrument=value' (repeatable)")
 	c.Flags().StringArrayVar(&f.constraintMin, "constraint-min", nil, "min constraint as 'instrument=value' (repeatable)")
 	c.Flags().StringArrayVar(&f.constraintReq, "constraint-require", nil, "require constraint as 'instrument=value' (repeatable, e.g. 'host_test=pass')")
@@ -79,9 +81,10 @@ func addGoalBodyFlags(c *cobra.Command, f *goalFlags) {
 func loadGoalFromFlags(f *goalFlags) (*entity.Goal, error) {
 	fileMode := f.file != ""
 	flagMode := f.objInstrument != "" || f.objDirection != "" ||
+		f.successThreshold > 0 || f.onSuccess != "" ||
 		len(f.constraintMax) > 0 || len(f.constraintMin) > 0 || len(f.constraintReq) > 0
 	if fileMode && flagMode {
-		return nil, errors.New("--file and --objective-* flags are mutually exclusive")
+		return nil, errors.New("--file and goal-construction flags are mutually exclusive")
 	}
 	if !fileMode && !flagMode {
 		return nil, errors.New("provide either --file or --objective-instrument + --objective-direction + at least one --constraint-*")
@@ -93,7 +96,7 @@ func loadGoalFromFlags(f *goalFlags) (*entity.Goal, error) {
 		}
 		return entity.ParseGoal(data)
 	}
-	return buildGoalFromFlags(f.objInstrument, f.objTarget, f.objDirection, f.objTargetEffect,
+	return buildGoalFromFlags(f.objInstrument, f.objTarget, f.objDirection, f.successThreshold, f.onSuccess,
 		f.constraintMax, f.constraintMin, f.constraintReq, f.steeringText)
 }
 
@@ -109,7 +112,8 @@ already exists on disk — use 'goal new' for subsequent goals.
 Two input modes, mutually exclusive:
 
   --file goal.md            Read a YAML-frontmatter goal document.
-  --objective-* + --constraint-*   Build the goal from flags directly.
+  --objective-* + --constraint-*   Build the goal from flags directly
+                                   (optional: --success-threshold, --on-success).
 
 The flag form is the one the main agent session uses when translating a
 human's natural-language request — the session never asks the human to
@@ -166,8 +170,8 @@ goal.md and point --file at it.`,
 				return err
 			}
 			return w.Emit(
-				fmt.Sprintf("bootstrapped %s: %s on %s (target_effect=%g, %d constraints)",
-					id, g.Objective.Direction, g.Objective.Instrument, g.Objective.TargetEffect, len(g.Constraints)),
+				fmt.Sprintf("bootstrapped %s: %s (%d constraints)",
+					id, formatGoalObjective(g), len(g.Constraints)),
 				map[string]any{"status": "ok", "id": id, "goal": g},
 			)
 		},
@@ -405,7 +409,8 @@ func runGoalClosure(args []string, text, author, status, eventKind, label string
 
 func buildGoalFromFlags(
 	instrument, target, direction string,
-	targetEffect float64,
+	successThreshold float64,
+	onSuccess string,
 	maxSpecs, minSpecs, reqSpecs []string,
 	steering string,
 ) (*entity.Goal, error) {
@@ -415,14 +420,25 @@ func buildGoalFromFlags(
 	if direction != "increase" && direction != "decrease" {
 		return nil, fmt.Errorf("--objective-direction must be 'increase' or 'decrease', got %q", direction)
 	}
+	if successThreshold <= 0 && strings.TrimSpace(onSuccess) != "" {
+		return nil, errors.New("--on-success requires --success-threshold")
+	}
 	g := &entity.Goal{
-		SchemaVersion: 2,
+		SchemaVersion: entity.GoalSchemaVersion,
 		Objective: entity.Objective{
-			Instrument:   instrument,
-			Target:       target,
-			Direction:    direction,
-			TargetEffect: targetEffect,
+			Instrument: instrument,
+			Target:     target,
+			Direction:  direction,
 		},
+	}
+	if successThreshold > 0 {
+		g.Completion = &entity.Completion{
+			Threshold:   successThreshold,
+			OnThreshold: strings.TrimSpace(onSuccess),
+		}
+		if g.Completion.OnThreshold == "" {
+			g.Completion.OnThreshold = entity.GoalOnThresholdAskHuman
+		}
 	}
 	for _, spec := range maxSpecs {
 		c, err := parseConstraintKV(spec, "max")
@@ -527,14 +543,8 @@ func goalShowCmd() *cobra.Command {
 			if g.ClosedAt != nil {
 				w.Textf("closed_at:    %s\n", g.ClosedAt.Format("2006-01-02T15:04:05Z07:00"))
 			}
-			w.Textf("objective:    %s %s", g.Objective.Direction, g.Objective.Instrument)
-			if g.Objective.Target != "" {
-				w.Textf(" on %s", g.Objective.Target)
-			}
-			if g.Objective.TargetEffect > 0 {
-				w.Textf(" (target_effect=%g)", g.Objective.TargetEffect)
-			}
-			w.Textln("")
+			w.Textf("objective:    %s\n", formatGoalObjective(g))
+			w.Textf("completion:   %s\n", formatGoalCompletion(g))
 			w.Textln("constraints:")
 			for _, cst := range g.Constraints {
 				w.Textf("  %s\n", entity.FormatConstraint(cst))
@@ -577,8 +587,8 @@ func goalListCmd() *cobra.Command {
 			}
 			if w.IsJSON() {
 				return w.JSON(map[string]any{
-					"current":  st.CurrentGoalID,
-					"goals":    filtered,
+					"current": st.CurrentGoalID,
+					"goals":   filtered,
 				})
 			}
 			if len(filtered) == 0 {

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -81,7 +81,7 @@ func addGoalBodyFlags(c *cobra.Command, f *goalFlags) {
 func loadGoalFromFlags(f *goalFlags) (*entity.Goal, error) {
 	fileMode := f.file != ""
 	flagMode := f.objInstrument != "" || f.objDirection != "" ||
-		f.successThreshold > 0 || f.onSuccess != "" ||
+		f.successThreshold != 0 || f.onSuccess != "" ||
 		len(f.constraintMax) > 0 || len(f.constraintMin) > 0 || len(f.constraintReq) > 0
 	if fileMode && flagMode {
 		return nil, errors.New("--file and goal-construction flags are mutually exclusive")
@@ -414,14 +414,17 @@ func buildGoalFromFlags(
 	maxSpecs, minSpecs, reqSpecs []string,
 	steering string,
 ) (*entity.Goal, error) {
+	if successThreshold < 0 {
+		return nil, errors.New("--success-threshold must be >= 0")
+	}
+	if successThreshold == 0 && strings.TrimSpace(onSuccess) != "" {
+		return nil, errors.New("--on-success requires --success-threshold")
+	}
 	if strings.TrimSpace(instrument) == "" {
 		return nil, errors.New("--objective-instrument is required in flag mode")
 	}
 	if direction != "increase" && direction != "decrease" {
 		return nil, fmt.Errorf("--objective-direction must be 'increase' or 'decrease', got %q", direction)
-	}
-	if successThreshold <= 0 && strings.TrimSpace(onSuccess) != "" {
-		return nil, errors.New("--on-success requires --success-threshold")
 	}
 	g := &entity.Goal{
 		SchemaVersion: entity.GoalSchemaVersion,

--- a/internal/cli/goal_display.go
+++ b/internal/cli/goal_display.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func formatGoalObjective(g *entity.Goal) string {
+	if g == nil {
+		return ""
+	}
+	obj := g.Objective.Direction + " " + g.Objective.Instrument
+	if g.Objective.Target != "" {
+		obj += " on " + g.Objective.Target
+	}
+	return obj
+}
+
+func formatGoalCompletion(g *entity.Goal) string {
+	if g == nil {
+		return ""
+	}
+	if g.IsOpenEnded() {
+		return "open-ended -> continue_until_stall"
+	}
+	return fmt.Sprintf("threshold=%g -> %s", g.Completion.Threshold, g.EffectiveOnThreshold())
+}

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -46,6 +46,23 @@ func TestBuildGoalFromFlags_RejectsOnSuccessWithoutThreshold(t *testing.T) {
 	}
 }
 
+func TestBuildGoalFromFlags_RejectsNegativeThreshold(t *testing.T) {
+	_, err := buildGoalFromFlags(
+		"host_timing",
+		"dsp_fir",
+		"decrease",
+		-0.1,
+		"",
+		[]string{"size_flash=131072"},
+		nil,
+		nil,
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected negative threshold to be rejected")
+	}
+}
+
 func TestAssessGoalCompletion(t *testing.T) {
 	t.Run("open ended goals continue", func(t *testing.T) {
 		goal := &entity.Goal{
@@ -116,6 +133,74 @@ func TestAssessGoalCompletion(t *testing.T) {
 		}
 		got := assessGoalCompletion(goal, concls, obsByExp)
 		if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("goal met only by reviewed candidate satisfying all constraints", func(t *testing.T) {
+		flashMax := 100.0
+		qualityMin := 0.99
+		pass := true
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+			Completion: &entity.Completion{
+				Threshold:   0.2,
+				OnThreshold: entity.GoalOnThresholdAskHuman,
+			},
+			Constraints: []entity.Constraint{
+				{Instrument: "size_flash", Max: &flashMax},
+				{Instrument: "quality_score", Min: &qualityMin},
+				{Instrument: "host_test", Require: "pass"},
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-0100",
+				Hypothesis:   "H-0100",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-0100",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.30},
+			},
+			{
+				ID:           "C-0101",
+				Hypothesis:   "H-0101",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-0101",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.25},
+			},
+			{
+				ID:           "C-0102",
+				Hypothesis:   "H-0102",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-0102",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.22},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-0100": {
+				{Instrument: "host_timing", Value: 0.70},
+				{Instrument: "size_flash", Value: 120},
+				{Instrument: "quality_score", Value: 0.995},
+				{Instrument: "host_test", Pass: &pass},
+			},
+			"E-0101": {
+				{Instrument: "host_timing", Value: 0.75},
+				{Instrument: "size_flash", Value: 90},
+				{Instrument: "quality_score", Value: 0.98},
+				{Instrument: "host_test", Pass: &pass},
+			},
+			"E-0102": {
+				{Instrument: "host_timing", Value: 0.78},
+				{Instrument: "size_flash", Value: 95},
+				{Instrument: "quality_score", Value: 0.995},
+				{Instrument: "host_test", Pass: &pass},
+			},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp)
+		if !got.Met || got.MetByConclusion != "C-0102" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
 	})

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestBuildGoalFromFlags_DefaultsThresholdPolicy(t *testing.T) {
+	g, err := buildGoalFromFlags(
+		"host_timing",
+		"dsp_fir",
+		"decrease",
+		0.2,
+		"",
+		[]string{"size_flash=131072"},
+		nil,
+		nil,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildGoalFromFlags failed: %v", err)
+	}
+	if g.Completion == nil {
+		t.Fatal("expected completion block to be populated")
+	}
+	if got, want := g.Completion.OnThreshold, entity.GoalOnThresholdAskHuman; got != want {
+		t.Fatalf("completion.on_threshold = %q, want %q", got, want)
+	}
+}
+
+func TestBuildGoalFromFlags_RejectsOnSuccessWithoutThreshold(t *testing.T) {
+	_, err := buildGoalFromFlags(
+		"host_timing",
+		"dsp_fir",
+		"decrease",
+		0,
+		entity.GoalOnThresholdStop,
+		[]string{"size_flash=131072"},
+		nil,
+		nil,
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected missing threshold to be rejected")
+	}
+}
+
+func TestAssessGoalCompletion(t *testing.T) {
+	t.Run("open ended goals continue", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		}
+		got := assessGoalCompletion(goal, nil, nil)
+		if got.Mode != "open_ended" || got.Met || got.RecommendedAction != "continue" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("thresholded decrease goal met by reviewed supported frontier candidate", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+			Completion: &entity.Completion{
+				Threshold:   0.2,
+				OnThreshold: entity.GoalOnThresholdAskHuman,
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-0001",
+				Hypothesis:   "H-0001",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-0001",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.25},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-0001": {{Instrument: "host_timing", Value: 0.75}},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp)
+		if !got.Met || got.MetByConclusion != "C-0001" || got.RecommendedAction != "ask_human" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("best reviewed candidate wins even when an unreviewed candidate is better", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+			Completion: &entity.Completion{
+				Threshold:   0.15,
+				OnThreshold: entity.GoalOnThresholdStop,
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-0001",
+				Hypothesis:   "H-0001",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "",
+				CandidateExp: "E-0001",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.30},
+			},
+			{
+				ID:           "C-0002",
+				Hypothesis:   "H-0002",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-0002",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.18},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-0001": {{Instrument: "host_timing", Value: 0.70}},
+			"E-0002": {{Instrument: "host_timing", Value: 0.82}},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp)
+		if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("increase goals use positive delta_frac threshold", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "throughput", Direction: "increase"},
+			Completion: &entity.Completion{
+				Threshold:   0.1,
+				OnThreshold: entity.GoalOnThresholdContinueUntilStall,
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-1000",
+				Hypothesis:   "H-1000",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-1000",
+				Effect:       entity.Effect{Instrument: "throughput", DeltaFrac: 0.12},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-1000": {{Instrument: "throughput", Value: 112}},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp)
+		if !got.Met || got.RecommendedAction != "continue" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("unreviewed or non-supported conclusions do not satisfy the goal", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+			Completion: &entity.Completion{
+				Threshold:   0.2,
+				OnThreshold: entity.GoalOnThresholdAskHuman,
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-2000",
+				Hypothesis:   "H-2000",
+				Verdict:      entity.VerdictInconclusive,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-2000",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.3},
+			},
+			{
+				ID:           "C-2001",
+				Hypothesis:   "H-2001",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "",
+				CandidateExp: "E-2001",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.3},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-2000": {{Instrument: "host_timing", Value: 0.70}},
+			"E-2001": {{Instrument: "host_timing", Value: 0.70}},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp)
+		if got.Met || got.RecommendedAction != "continue" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -26,8 +26,9 @@ func tuiRichSnapshot() *dashboardSnapshot {
 		Mode:    "strict",
 		Goal: &entity.Goal{
 			Objective: entity.Objective{
-				Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease", TargetEffect: 0.2,
+				Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease",
 			},
+			Completion: &entity.Completion{Threshold: 0.2, OnThreshold: entity.GoalOnThresholdAskHuman},
 			Constraints: []entity.Constraint{
 				{Instrument: "size_flash", Max: &flash},
 				{Instrument: "host_test", Require: "pass"},
@@ -389,9 +390,14 @@ func TestTUI_FrontierView(t *testing.T) {
 	v := newFrontierView()
 	g := &entity.Goal{Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}}
 	rows := []frontierRow{{Conclusion: "C-0001", Hypothesis: "H-0001", Value: 750067, DeltaFrac: -0.25}}
-	nv, _ := v.update(frontierLoadedMsg{goal: g, rows: rows, stalled: 2}, nil)
+	nv, _ := v.update(frontierLoadedMsg{
+		goal:       g,
+		rows:       rows,
+		assessment: frontierGoalAssessment{Mode: "open_ended", RecommendedAction: "continue"},
+		stalled:    2,
+	}, nil)
 	out := stripANSI(nv.view(120, 20))
-	for _, want := range []string{"decrease qemu_cycles", "stalled_for=2", "C-0001", "H-0001", "750067"} {
+	for _, want := range []string{"decrease qemu_cycles", "stalled_for=2", "open-ended -> continue_until_stall", "C-0001", "H-0001", "750067"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("frontier view missing %q:\n%s", want, out)
 		}
@@ -402,12 +408,13 @@ func TestTUI_GoalView(t *testing.T) {
 	v := newGoalView()
 	flash := 65536.0
 	g := &entity.Goal{
-		Objective:   entity.Objective{Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease", TargetEffect: 0.2},
+		Objective:   entity.Objective{Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease"},
+		Completion:  &entity.Completion{Threshold: 0.2, OnThreshold: entity.GoalOnThresholdAskHuman},
 		Constraints: []entity.Constraint{{Instrument: "size_flash", Max: &flash}, {Instrument: "host_test", Require: "pass"}},
 	}
 	nv, _ := v.update(goalLoadedMsg{g: g}, nil)
 	out := stripANSI(nv.view(100, 20))
-	for _, want := range []string{"Objective:", "decrease qemu_cycles", "size_flash", "host_test", "require=pass"} {
+	for _, want := range []string{"Objective:", "decrease qemu_cycles", "Completion:", "threshold=0.2 -> ask_human", "size_flash", "host_test", "require=pass"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("goal view missing %q:\n%s", want, out)
 		}

--- a/internal/cli/tui_view_dashboard.go
+++ b/internal/cli/tui_view_dashboard.go
@@ -297,14 +297,8 @@ func (v *dashboardView) renderTopStrip(width int) string {
 	if snap.Goal == nil {
 		lines = append(lines, tuiBold.Render("Goal:")+" "+tuiDim.Render("(no goal set — run `autoresearch goal set`)"))
 	} else {
-		obj := snap.Goal.Objective
-		line := tuiBold.Render("Goal:") + " " + tuiCyan.Render(obj.Direction+" "+obj.Instrument)
-		if obj.Target != "" {
-			line += " on " + obj.Target
-		}
-		if obj.TargetEffect > 0 {
-			line += fmt.Sprintf(" (target_effect=%g)", obj.TargetEffect)
-		}
+		line := tuiBold.Render("Goal:") + " " + tuiCyan.Render(formatGoalObjective(snap.Goal))
+		line += " [" + formatGoalCompletion(snap.Goal) + "]"
 		if len(snap.Goal.Constraints) > 0 {
 			var cs []string
 			for _, c := range snap.Goal.Constraints {

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -185,18 +185,20 @@ func (v *treeView) view(width, height int) string {
 // ---- frontier view ----
 
 type frontierView struct {
-	goal    *entity.Goal
-	rows    []frontierRow
-	stalled int
-	cursor  int
-	err     error
+	goal       *entity.Goal
+	rows       []frontierRow
+	assessment frontierGoalAssessment
+	stalled    int
+	cursor     int
+	err        error
 }
 
 type frontierLoadedMsg struct {
-	goal    *entity.Goal
-	rows    []frontierRow
-	stalled int
-	err     error
+	goal       *entity.Goal
+	rows       []frontierRow
+	assessment frontierGoalAssessment
+	stalled    int
+	err        error
 }
 
 func newFrontierView() *frontierView { return &frontierView{} }
@@ -213,8 +215,14 @@ func (v *frontierView) init(s *store.Store) tea.Cmd {
 		if err != nil {
 			return frontierLoadedMsg{err: err}
 		}
-		rows, stalled := computeFrontier(s, goal, concls)
-		return frontierLoadedMsg{goal: goal, rows: rows, stalled: stalled}
+		obsByExp := loadObservationsByExperiment(s)
+		rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp)
+		return frontierLoadedMsg{
+			goal:       goal,
+			rows:       rows,
+			assessment: assessGoalCompletion(goal, concls, obsByExp),
+			stalled:    stalled,
+		}
 	}
 }
 
@@ -223,6 +231,7 @@ func (v *frontierView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	case frontierLoadedMsg:
 		v.goal = msg.goal
 		v.rows = msg.rows
+		v.assessment = msg.assessment
 		v.stalled = msg.stalled
 		v.err = msg.err
 		return v, nil
@@ -260,6 +269,17 @@ func (v *frontierView) view(width, height int) string {
 	}
 	header := tuiBold.Render(fmt.Sprintf("%s %s  ·  %d rows  ·  stalled_for=%d",
 		v.goal.Objective.Direction, v.goal.Objective.Instrument, len(v.rows), v.stalled))
+	assessment := ""
+	switch v.assessment.Mode {
+	case "threshold":
+		assessment = fmt.Sprintf("threshold=%g -> %s", v.assessment.Threshold, v.assessment.OnThreshold)
+		if v.assessment.Met {
+			assessment += " (met)"
+		}
+	default:
+		assessment = "open-ended -> continue_until_stall"
+	}
+	header += "  ·  " + assessment
 	if len(v.rows) == 0 {
 		return header + "\n\n" + tuiDim.Render("(no feasible supported conclusions yet)")
 	}
@@ -327,14 +347,10 @@ func (v *goalView) view(width, height int) string {
 	g := v.g
 	lines := []string{}
 	lines = append(lines, tuiBold.Render("Objective:"))
-	line := "  " + tuiCyan.Render(g.Objective.Direction+" "+g.Objective.Instrument)
-	if g.Objective.Target != "" {
-		line += " on " + g.Objective.Target
-	}
-	if g.Objective.TargetEffect > 0 {
-		line += fmt.Sprintf(" (target_effect=%g)", g.Objective.TargetEffect)
-	}
-	lines = append(lines, line)
+	lines = append(lines, "  "+tuiCyan.Render(formatGoalObjective(g)))
+	lines = append(lines, "")
+	lines = append(lines, tuiBold.Render("Completion:"))
+	lines = append(lines, "  "+formatGoalCompletion(g))
 	lines = append(lines, "")
 	lines = append(lines, tuiBold.Render(fmt.Sprintf("Constraints (%d):", len(g.Constraints))))
 	if len(g.Constraints) == 0 {

--- a/internal/entity/goal.go
+++ b/internal/entity/goal.go
@@ -85,7 +85,13 @@ func ParseGoal(data []byte) (*Goal, error) {
 		return nil, fmt.Errorf("parse goal yaml: %w", err)
 	}
 	if raw.Objective.DeprecatedTargetEffect != nil {
-		return nil, fmt.Errorf("goal objective.target_effect has been removed; use completion.threshold and completion.on_threshold instead")
+		if raw.Completion != nil {
+			return nil, fmt.Errorf("goal mixes deprecated objective.target_effect with completion; use completion.threshold and completion.on_threshold only")
+		}
+		raw.Completion = &Completion{
+			Threshold:   *raw.Objective.DeprecatedTargetEffect,
+			OnThreshold: GoalOnThresholdAskHuman,
+		}
 	}
 	if raw.Completion != nil && raw.Completion.Threshold > 0 && raw.Completion.OnThreshold == "" {
 		raw.Completion.OnThreshold = GoalOnThresholdAskHuman

--- a/internal/entity/goal.go
+++ b/internal/entity/goal.go
@@ -1,6 +1,7 @@
 package entity
 
 import (
+	"bytes"
 	"fmt"
 	"time"
 
@@ -11,6 +12,12 @@ const (
 	GoalStatusActive    = "active"
 	GoalStatusConcluded = "concluded"
 	GoalStatusAbandoned = "abandoned"
+	GoalSchemaVersion   = 3
+
+	GoalOnThresholdAskHuman               = "ask_human"
+	GoalOnThresholdStop                   = "stop"
+	GoalOnThresholdContinueUntilStall     = "continue_until_stall"
+	GoalOnThresholdContinueUntilBudgetCap = "continue_until_budget_cap"
 )
 
 type Goal struct {
@@ -23,15 +30,20 @@ type Goal struct {
 	ClosedAt      *time.Time   `yaml:"closed_at,omitempty"      json:"closed_at,omitempty"`
 	ClosureReason string       `yaml:"closure_reason,omitempty" json:"closure_reason,omitempty"`
 	Objective     Objective    `yaml:"objective"                json:"objective"`
+	Completion    *Completion  `yaml:"completion,omitempty"     json:"completion,omitempty"`
 	Constraints   []Constraint `yaml:"constraints"              json:"constraints"`
 	Body          string       `yaml:"-"                        json:"body,omitempty"`
 }
 
 type Objective struct {
-	Instrument   string  `yaml:"instrument"              json:"instrument"`
-	Target       string  `yaml:"target,omitempty"        json:"target,omitempty"`
-	Direction    string  `yaml:"direction"               json:"direction"`
-	TargetEffect float64 `yaml:"target_effect,omitempty" json:"target_effect,omitempty"`
+	Instrument string `yaml:"instrument"       json:"instrument"`
+	Target     string `yaml:"target,omitempty" json:"target,omitempty"`
+	Direction  string `yaml:"direction"        json:"direction"`
+}
+
+type Completion struct {
+	Threshold   float64 `yaml:"threshold,omitempty"    json:"threshold,omitempty"`
+	OnThreshold string  `yaml:"on_threshold,omitempty" json:"on_threshold,omitempty"`
 }
 
 type Constraint struct {
@@ -46,20 +58,65 @@ func ParseGoal(data []byte) (*Goal, error) {
 	if err != nil {
 		return nil, err
 	}
-	var g Goal
-	if err := yaml.Unmarshal(yb, &g); err != nil {
+
+	type rawObjective struct {
+		Instrument             string   `yaml:"instrument"`
+		Target                 string   `yaml:"target,omitempty"`
+		Direction              string   `yaml:"direction"`
+		DeprecatedTargetEffect *float64 `yaml:"target_effect,omitempty"`
+	}
+	type rawGoal struct {
+		SchemaVersion int          `yaml:"schema_version,omitempty"`
+		ID            string       `yaml:"id,omitempty"`
+		Status        string       `yaml:"status,omitempty"`
+		DerivedFrom   string       `yaml:"derived_from,omitempty"`
+		Trigger       string       `yaml:"trigger,omitempty"`
+		CreatedAt     *time.Time   `yaml:"created_at,omitempty"`
+		ClosedAt      *time.Time   `yaml:"closed_at,omitempty"`
+		ClosureReason string       `yaml:"closure_reason,omitempty"`
+		Objective     rawObjective `yaml:"objective"`
+		Completion    *Completion  `yaml:"completion,omitempty"`
+		Constraints   []Constraint `yaml:"constraints"`
+	}
+
+	var raw rawGoal
+	dec := yaml.NewDecoder(bytes.NewReader(yb))
+	if err := dec.Decode(&raw); err != nil {
 		return nil, fmt.Errorf("parse goal yaml: %w", err)
+	}
+	if raw.Objective.DeprecatedTargetEffect != nil {
+		return nil, fmt.Errorf("goal objective.target_effect has been removed; use completion.threshold and completion.on_threshold instead")
+	}
+	if raw.Completion != nil && raw.Completion.Threshold > 0 && raw.Completion.OnThreshold == "" {
+		raw.Completion.OnThreshold = GoalOnThresholdAskHuman
+	}
+	g := Goal{
+		SchemaVersion: raw.SchemaVersion,
+		ID:            raw.ID,
+		Status:        raw.Status,
+		DerivedFrom:   raw.DerivedFrom,
+		Trigger:       raw.Trigger,
+		CreatedAt:     raw.CreatedAt,
+		ClosedAt:      raw.ClosedAt,
+		ClosureReason: raw.ClosureReason,
+		Objective: Objective{
+			Instrument: raw.Objective.Instrument,
+			Target:     raw.Objective.Target,
+			Direction:  raw.Objective.Direction,
+		},
+		Completion:  raw.Completion,
+		Constraints: raw.Constraints,
 	}
 	g.Body = string(body)
 	if g.SchemaVersion == 0 {
-		g.SchemaVersion = 2
+		g.SchemaVersion = GoalSchemaVersion
 	}
 	return &g, nil
 }
 
 func (g *Goal) Marshal() ([]byte, error) {
 	if g.SchemaVersion == 0 {
-		g.SchemaVersion = 2
+		g.SchemaVersion = GoalSchemaVersion
 	}
 	body := g.Body
 	if body == "" {
@@ -85,4 +142,25 @@ func FormatConstraint(c Constraint) string {
 
 func (g *Goal) Steering() string {
 	return ExtractSection(g.Body, "Steering")
+}
+
+func (g *Goal) HasCompletionThreshold() bool {
+	return g != nil && g.Completion != nil && g.Completion.Threshold > 0
+}
+
+func (g *Goal) IsOpenEnded() bool {
+	return !g.HasCompletionThreshold()
+}
+
+func (g *Goal) EffectiveOnThreshold() string {
+	if g == nil {
+		return GoalOnThresholdContinueUntilStall
+	}
+	if g.HasCompletionThreshold() {
+		if g.Completion.OnThreshold != "" {
+			return g.Completion.OnThreshold
+		}
+		return GoalOnThresholdAskHuman
+	}
+	return GoalOnThresholdContinueUntilStall
 }

--- a/internal/entity/goal_test.go
+++ b/internal/entity/goal_test.go
@@ -10,11 +10,15 @@ func TestGoalRoundTrip(t *testing.T) {
 	flash := 65536.0
 	ram := 16384.0
 	g := &entity.Goal{
+		SchemaVersion: entity.GoalSchemaVersion,
 		Objective: entity.Objective{
-			Instrument:   "qemu_cycles",
-			Target:       "dsp_fir_bench",
-			Direction:    "decrease",
-			TargetEffect: 0.15,
+			Instrument: "qemu_cycles",
+			Target:     "dsp_fir_bench",
+			Direction:  "decrease",
+		},
+		Completion: &entity.Completion{
+			Threshold:   0.15,
+			OnThreshold: entity.GoalOnThresholdAskHuman,
 		},
 		Constraints: []entity.Constraint{
 			{Instrument: "size_flash", Max: &flash},
@@ -43,7 +47,57 @@ func TestGoalRoundTrip(t *testing.T) {
 	if back.Constraints[2].Require != "pass" {
 		t.Errorf("host_test require: %q", back.Constraints[2].Require)
 	}
+	if back.Completion == nil || back.Completion.Threshold != 0.15 || back.Completion.OnThreshold != entity.GoalOnThresholdAskHuman {
+		t.Errorf("completion round-trip mismatch: %+v", back.Completion)
+	}
 	if back.Steering() == "" {
 		t.Errorf("steering extraction empty")
+	}
+}
+
+func TestGoalRejectsDeprecatedTargetEffect(t *testing.T) {
+	data := []byte(`---
+objective:
+  instrument: qemu_cycles
+  target: dsp_fir_bench
+  direction: decrease
+  target_effect: 0.15
+constraints:
+  - instrument: size_flash
+    max: 65536
+---
+
+# Steering
+
+focus on the hot inner loop
+`)
+	if _, err := entity.ParseGoal(data); err == nil || err.Error() == "" {
+		t.Fatal("expected deprecated target_effect to be rejected")
+	}
+}
+
+func TestGoalDefaultsThresholdPolicyWhenOmitted(t *testing.T) {
+	data := []byte(`---
+objective:
+  instrument: qemu_cycles
+  target: dsp_fir_bench
+  direction: decrease
+completion:
+  threshold: 0.15
+constraints:
+  - instrument: size_flash
+    max: 65536
+---
+
+# Steering
+
+focus on the hot inner loop
+`)
+	back, err := entity.ParseGoal(data)
+	if err != nil {
+		t.Fatalf("ParseGoal failed: %v", err)
+	}
+	if back.Completion == nil || back.Completion.OnThreshold != entity.GoalOnThresholdAskHuman {
+		t.Fatalf("completion.on_threshold = %+v, want %q", back.Completion, entity.GoalOnThresholdAskHuman)
 	}
 }

--- a/internal/entity/goal_test.go
+++ b/internal/entity/goal_test.go
@@ -55,7 +55,7 @@ func TestGoalRoundTrip(t *testing.T) {
 	}
 }
 
-func TestGoalRejectsDeprecatedTargetEffect(t *testing.T) {
+func TestGoalAcceptsLegacyTargetEffect(t *testing.T) {
 	data := []byte(`---
 objective:
   instrument: qemu_cycles
@@ -71,8 +71,36 @@ constraints:
 
 focus on the hot inner loop
 `)
-	if _, err := entity.ParseGoal(data); err == nil || err.Error() == "" {
-		t.Fatal("expected deprecated target_effect to be rejected")
+	back, err := entity.ParseGoal(data)
+	if err != nil {
+		t.Fatalf("ParseGoal failed: %v", err)
+	}
+	if back.Completion == nil || back.Completion.Threshold != 0.15 || back.Completion.OnThreshold != entity.GoalOnThresholdAskHuman {
+		t.Fatalf("legacy target_effect should map to ask_human completion, got %+v", back.Completion)
+	}
+}
+
+func TestGoalRejectsLegacyTargetEffectAlongsideCompletion(t *testing.T) {
+	data := []byte(`---
+objective:
+  instrument: qemu_cycles
+  target: dsp_fir_bench
+  direction: decrease
+  target_effect: 0.15
+completion:
+  threshold: 0.2
+  on_threshold: stop
+constraints:
+  - instrument: size_flash
+    max: 65536
+---
+
+# Steering
+
+focus on the hot inner loop
+`)
+	if _, err := entity.ParseGoal(data); err == nil {
+		t.Fatal("expected mixed legacy and new completion fields to be rejected")
 	}
 }
 

--- a/internal/firewall/validators.go
+++ b/internal/firewall/validators.go
@@ -51,6 +51,24 @@ func ValidateGoal(g *entity.Goal, cfg *store.Config) error {
 	default:
 		return fmt.Errorf("objective direction must be 'increase' or 'decrease', got %q", g.Objective.Direction)
 	}
+	if g.Completion != nil {
+		if g.Completion.Threshold <= 0 {
+			return errors.New("goal completion.threshold must be > 0")
+		}
+		switch g.EffectiveOnThreshold() {
+		case entity.GoalOnThresholdAskHuman,
+			entity.GoalOnThresholdStop,
+			entity.GoalOnThresholdContinueUntilStall,
+			entity.GoalOnThresholdContinueUntilBudgetCap:
+		default:
+			return fmt.Errorf("goal completion.on_threshold must be one of %q, %q, %q, or %q, got %q",
+				entity.GoalOnThresholdAskHuman,
+				entity.GoalOnThresholdStop,
+				entity.GoalOnThresholdContinueUntilStall,
+				entity.GoalOnThresholdContinueUntilBudgetCap,
+				g.Completion.OnThreshold)
+		}
+	}
 	if len(g.Constraints) == 0 {
 		return errors.New("goal must declare at least one constraint (autoresearch needs something to bound the search)")
 	}

--- a/internal/firewall/validators_test.go
+++ b/internal/firewall/validators_test.go
@@ -98,6 +98,10 @@ func TestValidateGoal_Happy(t *testing.T) {
 	max := 65536.0
 	g := &entity.Goal{
 		Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"},
+		Completion: &entity.Completion{
+			Threshold:   0.2,
+			OnThreshold: entity.GoalOnThresholdAskHuman,
+		},
 		Constraints: []entity.Constraint{
 			{Instrument: "size_flash", Max: &max},
 		},
@@ -105,6 +109,34 @@ func TestValidateGoal_Happy(t *testing.T) {
 	if err := firewall.ValidateGoal(g, cfgWith("qemu_cycles", "size_flash")); err != nil {
 		t.Errorf("valid goal rejected: %v", err)
 	}
+}
+
+func TestValidateGoal_InvalidCompletion(t *testing.T) {
+	max := 65536.0
+	base := &entity.Goal{
+		Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"},
+		Constraints: []entity.Constraint{
+			{Instrument: "size_flash", Max: &max},
+		},
+	}
+
+	t.Run("threshold must be positive", func(t *testing.T) {
+		g := *base
+		g.Completion = &entity.Completion{Threshold: 0}
+		err := firewall.ValidateGoal(&g, cfgWith("qemu_cycles", "size_flash"))
+		if err == nil || !strings.Contains(err.Error(), "threshold must be > 0") {
+			t.Fatalf("expected bad threshold to fail, got %v", err)
+		}
+	})
+
+	t.Run("on_threshold must be known", func(t *testing.T) {
+		g := *base
+		g.Completion = &entity.Completion{Threshold: 0.2, OnThreshold: "invent_it"}
+		err := firewall.ValidateGoal(&g, cfgWith("qemu_cycles", "size_flash"))
+		if err == nil || !strings.Contains(err.Error(), "completion.on_threshold") {
+			t.Fatalf("expected bad on_threshold to fail, got %v", err)
+		}
+	})
 }
 
 func TestValidateHypothesis_MissingFields(t *testing.T) {

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -36,8 +36,10 @@ load-bearing.
    If so, the current direction may be hitting diminishing returns.
 5. `autoresearch tree --json` — every existing hypothesis. Do not
    duplicate open work.
-6. `autoresearch frontier --json` — the current best (if any) and the
-   `stalled_for` counter. If it's climbing, diversify.
+6. `autoresearch frontier --json` — the current best (if any), the
+   `stalled_for` counter, and `goal_assessment`. If the threshold is met
+   and the recommended action is `ask_human` or `stop`, do not start
+   another cycle. If `stalled_for` is climbing, diversify.
 7. `autoresearch instrument list --json` — what you can measure.
 8. Enough of the codebase (via Read / Grep / Glob) to understand what's
    being optimized. Focus on `goal.objective.target`.
@@ -132,6 +134,12 @@ until the gate reviewer has accepted or downgraded that chain.
   mechanisms. Don't cluster them in one subtree.
 - **Healthy frontier**: refine the best (`--parent`) or attack from a
   different angle.
+- **`goal_assessment.met=true` + `recommended_action=ask_human|stop`**:
+  stop here and yield to the main session. Goal completion is separate
+  from hypothesis support.
+- **`goal_assessment.met=true` + `recommended_action=continue`**:
+  continue only if the goal explicitly says to keep exploring after
+  threshold satisfaction.
 - **`stalled_for` climbing**: diversify — propose something the tree
   hasn't tried.
 - **`priority: human`**: address these first.

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -177,12 +177,20 @@ by creating a new goal that ` + "`--from`" + ` the previous one; the new goal
 gets its own fresh hypotheses, experiments, and observations because
 the circumstances are different.
 
+Goals may be thresholded or open-ended. Use ` + "`--success-threshold`" + ` to
+declare what counts as "goal met", and ` + "`--on-success`" + ` to say whether
+the loop should stop, ask the human, or keep exploring once that threshold is
+cleared. If no threshold is declared, the goal is directional/open-ended and
+the default behavior is to continue until the frontier stalls, the budget is
+hit, or the human re-steers.
+
     # Bootstrap (first goal only — refuses if any goal already exists)
     autoresearch goal set \
         --objective-instrument qemu_cycles \
         --objective-target dsp_fir \
         --objective-direction decrease \
-        --objective-target-effect 0.20 \
+        --success-threshold 0.20 \
+        --on-success ask_human \
         --constraint-max 'binary_size=65536' \
         --constraint-require 'test=pass' \
         --steering "start with loop unrolling"
@@ -223,7 +231,7 @@ the firewall sees.
     autoresearch hypothesis diff     <hyp-id> [--conclusion C-NNNN]  # unified diff vs baseline
     autoresearch hypothesis apply    <hyp-id> [--conclusion C-NNNN] [--merge]  # ship it (requires reviewed conclusion)
     autoresearch tree               [--root H-XXXX]
-    autoresearch frontier                                  # best-first, stalled_for
+    autoresearch frontier                                  # best-first, stalled_for, goal_assessment
     autoresearch report             <hyp-id>               # markdown writeup
 
 ### Experiments

--- a/internal/store/goal_test.go
+++ b/internal/store/goal_test.go
@@ -30,8 +30,9 @@ func TestGoalSequenceWriteReadList(t *testing.T) {
 		Status:    entity.GoalStatusActive,
 		CreatedAt: &now,
 		Objective: entity.Objective{
-			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease", TargetEffect: 0.15,
+			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease",
 		},
+		Completion: &entity.Completion{Threshold: 0.15, OnThreshold: entity.GoalOnThresholdAskHuman},
 		Constraints: []entity.Constraint{
 			{Instrument: "size_flash", Max: &flash},
 		},
@@ -140,7 +141,7 @@ func TestOpenMigratesLegacyGoal(t *testing.T) {
 	legacy := &entity.Goal{
 		SchemaVersion: 1,
 		Objective: entity.Objective{
-			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease", TargetEffect: 0.15,
+			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease",
 		},
 		Constraints: []entity.Constraint{
 			{Instrument: "size_flash", Max: &flash},

--- a/internal/store/goal_test.go
+++ b/internal/store/goal_test.go
@@ -137,21 +137,22 @@ func TestOpenMigratesLegacyGoal(t *testing.T) {
 	// Fake v1 shape: drop a legacy goal.md, downgrade schema_version to 1,
 	// write a hypothesis without goal_id, and remove the goals/ dir so the
 	// migration has room to reconstruct it.
-	flash := 65536.0
-	legacy := &entity.Goal{
-		SchemaVersion: 1,
-		Objective: entity.Objective{
-			Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease",
-		},
-		Constraints: []entity.Constraint{
-			{Instrument: "size_flash", Max: &flash},
-		},
-		Body: "# Steering\n\nstart with unrolling\n",
-	}
-	legacyData, err := legacy.Marshal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	legacyData := []byte(`---
+schema_version: 1
+objective:
+  instrument: qemu_cycles
+  target: dsp_fir
+  direction: decrease
+  target_effect: 0.15
+constraints:
+  - instrument: size_flash
+    max: 65536
+---
+
+# Steering
+
+start with unrolling
+`)
 	if err := os.WriteFile(filepath.Join(dir, ".research", "goal.md"), legacyData, 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -219,6 +220,9 @@ func TestOpenMigratesLegacyGoal(t *testing.T) {
 	}
 	if g.Objective.Instrument != "qemu_cycles" {
 		t.Errorf("migrated goal objective lost: %+v", g.Objective)
+	}
+	if g.Completion == nil || g.Completion.Threshold != 0.15 || g.Completion.OnThreshold != entity.GoalOnThresholdAskHuman {
+		t.Errorf("migrated goal should preserve legacy target_effect as completion, got %+v", g.Completion)
 	}
 
 	hBack, err := s2.ReadHypothesis(hID)

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -51,7 +51,7 @@ func (s *Store) migrateV1ToV2() error {
 	g.ID = newID
 	g.Status = entity.GoalStatusActive
 	g.CreatedAt = &createdAt
-	g.SchemaVersion = 2
+	g.SchemaVersion = entity.GoalSchemaVersion
 
 	if err := os.MkdirAll(s.GoalsDir(), 0o755); err != nil {
 		return fmt.Errorf("create goals dir: %w", err)
@@ -93,7 +93,7 @@ func (s *Store) migrateV1ToV2() error {
 	}
 
 	payload, _ := json.Marshal(map[string]any{
-		"goal_id":           newID,
+		"goal_id":            newID,
 		"stamped_hypotheses": len(hyps),
 	})
 	return s.AppendEvent(Event{
@@ -122,4 +122,3 @@ func (s *Store) maybeMigrate() error {
 	}
 	return nil
 }
-


### PR DESCRIPTION
## Summary
- replace `goal.objective.target_effect` with an explicit `completion` model (`threshold` + `on_threshold`)
- update `goal set` / `goal new` to use `--success-threshold` and `--on-success`
- extend `frontier` with `goal_assessment` so agents can distinguish thresholded goals from open-ended optimization
- update dashboard/TUI/docs/examples to render the new goal semantics
- add tests for goal parsing/defaulting, completion validation, and frontier assessment

## Testing
- `GOCACHE=/tmp/autoresearch-gocache make test`

Closes #1
