### PR TITLE
Scope CLI and TUI reads to the current goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ is paused.
 | **analyze** | `analyze <exp> [--baseline <exp>]` |
 | **conclude** | `conclude <hyp> --verdict ... --observations ...` |
 | **conclusion** | `list`, `show`, `accept`, `downgrade`, `appeal` |
-| **tree / frontier** | `tree [--goal G-NNNN]`, `frontier [--goal G-NNNN]` |
+| **tree / frontier** | `tree [--goal G-NNNN\|all]`, `frontier [--goal G-NNNN\|all]` |
 | **log** | `log [--tail --kind --since --follow]` |
 | **report** | `report <hyp>` |
 | **artifact** | `list`, `stat`, `path`, `head`, `tail`, `range`, `grep`, `diff`, `show` |
@@ -219,7 +219,7 @@ is paused.
 | **budget** | `show`, `set` |
 | **gc** | `gc` |
 | **install** | `install claude [docs\|agents] [--trust-shell]`, `install codex [docs\|agents]` |
-| **dashboard** | `dashboard [--refresh N] [--color auto\|always\|never]`, `dashboard tui` |
+| **dashboard** | `dashboard [--goal G-NNNN\|all] [--refresh N] [--color auto\|always\|never]`, `dashboard tui [--goal G-NNNN\|all]` |
 
 Exit codes: `0` success, `1` generic error, `2` cobra usage, `3` paused,
 `4` budget exhausted. The orchestrator loop uses 3/4 to decide when to stop.
@@ -248,6 +248,13 @@ either the objective instrument or one of the explicit constraint instruments.
 Other registered instruments are still useful as supporting measurements on
 experiments, but they are not standalone optimization targets unless the goal
 names them.
+
+Read surfaces that aggregate goal-derived entities default to the active goal:
+`hypothesis list`, `experiment list`, `conclusion list`, `lesson list`,
+`artifact list`, `log`, `status`, `dashboard`, `dashboard tui`, `tree`, and
+`frontier`. Pass `--goal G-NNNN` to inspect a historical goal or `--goal all`
+to broaden the view across goals. System lessons remain visible in scoped
+views.
 
 ## Goal format
 
@@ -359,7 +366,9 @@ you drive research from the main session.
 
 ```sh
 autoresearch dashboard                  # one-shot composite snapshot
-autoresearch dashboard tui              # interactive read-only TUI
+autoresearch dashboard --goal all       # broaden the dashboard across goals
+autoresearch dashboard tui              # interactive read-only TUI (scoped to active goal)
+autoresearch dashboard tui --goal G-0001
 autoresearch dashboard --refresh 2      # live, auto-redraws every 2s (TTY only)
 autoresearch dashboard --json           # structured snapshot for tools
 autoresearch log --follow               # tail events.jsonl as they arrive
@@ -381,7 +390,8 @@ A Bubble Tea TUI built on top of the same `captureDashboard` snapshot.
 Richer than the one-shot view, but the read-only constraint is
 identical: it never mutates `.research/`, and there are no "quick
 action" keystrokes — steering is still conversational with the main
-agent session.
+agent session. Like the CLI read surfaces, it defaults to the active goal and
+accepts `--goal G-NNNN` or `--goal all` at launch.
 
 The TUI surfaces every read-only CLI verb as a navigable view:
 
@@ -395,8 +405,9 @@ The TUI surfaces every read-only CLI verb as a navigable view:
 - **Event log**: full log with follow mode, kind filter, and an event
   detail view that pretty-prints JSON payloads with colorized keys,
   strings, numbers, and literals.
-- **Tree / Frontier / Goal / Status / Instruments**: full-screen
+- **Tree / Frontier / Goals / Status / Instruments**: full-screen
   versions of the corresponding CLI verbs.
+- **Goals**: list + detail, with the current goal marked in the list.
 - **Artifacts**: list + scrollable viewer with head/tail/full/grep
   modes. `d` prompts for a second SHA and shows the unified diff,
   colorized.
@@ -407,7 +418,7 @@ Top-level jump keys reach every view from anywhere:
 
 ```
 H hypotheses      E experiments     C conclusions     L event log
-T tree            F frontier        G goal            S status
+T tree            F frontier        O goals           S status
 A artifacts       I instruments     R report picker   D dashboard
 ? help overlay    Esc / ⌫  pop current view           q / Ctrl-C  quit
 ```

--- a/internal/cli/artifact.go
+++ b/internal/cli/artifact.go
@@ -113,7 +113,7 @@ func findArtifactOwners(s *store.Store, sha string) []string {
 // ---- list ----
 
 func artifactListCmd() *cobra.Command {
-	var experiment, observation string
+	var experiment, observation, goalFlag string
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List artifacts produced by observations",
@@ -123,6 +123,11 @@ func artifactListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
+			resolver := newGoalScopeResolver(s, scope)
 
 			var obs []*entity.Observation
 			switch {
@@ -142,6 +147,10 @@ func artifactListCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+			}
+			obs, err = resolver.filterObservations(obs)
+			if err != nil {
+				return err
 			}
 
 			type row struct {
@@ -166,7 +175,7 @@ func artifactListCmd() *cobra.Command {
 				}
 			}
 			if w.IsJSON() {
-				return w.JSON(map[string]any{"artifacts": rows})
+				return w.JSON(mergeGoalScopePayload(map[string]any{"artifacts": rows}, scope))
 			}
 			if len(rows) == 0 {
 				w.Textln("(no artifacts)")
@@ -185,6 +194,7 @@ func artifactListCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&experiment, "experiment", "", "filter by experiment id")
 	c.Flags().StringVar(&observation, "observation", "", "filter by observation id")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the list to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -20,7 +20,7 @@ func conclusionCommands() []*cobra.Command {
 }
 
 func conclusionListCmd() *cobra.Command {
-	var hyp, verdict string
+	var hyp, verdict, goalFlag string
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List conclusions",
@@ -30,7 +30,15 @@ func conclusionListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			all, err := s.ListConclusions()
+			if err != nil {
+				return err
+			}
+			all, err = newGoalScopeResolver(s, scope).filterConclusions(all)
 			if err != nil {
 				return err
 			}
@@ -64,6 +72,7 @@ func conclusionListCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&hyp, "hypothesis", "", "filter by hypothesis id")
 	c.Flags().StringVar(&verdict, "verdict", "", "filter by verdict (supported|refuted|inconclusive)")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the list to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -32,6 +32,7 @@ func dashboardCmd() *cobra.Command {
 	var (
 		refresh   int
 		colorMode string
+		goalFlag  string
 	)
 	c := &cobra.Command{
 		Use:   "dashboard",
@@ -65,8 +66,12 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			if globalJSON {
-				snap, err := captureDashboard(s)
+				snap, err := captureDashboardScoped(s, scope)
 				if err != nil {
 					return err
 				}
@@ -75,7 +80,7 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 				return enc.Encode(snap)
 			}
 			if refresh == 0 {
-				return runDashboardOnce(s, os.Stdout, colors)
+				return runDashboardOnce(s, scope, os.Stdout, colors)
 			}
 			if refresh < 1 {
 				return errors.New("--refresh must be at least 1 second")
@@ -83,11 +88,12 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 			if !term.IsTerminal(int(os.Stdout.Fd())) {
 				return errors.New("dashboard --refresh requires a TTY; for scripting use one-shot `dashboard --json`")
 			}
-			return runDashboardLoop(s, os.Stdout, time.Duration(refresh)*time.Second, colors)
+			return runDashboardLoop(s, scope, os.Stdout, time.Duration(refresh)*time.Second, colors)
 		},
 	}
 	c.Flags().IntVar(&refresh, "refresh", 0, "seconds between auto-refreshes (0 = one-shot, requires a TTY when > 0)")
 	c.Flags().StringVar(&colorMode, "color", "auto", "color output: auto (TTY-detect), always (force on, for `watch -c`), never")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the dashboard to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 
@@ -95,6 +101,8 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 
 type dashboardSnapshot struct {
 	Project                string              `json:"project"`
+	ScopeGoalID            string              `json:"scope_goal_id,omitempty"`
+	ScopeAll               bool                `json:"scope_all"`
 	Paused                 bool                `json:"paused"`
 	PauseReason            string              `json:"pause_reason,omitempty"`
 	Mode                   string              `json:"mode"`
@@ -169,8 +177,18 @@ func readDashboardRecentEvents(all []store.Event, offsetNewest, limit int) ([]st
 // captureDashboard gathers everything the dashboard renders. All reads go
 // through existing store methods — no new store APIs, no mutation.
 func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
+	scope, err := resolveGoalScope(s, "")
+	if err != nil {
+		return nil, err
+	}
+	return captureDashboardScoped(s, scope)
+}
+
+func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot, error) {
 	snap := &dashboardSnapshot{
 		Project:                s.Root(),
+		ScopeGoalID:            scope.GoalID,
+		ScopeAll:               scope.All,
 		CapturedAt:             time.Now().UTC(),
 		MainCheckoutDirtyPaths: []string{},
 		Tree:                   []*treeNode{},
@@ -198,10 +216,8 @@ func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
 	snap.MainCheckoutDirty = mainCheckout.Dirty
 	snap.MainCheckoutDirtyPaths = mainCheckout.Paths
 
-	// Use the already-loaded state to read the goal directly, avoiding a
-	// second State() read inside ActiveGoal().
-	if st.CurrentGoalID != "" {
-		if g, err := s.ReadGoal(st.CurrentGoalID); err == nil {
+	if !scope.All && scope.GoalID != "" {
+		if g, err := s.ReadGoal(scope.GoalID); err == nil {
 			snap.Goal = g
 		}
 	}
@@ -214,14 +230,21 @@ func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
 		snap.Budgets.Usage.ElapsedH = time.Since(*st.ResearchStartedAt).Hours()
 	}
 
+	resolver := newGoalScopeResolver(s, scope)
+
 	hyps, err := s.ListHypotheses()
 	if err != nil {
 		return nil, err
 	}
+	hyps = resolver.filterHypotheses(hyps)
 	roots, children := buildHypothesisForest(hyps)
 	snap.Tree = buildTreeJSON(roots, children)
 
 	concls, err := s.ListConclusions()
+	if err != nil {
+		return nil, err
+	}
+	concls, err = resolver.filterConclusions(concls)
 	if err != nil {
 		return nil, err
 	}
@@ -238,8 +261,16 @@ func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
 	if err != nil {
 		return nil, err
 	}
+	allEvents, err = resolver.filterEvents(allEvents)
+	if err != nil {
+		return nil, err
+	}
 
 	exps, err := s.ListExperiments()
+	if err != nil {
+		return nil, err
+	}
+	exps, err = resolver.filterExperiments(exps)
 	if err != nil {
 		return nil, err
 	}
@@ -307,8 +338,21 @@ func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
 		}
 	}
 
+	allObs, err := s.ListObservations()
+	if err != nil {
+		return nil, err
+	}
+	allObs, err = resolver.filterObservations(allObs)
+	if err != nil {
+		return nil, err
+	}
+
 	var lessonCount int
 	if lessons, err := s.ListLessons(); err == nil {
+		lessons, err = resolver.filterLessons(lessons)
+		if err != nil {
+			return nil, err
+		}
 		lessonCount = len(lessons)
 		// Split by effective lifecycle so steering lessons surface first.
 		buckets := map[string][]*entity.Lesson{
@@ -342,19 +386,11 @@ func captureDashboard(s *store.Store) (*dashboardSnapshot, error) {
 	// targeted ReadDir because they're loaded inside computeFrontier, not
 	// directly available here.
 	snap.Counts = map[string]int{
-		"hypotheses":  len(hyps),
-		"experiments": len(exps),
-		"conclusions": len(concls),
-		"lessons":     lessonCount,
-	}
-	if entries, err := os.ReadDir(s.ObservationsDir()); err == nil {
-		n := 0
-		for _, e := range entries {
-			if !e.IsDir() {
-				n++
-			}
-		}
-		snap.Counts["observations"] = n
+		"hypotheses":   len(hyps),
+		"experiments":  len(exps),
+		"observations": len(allObs),
+		"conclusions":  len(concls),
+		"lessons":      lessonCount,
 	}
 
 	snap.RecentEvents, _ = readDashboardRecentEvents(allEvents, 0, dashboardRecentEventsSummaryLimit)
@@ -377,8 +413,8 @@ func findLastEventForExperiment(events []store.Event, expID string) (ts *time.Ti
 
 // ---- one-shot + refresh loop ----
 
-func runDashboardOnce(s *store.Store, w io.Writer, colors *ansi) error {
-	snap, err := captureDashboard(s)
+func runDashboardOnce(s *store.Store, scope goalScope, w io.Writer, colors *ansi) error {
+	snap, err := captureDashboardScoped(s, scope)
 	if err != nil {
 		return err
 	}
@@ -388,7 +424,7 @@ func runDashboardOnce(s *store.Store, w io.Writer, colors *ansi) error {
 	return err
 }
 
-func runDashboardLoop(s *store.Store, w io.Writer, refresh time.Duration, colors *ansi) error {
+func runDashboardLoop(s *store.Store, scope goalScope, w io.Writer, refresh time.Duration, colors *ansi) error {
 	_, _ = io.WriteString(w, "\x1b[?25l")
 	defer io.WriteString(w, "\x1b[?25h\n")
 
@@ -405,7 +441,7 @@ func runDashboardLoop(s *store.Store, w io.Writer, refresh time.Duration, colors
 	refreshLabel := fmt.Sprintf("refreshing every %s", refresh)
 
 	render := func() error {
-		snap, err := captureDashboard(s)
+		snap, err := captureDashboardScoped(s, scope)
 		if err != nil {
 			return err
 		}
@@ -499,10 +535,16 @@ func renderDashboardHeader(w io.Writer, snap *dashboardSnapshot, width int, a *a
 }
 
 func renderDashboardGoal(w io.Writer, snap *dashboardSnapshot, a *ansi) {
+	if snap.ScopeAll {
+		fmt.Fprintln(w, " "+a.bold("Scope:")+" "+a.cyan("all goals"))
+		fmt.Fprintln(w, " "+a.bold("Goal:")+" "+a.dim("(goal-specific panels are disabled in all-goal scope)"))
+		return
+	}
 	if snap.Goal == nil {
 		fmt.Fprintln(w, " "+a.bold("Goal:")+" "+a.dim("(no goal set — run `autoresearch goal set`)"))
 		return
 	}
+	fmt.Fprintln(w, " "+a.bold("Scope:")+" "+a.cyan(snap.Goal.ID))
 	fmt.Fprintln(w, " "+a.bold("Goal:")+" "+a.cyan(formatGoalObjective(snap.Goal)))
 	fmt.Fprintln(w, " "+a.bold("Completion:")+" "+formatGoalCompletion(snap.Goal))
 	if len(snap.Goal.Constraints) > 0 {
@@ -541,7 +583,7 @@ func renderDashboardBudget(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 		s := fmt.Sprintf("%.1fh/%dh elapsed", snap.Budgets.Usage.ElapsedH, lim)
 		parts = append(parts, meterColor(a, snap.Budgets.Usage.ElapsedH, float64(lim), s))
 	}
-	if lim := snap.Budgets.Limits.FrontierStallK; lim > 0 {
+	if lim := snap.Budgets.Limits.FrontierStallK; lim > 0 && !snap.ScopeAll {
 		s := fmt.Sprintf("stalled %d/%d", snap.StalledFor, lim)
 		parts = append(parts, meterColor(a, float64(snap.StalledFor), float64(lim), s))
 	}
@@ -577,6 +619,10 @@ func renderDashboardTree(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 
 func renderDashboardFrontier(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 	sectionHeader(w, "Frontier", a)
+	if snap.ScopeAll {
+		fmt.Fprintln(w, "   "+a.dim("(goal-specific — rerun with --goal G-NNNN)"))
+		return
+	}
 	if snap.Goal == nil {
 		fmt.Fprintln(w, "   "+a.dim("(no goal set)"))
 		return

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -462,7 +462,7 @@ func experimentWorktreeCmd() *cobra.Command {
 }
 
 func experimentListCmd() *cobra.Command {
-	var status, hyp string
+	var status, hyp, goalFlag string
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List experiments",
@@ -472,7 +472,15 @@ func experimentListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			all, err := s.ListExperiments()
+			if err != nil {
+				return err
+			}
+			all, err = newGoalScopeResolver(s, scope).filterExperiments(all)
 			if err != nil {
 				return err
 			}
@@ -502,6 +510,7 @@ func experimentListCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&status, "status", "", "filter by status")
 	c.Flags().StringVar(&hyp, "hypothesis", "", "filter by hypothesis id")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the list to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -10,7 +10,7 @@ import (
 )
 
 func frontierCommands() []*cobra.Command {
-	var goalID string
+	var goalFlag string
 	c := &cobra.Command{
 		Use:   "frontier",
 		Short: "Show the Pareto frontier of conclusions on the goal's objective",
@@ -19,8 +19,9 @@ func frontierCommands() []*cobra.Command {
 written since the last one that actually improved the frontier.
 
 Defaults to the active goal; pass --goal G-NNNN to view a historical
-goal's frontier. Only conclusions whose hypothesis was bound to the
-scoped goal are considered.
+goal's frontier, or --goal all to render one frontier section per goal.
+Only conclusions whose hypothesis was bound to the scoped goal are
+considered.
 
 A conclusion is "feasible" if every constraint with op=require is satisfied
 by at least one matching observation in its candidate experiment. For v1
@@ -39,87 +40,72 @@ configured ` + "`budgets.frontier_stall_k`" + ` to decide when to stop the loop.
 			if err != nil {
 				return err
 			}
-			var goal *entity.Goal
-			if goalID != "" {
-				goal, err = s.ReadGoal(goalID)
-			} else {
-				goal, err = s.ActiveGoal()
-			}
+			scope, err := resolveGoalScope(s, goalFlag)
 			if err != nil {
 				return err
 			}
-			concls, err := s.ListConclusions()
+			frontiers, err := collectFrontiers(s, scope)
 			if err != nil {
 				return err
 			}
-			concls, err = scopeConclusionsToGoal(s, concls, goal.ID)
-			if err != nil {
-				return err
-			}
-			obsByExp := loadObservationsByExperiment(s)
-			rows, stalledFor := computeFrontierFromObservations(goal, concls, obsByExp)
-			assessment := assessGoalCompletion(goal, concls, obsByExp)
-
 			cfg, err := s.Config()
 			if err != nil {
 				return err
 			}
 
-			if w.IsJSON() {
-				return w.JSON(map[string]any{
-					"goal_id": goal.ID,
-					"objective": map[string]any{
-						"instrument": goal.Objective.Instrument,
-						"direction":  goal.Objective.Direction,
-					},
-					"frontier":         rows,
-					"goal_assessment":  assessment,
-					"stalled_for":      stalledFor,
-					"frontier_stall_k": cfg.Budgets.FrontierStallK,
-					"stall_reached":    cfg.Budgets.FrontierStallK > 0 && stalledFor >= cfg.Budgets.FrontierStallK,
-				})
-			}
-			w.Textf("[goal: %s, objective: %s, %d supported conclusions]\n", goal.ID, formatGoalObjective(goal), len(rows))
-			w.Textln("")
-			if len(rows) == 0 {
-				w.Textln("(no supported+feasible conclusions yet)")
-				w.Textln("")
-			} else {
-				for i, r := range rows {
-					marker := "  "
-					if i == 0 {
-						marker = "* "
+			if scope.All {
+				if w.IsJSON() {
+					items := make([]map[string]any, 0, len(frontiers))
+					for _, f := range frontiers {
+						items = append(items, map[string]any{
+							"goal_id":          f.Goal.ID,
+							"objective":        f.Goal.Objective,
+							"frontier":         f.Rows,
+							"goal_assessment":  f.Assessment,
+							"stalled_for":      f.StalledFor,
+							"frontier_stall_k": cfg.Budgets.FrontierStallK,
+							"stall_reached":    cfg.Budgets.FrontierStallK > 0 && f.StalledFor >= cfg.Budgets.FrontierStallK,
+						})
 					}
-					w.Textf("%s%s  %s  %s=%.6g\n", marker, r.Conclusion, r.Hypothesis, goal.Objective.Instrument, r.Value)
+					return w.JSON(mergeGoalScopePayload(map[string]any{"frontiers": items}, scope))
 				}
-				w.Textln("")
-			}
-			switch assessment.Mode {
-			case "threshold":
-				w.Textf("goal_assessment: threshold=%g -> %s", assessment.Threshold, assessment.OnThreshold)
-				if assessment.Met {
-					w.Textf(" (met by %s; recommended=%s)\n", assessment.MetByConclusion, assessment.RecommendedAction)
-				} else {
-					w.Textf(" (not yet met; recommended=%s)\n", assessment.RecommendedAction)
+				w.Textln("[goal: all]")
+				if len(frontiers) == 0 {
+					w.Textln("(no goals)")
+					return nil
 				}
-			default:
-				w.Textln("goal_assessment: open-ended -> continue_until_stall (recommended=continue)")
-			}
-			w.Textf("stalled_for: %d", stalledFor)
-			if cfg.Budgets.FrontierStallK > 0 {
-				w.Textf(" (stall-k=%d)", cfg.Budgets.FrontierStallK)
-				if stalledFor >= cfg.Budgets.FrontierStallK {
-					w.Textln(" — STALL REACHED, orchestrator should stop")
-				} else {
-					w.Textln("")
+				for i, f := range frontiers {
+					if i > 0 {
+						w.Textln("")
+					}
+					renderFrontierSection(w, f, cfg.Budgets.FrontierStallK)
 				}
-			} else {
-				w.Textln("")
+				return nil
 			}
+
+			if len(frontiers) == 0 {
+				return nil
+			}
+			f := frontiers[0]
+			if w.IsJSON() {
+				return w.JSON(mergeGoalScopePayload(map[string]any{
+					"goal_id": f.Goal.ID,
+					"objective": map[string]any{
+						"instrument": f.Goal.Objective.Instrument,
+						"direction":  f.Goal.Objective.Direction,
+					},
+					"frontier":         f.Rows,
+					"goal_assessment":  f.Assessment,
+					"stalled_for":      f.StalledFor,
+					"frontier_stall_k": cfg.Budgets.FrontierStallK,
+					"stall_reached":    cfg.Budgets.FrontierStallK > 0 && f.StalledFor >= cfg.Budgets.FrontierStallK,
+				}, scope))
+			}
+			renderFrontierSection(w, f, cfg.Budgets.FrontierStallK)
 			return nil
 		},
 	}
-	c.Flags().StringVar(&goalID, "goal", "", "goal to scope the frontier to (defaults to active goal)")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the frontier to (defaults to active goal; use 'all' for every goal)")
 	return []*cobra.Command{c}
 }
 
@@ -130,24 +116,99 @@ func scopeConclusionsToGoal(s *store.Store, concls []*entity.Conclusion, goalID 
 	if goalID == "" {
 		return concls, nil
 	}
-	cache := map[string]string{}
-	out := make([]*entity.Conclusion, 0, len(concls))
-	for _, c := range concls {
-		hid := c.Hypothesis
-		gid, ok := cache[hid]
-		if !ok {
-			h, err := s.ReadHypothesis(hid)
+	return newGoalScopeResolver(s, goalScope{GoalID: goalID}).filterConclusions(concls)
+}
+
+type goalFrontier struct {
+	Goal       *entity.Goal
+	Rows       []frontierRow
+	Assessment frontierGoalAssessment
+	StalledFor int
+}
+
+func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
+	allConcls, err := s.ListConclusions()
+	if err != nil {
+		return nil, err
+	}
+	obsByExp := loadObservationsByExperiment(s)
+	if scope.All {
+		goals, err := s.ListGoals()
+		if err != nil {
+			return nil, err
+		}
+		out := make([]goalFrontier, 0, len(goals))
+		for _, goal := range goals {
+			concls, err := scopeConclusionsToGoal(s, allConcls, goal.ID)
 			if err != nil {
 				return nil, err
 			}
-			gid = h.GoalID
-			cache[hid] = gid
+			rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp)
+			out = append(out, goalFrontier{
+				Goal:       goal,
+				Rows:       rows,
+				Assessment: assessGoalCompletion(goal, concls, obsByExp),
+				StalledFor: stalled,
+			})
 		}
-		if gid == goalID {
-			out = append(out, c)
+		return out, nil
+	}
+	goal, err := s.ReadGoal(scope.GoalID)
+	if err != nil {
+		return nil, err
+	}
+	concls, err := scopeConclusionsToGoal(s, allConcls, goal.ID)
+	if err != nil {
+		return nil, err
+	}
+	rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp)
+	return []goalFrontier{{
+		Goal:       goal,
+		Rows:       rows,
+		Assessment: assessGoalCompletion(goal, concls, obsByExp),
+		StalledFor: stalled,
+	}}, nil
+}
+
+func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
+	if f.Goal == nil {
+		return
+	}
+	w.Textf("[goal: %s, objective: %s, %d supported conclusions]\n", f.Goal.ID, formatGoalObjective(f.Goal), len(f.Rows))
+	w.Textln("")
+	if len(f.Rows) == 0 {
+		w.Textln("(no supported+feasible conclusions yet)")
+		w.Textln("")
+	} else {
+		for i, r := range f.Rows {
+			marker := "  "
+			if i == 0 {
+				marker = "* "
+			}
+			w.Textf("%s%s  %s  %s=%.6g\n", marker, r.Conclusion, r.Hypothesis, f.Goal.Objective.Instrument, r.Value)
+		}
+		w.Textln("")
+	}
+	switch f.Assessment.Mode {
+	case "threshold":
+		w.Textf("goal_assessment: threshold=%g -> %s", f.Assessment.Threshold, f.Assessment.OnThreshold)
+		if f.Assessment.Met {
+			w.Textf(" (met by %s; recommended=%s)\n", f.Assessment.MetByConclusion, f.Assessment.RecommendedAction)
+		} else {
+			w.Textf(" (not yet met; recommended=%s)\n", f.Assessment.RecommendedAction)
+		}
+	default:
+		w.Textln("goal_assessment: open-ended -> continue_until_stall (recommended=continue)")
+	}
+	w.Textf("stalled_for: %d", f.StalledFor)
+	if stallK > 0 {
+		w.Textf(" (stall-k=%d)", stallK)
+		if f.StalledFor >= stallK {
+			w.Textln(" — STALL REACHED, orchestrator should stop")
+			return
 		}
 	}
-	return out, nil
+	w.Textln("")
 }
 
 type frontierRow struct {

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -167,7 +167,7 @@ func hypothesisAddCmd() *cobra.Command {
 }
 
 func hypothesisListCmd() *cobra.Command {
-	var status, parent string
+	var status, parent, goalFlag string
 	c := &cobra.Command{
 		Use:   "list",
 		Short: "List hypotheses",
@@ -177,10 +177,15 @@ func hypothesisListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			all, err := s.ListHypotheses()
 			if err != nil {
 				return err
 			}
+			all = newGoalScopeResolver(s, scope).filterHypotheses(all)
 			var filtered []*entity.Hypothesis
 			for _, h := range all {
 				if status != "" && h.Status != status {
@@ -210,6 +215,7 @@ func hypothesisListCmd() *cobra.Command {
 	}
 	c.Flags().StringVar(&status, "status", "", "filter by status")
 	c.Flags().StringVar(&parent, "parent", "", "filter by parent id")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the list to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 

--- a/internal/cli/lesson.go
+++ b/internal/cli/lesson.go
@@ -175,10 +175,11 @@ with --from.`,
 
 func lessonListCmd() *cobra.Command {
 	var (
-		scope   string
-		status  string
-		subject string
-		tag     string
+		scope    string
+		status   string
+		subject  string
+		tag      string
+		goalFlag string
 	)
 	c := &cobra.Command{
 		Use:   "list",
@@ -189,7 +190,15 @@ func lessonListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			goalScope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			all, err := s.ListLessons()
+			if err != nil {
+				return err
+			}
+			all, err = newGoalScopeResolver(s, goalScope).filterLessons(all)
 			if err != nil {
 				return err
 			}
@@ -239,6 +248,7 @@ func lessonListCmd() *cobra.Command {
 	c.Flags().StringVar(&status, "status", "", "filter by status (active | provisional | invalidated | superseded)")
 	c.Flags().StringVar(&subject, "subject", "", "filter by subject id (returns lessons citing this id)")
 	c.Flags().StringVar(&tag, "tag", "", "filter by tag")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the list to (defaults to active goal; use 'all' for every goal)")
 	return c
 }
 

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -393,7 +393,8 @@ func runProjectCommand(projectDir, shellCmd string) error {
 }
 
 func statusCmd() *cobra.Command {
-	return &cobra.Command{
+	var goalFlag string
+	c := &cobra.Command{
 		Use:   "status",
 		Short: "Show pause state, budget consumption, and entity counts",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -403,11 +404,12 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			st, err := s.State()
+			scope, err := resolveGoalScope(s, goalFlag)
 			if err != nil {
 				return err
 			}
-			counts, err := s.Counts()
+			resolver := newGoalScopeResolver(s, scope)
+			st, err := s.State()
 			if err != nil {
 				return err
 			}
@@ -419,8 +421,43 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			hyps, err := s.ListHypotheses()
+			if err != nil {
+				return err
+			}
+			hyps = resolver.filterHypotheses(hyps)
+			exps, err := s.ListExperiments()
+			if err != nil {
+				return err
+			}
+			exps, err = resolver.filterExperiments(exps)
+			if err != nil {
+				return err
+			}
+			obs, err := s.ListObservations()
+			if err != nil {
+				return err
+			}
+			obs, err = resolver.filterObservations(obs)
+			if err != nil {
+				return err
+			}
+			concls, err := s.ListConclusions()
+			if err != nil {
+				return err
+			}
+			concls, err = resolver.filterConclusions(concls)
+			if err != nil {
+				return err
+			}
+			counts := map[string]int{
+				"hypotheses":   len(hyps),
+				"experiments":  len(exps),
+				"observations": len(obs),
+				"conclusions":  len(concls),
+			}
 
-			payload := map[string]any{
+			payload := mergeGoalScopePayload(map[string]any{
 				"root":                      s.Root(),
 				"dir":                       s.DirPath(),
 				"mode":                      cfg.Mode,
@@ -431,7 +468,7 @@ func statusCmd() *cobra.Command {
 				"last_event_at":             st.LastEventAt,
 				"main_checkout_dirty":       mainCheckout.Dirty,
 				"main_checkout_dirty_paths": mainCheckout.Paths,
-			}
+			}, scope)
 
 			// Stale experiment detection.
 			type staleExp struct {
@@ -443,11 +480,10 @@ func statusCmd() *cobra.Command {
 			}
 			var stale []staleExp
 			if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
-				exps, err := s.ListExperiments()
+				allEvents, err := s.Events(0)
 				if err != nil {
 					return err
 				}
-				allEvents, _ := s.Events(0)
 				threshold := time.Duration(staleMinutes) * time.Minute
 				now := time.Now().UTC()
 				for _, e := range exps {
@@ -484,16 +520,14 @@ func statusCmd() *cobra.Command {
 			// observations anywhere. A nudge for the orchestrator that it
 			// may be skipping a required measurement.
 			var unobservedInstruments []string
-			if st.CurrentGoalID != "" {
-				if goal, err := s.ActiveGoal(); err == nil {
+			if !scope.All && scope.GoalID != "" {
+				if goal, err := s.ReadGoal(scope.GoalID); err == nil {
 					needed := map[string]bool{goal.Objective.Instrument: true}
 					for _, c := range goal.Constraints {
 						needed[c.Instrument] = true
 					}
-					if obs, err := s.ListObservations(); err == nil {
-						for _, o := range obs {
-							delete(needed, o.Instrument)
-						}
+					for _, o := range obs {
+						delete(needed, o.Instrument)
 					}
 					for inst := range needed {
 						unobservedInstruments = append(unobservedInstruments, inst)
@@ -511,6 +545,7 @@ func statusCmd() *cobra.Command {
 
 			w.Textf("root:           %s\n", s.Root())
 			w.Textf("dir:            %s\n", s.DirPath())
+			w.Textf("scope:          %s\n", scope.label())
 			w.Textf("mode:           %s\n", cfg.Mode)
 			if mainCheckout.Dirty {
 				w.Textf("main checkout:  DIRTY (%d path(s) outside autoresearch-managed files)\n", len(mainCheckout.Paths))
@@ -566,4 +601,6 @@ func statusCmd() *cobra.Command {
 			return nil
 		},
 	}
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the status view to (defaults to active goal; use 'all' for every goal)")
+	return c
 }

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -19,10 +19,11 @@ import (
 
 func logCommands() []*cobra.Command {
 	var (
-		tail   int
-		kind   string
-		since  string
-		follow bool
+		tail     int
+		kind     string
+		since    string
+		follow   bool
+		goalFlag string
 	)
 	c := &cobra.Command{
 		Use:   "log",
@@ -42,6 +43,11 @@ event is appended with the standard formatter; in --json mode emits JSONL
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
+			resolver := newGoalScopeResolver(s, scope)
 
 			limits := map[string]any{"tail": tail}
 			if kind != "" {
@@ -53,8 +59,15 @@ event is appended with the standard formatter; in --json mode emits JSONL
 			if follow {
 				limits["follow"] = true
 			}
+			for k, v := range scope.payload() {
+				limits[k] = v
+			}
 
 			all, err := s.Events(0)
+			if err != nil {
+				return err
+			}
+			all, err = resolver.filterEvents(all)
 			if err != nil {
 				return err
 			}
@@ -96,13 +109,13 @@ event is appended with the standard formatter; in --json mode emits JSONL
 			truncated := !follow && total > len(filtered)
 
 			if w.IsJSON() && !follow {
-				return w.JSON(map[string]any{
+				return w.JSON(mergeGoalScopePayload(map[string]any{
 					"limits":       limits,
 					"total_events": total,
 					"shown_events": len(filtered),
 					"truncated":    truncated,
 					"events":       filtered,
-				})
+				}, scope))
 			}
 
 			if w.IsJSON() && follow {
@@ -129,7 +142,13 @@ event is appended with the standard formatter; in --json mode emits JSONL
 			}
 
 			if follow {
-				return followEvents(s, keep, w.IsJSON())
+				return followEvents(s, func(e store.Event) bool {
+					ok, err := resolver.eventMatches(e)
+					if err != nil || !ok {
+						return false
+					}
+					return keep(e)
+				}, w.IsJSON())
 			}
 			return nil
 		},
@@ -138,6 +157,7 @@ event is appended with the standard formatter; in --json mode emits JSONL
 	c.Flags().StringVar(&kind, "kind", "", "filter by event kind (exact or prefix, e.g. 'conclusion.')")
 	c.Flags().StringVar(&since, "since", "", "only events at or after this RFC3339 timestamp")
 	c.Flags().BoolVar(&follow, "follow", false, "after printing history, tail events.jsonl for new events (Ctrl-C to exit)")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the log to (defaults to active goal; use 'all' for every goal)")
 	return []*cobra.Command{c}
 }
 

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -142,13 +142,7 @@ event is appended with the standard formatter; in --json mode emits JSONL
 			}
 
 			if follow {
-				return followEvents(s, func(e store.Event) bool {
-					ok, err := resolver.eventMatches(e)
-					if err != nil || !ok {
-						return false
-					}
-					return keep(e)
-				}, w.IsJSON())
+				return followEvents(s, newFollowEventFilter(s, scope, keep), w.IsJSON())
 			}
 			return nil
 		},
@@ -175,6 +169,23 @@ func writeEventLine(w io.Writer, e store.Event) {
 		subject,
 		e.Actor,
 	)
+}
+
+// newFollowEventFilter recreates the scope resolver per streamed event so
+// baseline ownership picks up experiment.baseline events appended after
+// `log --follow` starts.
+func newFollowEventFilter(s *store.Store, scope goalScope, keep func(store.Event) bool) func(store.Event) bool {
+	if scope.All {
+		return keep
+	}
+	return func(e store.Event) bool {
+		resolver := newGoalScopeResolver(s, scope)
+		ok, err := resolver.eventMatches(e)
+		if err != nil || !ok {
+			return false
+		}
+		return keep(e)
+	}
 }
 
 // followEvents is the tail loop. It polls events.jsonl by byte offset every

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func TestNewFollowEventFilter_RefreshesBaselineGoalScope(t *testing.T) {
+	s := scopedFixtureStore(t)
+	filter := newFollowEventFilter(s, goalScope{GoalID: "G-0001"}, func(store.Event) bool { return true })
+
+	// Warm the historical baseline cache the same way `log --follow` does
+	// before the tail loop starts.
+	if !filter(store.Event{Kind: "experiment.baseline", Subject: "E-0001"}) {
+		t.Fatal("historical baseline should match goal scope")
+	}
+
+	now := time.Now().UTC()
+	baseline := &entity.Experiment{
+		ID:          "E-0004",
+		IsBaseline:  true,
+		Status:      entity.ExpMeasured,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "ghi789"},
+		Instruments: []string{"host_timing"},
+		Author:      "system",
+		CreatedAt:   now,
+	}
+	if err := s.WriteExperiment(baseline); err != nil {
+		t.Fatal(err)
+	}
+
+	baselineEvent := store.Event{
+		Ts:      now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: baseline.ID,
+		Data:    jsonRaw(map[string]any{"goal": "G-0001"}),
+	}
+	if err := s.AppendEvent(baselineEvent); err != nil {
+		t.Fatal(err)
+	}
+
+	obs := &entity.Observation{
+		ID:         "O-0003",
+		Experiment: baseline.ID,
+		Instrument: "host_timing",
+		MeasuredAt: now,
+		Value:      0.9,
+		Unit:       "s",
+		Samples:    3,
+		Author:     "system",
+	}
+	if err := s.WriteObservation(obs); err != nil {
+		t.Fatal(err)
+	}
+
+	observationEvent := store.Event{
+		Ts:      now,
+		Kind:    "observation.record",
+		Actor:   "system",
+		Subject: obs.ID,
+	}
+	if err := s.AppendEvent(observationEvent); err != nil {
+		t.Fatal(err)
+	}
+
+	if !filter(baselineEvent) {
+		t.Fatal("new baseline event should match goal scope after follow starts")
+	}
+	if !filter(observationEvent) {
+		t.Fatal("observation for new baseline should match goal scope after follow starts")
+	}
+}

--- a/internal/cli/scope.go
+++ b/internal/cli/scope.go
@@ -1,0 +1,413 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const goalScopeAll = "all"
+
+type goalScope struct {
+	GoalID string
+	All    bool
+}
+
+func (s goalScope) label() string {
+	if s.All || s.GoalID == "" {
+		return goalScopeAll
+	}
+	return s.GoalID
+}
+
+func (s goalScope) payload() map[string]any {
+	out := map[string]any{"scope_all": s.All}
+	if !s.All && s.GoalID != "" {
+		out["scope_goal_id"] = s.GoalID
+	}
+	return out
+}
+
+func resolveGoalScope(s *store.Store, flag string) (goalScope, error) {
+	flag = strings.TrimSpace(flag)
+	if flag == "" {
+		st, err := s.State()
+		if err != nil {
+			return goalScope{}, err
+		}
+		if st.CurrentGoalID == "" {
+			return goalScope{All: true}, nil
+		}
+		return goalScope{GoalID: st.CurrentGoalID}, nil
+	}
+	if flag == goalScopeAll {
+		return goalScope{All: true}, nil
+	}
+	ok, err := s.GoalExists(flag)
+	if err != nil {
+		return goalScope{}, err
+	}
+	if !ok {
+		return goalScope{}, fmt.Errorf("--goal %s: goal does not exist", flag)
+	}
+	return goalScope{GoalID: flag}, nil
+}
+
+func mergeGoalScopePayload(payload map[string]any, scope goalScope) map[string]any {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	for k, v := range scope.payload() {
+		payload[k] = v
+	}
+	return payload
+}
+
+func isNotFound(err error) bool {
+	return errors.Is(err, store.ErrGoalNotFound) ||
+		errors.Is(err, store.ErrHypothesisNotFound) ||
+		errors.Is(err, store.ErrExperimentNotFound) ||
+		errors.Is(err, store.ErrObservationNotFound) ||
+		errors.Is(err, store.ErrConclusionNotFound) ||
+		errors.Is(err, store.ErrLessonNotFound)
+}
+
+type goalScopeResolver struct {
+	store *store.Store
+	scope goalScope
+
+	hypGoals       map[string]string
+	expGoals       map[string]string
+	conclusionMap  map[string]string
+	observationMap map[string]string
+
+	eventsLoaded bool
+	events       []store.Event
+
+	baselineLoaded bool
+	baselineGoals  map[string]string
+}
+
+func newGoalScopeResolver(s *store.Store, scope goalScope) *goalScopeResolver {
+	return &goalScopeResolver{
+		store:          s,
+		scope:          scope,
+		hypGoals:       map[string]string{},
+		expGoals:       map[string]string{},
+		conclusionMap:  map[string]string{},
+		observationMap: map[string]string{},
+		baselineGoals:  map[string]string{},
+	}
+}
+
+func (r *goalScopeResolver) inScope(goalID string) bool {
+	if r.scope.All {
+		return true
+	}
+	return goalID != "" && goalID == r.scope.GoalID
+}
+
+func (r *goalScopeResolver) hypothesisGoal(id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	if gid, ok := r.hypGoals[id]; ok {
+		return gid, nil
+	}
+	h, err := r.store.ReadHypothesis(id)
+	if err != nil {
+		if isNotFound(err) {
+			r.hypGoals[id] = ""
+			return "", nil
+		}
+		return "", err
+	}
+	r.hypGoals[id] = h.GoalID
+	return h.GoalID, nil
+}
+
+func (r *goalScopeResolver) ensureEvents() error {
+	if r.eventsLoaded {
+		return nil
+	}
+	all, err := r.store.Events(0)
+	if err != nil {
+		return err
+	}
+	r.events = all
+	r.eventsLoaded = true
+	return nil
+}
+
+func (r *goalScopeResolver) ensureBaselineGoals() error {
+	if r.baselineLoaded {
+		return nil
+	}
+	if err := r.ensureEvents(); err != nil {
+		return err
+	}
+	type baselinePayload struct {
+		Goal string `json:"goal"`
+	}
+	for _, ev := range r.events {
+		if ev.Kind != "experiment.baseline" || ev.Subject == "" {
+			continue
+		}
+		var payload baselinePayload
+		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+			continue
+		}
+		if payload.Goal != "" {
+			r.baselineGoals[ev.Subject] = payload.Goal
+		}
+	}
+	r.baselineLoaded = true
+	return nil
+}
+
+func (r *goalScopeResolver) experimentGoal(id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	if gid, ok := r.expGoals[id]; ok {
+		return gid, nil
+	}
+	e, err := r.store.ReadExperiment(id)
+	if err != nil {
+		if isNotFound(err) {
+			r.expGoals[id] = ""
+			return "", nil
+		}
+		return "", err
+	}
+	if e.Hypothesis != "" {
+		gid, err := r.hypothesisGoal(e.Hypothesis)
+		if err != nil {
+			return "", err
+		}
+		r.expGoals[id] = gid
+		return gid, nil
+	}
+	if err := r.ensureBaselineGoals(); err != nil {
+		return "", err
+	}
+	gid := r.baselineGoals[id]
+	r.expGoals[id] = gid
+	return gid, nil
+}
+
+func (r *goalScopeResolver) conclusionGoal(id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	if gid, ok := r.conclusionMap[id]; ok {
+		return gid, nil
+	}
+	c, err := r.store.ReadConclusion(id)
+	if err != nil {
+		if isNotFound(err) {
+			r.conclusionMap[id] = ""
+			return "", nil
+		}
+		return "", err
+	}
+	gid, err := r.hypothesisGoal(c.Hypothesis)
+	if err != nil {
+		return "", err
+	}
+	r.conclusionMap[id] = gid
+	return gid, nil
+}
+
+func (r *goalScopeResolver) observationGoal(id string) (string, error) {
+	if id == "" {
+		return "", nil
+	}
+	if gid, ok := r.observationMap[id]; ok {
+		return gid, nil
+	}
+	o, err := r.store.ReadObservation(id)
+	if err != nil {
+		if isNotFound(err) {
+			r.observationMap[id] = ""
+			return "", nil
+		}
+		return "", err
+	}
+	gid, err := r.experimentGoal(o.Experiment)
+	if err != nil {
+		return "", err
+	}
+	r.observationMap[id] = gid
+	return gid, nil
+}
+
+func (r *goalScopeResolver) lessonMatches(l *entity.Lesson) (bool, error) {
+	if l == nil || r.scope.All {
+		return true, nil
+	}
+	if l.Scope == entity.LessonScopeSystem {
+		return true, nil
+	}
+	for _, sub := range l.Subjects {
+		var (
+			gid string
+			err error
+		)
+		switch {
+		case strings.HasPrefix(sub, "H-"):
+			gid, err = r.hypothesisGoal(sub)
+		case strings.HasPrefix(sub, "E-"):
+			gid, err = r.experimentGoal(sub)
+		case strings.HasPrefix(sub, "C-"):
+			gid, err = r.conclusionGoal(sub)
+		default:
+			continue
+		}
+		if err != nil {
+			return false, err
+		}
+		if r.inScope(gid) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *goalScopeResolver) eventMatches(ev store.Event) (bool, error) {
+	if r.scope.All {
+		return true, nil
+	}
+	if ev.Subject == "" {
+		return false, nil
+	}
+	switch {
+	case strings.HasPrefix(ev.Subject, "G-"):
+		return ev.Subject == r.scope.GoalID, nil
+	case strings.HasPrefix(ev.Subject, "H-"):
+		gid, err := r.hypothesisGoal(ev.Subject)
+		return r.inScope(gid), err
+	case strings.HasPrefix(ev.Subject, "E-"):
+		gid, err := r.experimentGoal(ev.Subject)
+		return r.inScope(gid), err
+	case strings.HasPrefix(ev.Subject, "O-"):
+		gid, err := r.observationGoal(ev.Subject)
+		return r.inScope(gid), err
+	case strings.HasPrefix(ev.Subject, "C-"):
+		gid, err := r.conclusionGoal(ev.Subject)
+		return r.inScope(gid), err
+	case strings.HasPrefix(ev.Subject, "L-"):
+		l, err := r.store.ReadLesson(ev.Subject)
+		if err != nil {
+			if isNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+		return r.lessonMatches(l)
+	default:
+		return false, nil
+	}
+}
+
+func (r *goalScopeResolver) filterHypotheses(all []*entity.Hypothesis) []*entity.Hypothesis {
+	if r.scope.All {
+		return all
+	}
+	out := make([]*entity.Hypothesis, 0, len(all))
+	for _, h := range all {
+		if h != nil && r.inScope(h.GoalID) {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func (r *goalScopeResolver) filterExperiments(all []*entity.Experiment) ([]*entity.Experiment, error) {
+	if r.scope.All {
+		return all, nil
+	}
+	out := make([]*entity.Experiment, 0, len(all))
+	for _, e := range all {
+		gid, err := r.experimentGoal(e.ID)
+		if err != nil {
+			return nil, err
+		}
+		if r.inScope(gid) {
+			out = append(out, e)
+		}
+	}
+	return out, nil
+}
+
+func (r *goalScopeResolver) filterConclusions(all []*entity.Conclusion) ([]*entity.Conclusion, error) {
+	if r.scope.All {
+		return all, nil
+	}
+	out := make([]*entity.Conclusion, 0, len(all))
+	for _, c := range all {
+		gid, err := r.hypothesisGoal(c.Hypothesis)
+		if err != nil {
+			return nil, err
+		}
+		if r.inScope(gid) {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (r *goalScopeResolver) filterObservations(all []*entity.Observation) ([]*entity.Observation, error) {
+	if r.scope.All {
+		return all, nil
+	}
+	out := make([]*entity.Observation, 0, len(all))
+	for _, o := range all {
+		gid, err := r.experimentGoal(o.Experiment)
+		if err != nil {
+			return nil, err
+		}
+		if r.inScope(gid) {
+			out = append(out, o)
+		}
+	}
+	return out, nil
+}
+
+func (r *goalScopeResolver) filterLessons(all []*entity.Lesson) ([]*entity.Lesson, error) {
+	if r.scope.All {
+		return all, nil
+	}
+	out := make([]*entity.Lesson, 0, len(all))
+	for _, l := range all {
+		ok, err := r.lessonMatches(l)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, l)
+		}
+	}
+	return out, nil
+}
+
+func (r *goalScopeResolver) filterEvents(all []store.Event) ([]store.Event, error) {
+	if r.scope.All {
+		return all, nil
+	}
+	out := make([]store.Event, 0, len(all))
+	for _, ev := range all {
+		ok, err := r.eventMatches(ev)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			out = append(out, ev)
+		}
+	}
+	return out, nil
+}

--- a/internal/cli/scope_test.go
+++ b/internal/cli/scope_test.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func scopedFixtureStore(t *testing.T) *store.Store {
+	t.Helper()
+
+	s, err := store.Create(t.TempDir(), store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	g1 := &entity.Goal{
+		ID:        "G-0001",
+		Status:    entity.GoalStatusConcluded,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Constraints: []entity.Constraint{
+			{Instrument: "host_test", Require: "pass"},
+		},
+	}
+	g2 := &entity.Goal{
+		ID:        "G-0002",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"},
+		Constraints: []entity.Constraint{
+			{Instrument: "size_flash", Max: ptrFloat(131072)},
+		},
+	}
+	for _, g := range []*entity.Goal{g1, g2} {
+		if err := s.WriteGoal(g); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.UpdateState(func(st *store.State) error {
+		st.CurrentGoalID = g2.ID
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	h1 := &entity.Hypothesis{
+		ID: "H-0001", GoalID: g1.ID, Claim: "goal 1 hypothesis", Status: entity.StatusOpen, Author: "human", CreatedAt: now,
+		Predicts: entity.Predicts{Instrument: "host_timing", Target: "fir", Direction: "decrease"},
+	}
+	h2 := &entity.Hypothesis{
+		ID: "H-0002", GoalID: g2.ID, Claim: "goal 2 hypothesis", Status: entity.StatusOpen, Author: "human", CreatedAt: now,
+		Predicts: entity.Predicts{Instrument: "qemu_cycles", Target: "fir", Direction: "decrease"},
+	}
+	for _, h := range []*entity.Hypothesis{h1, h2} {
+		if err := s.WriteHypothesis(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	base := &entity.Experiment{
+		ID: "E-0001", IsBaseline: true, Status: entity.ExpMeasured,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{"host_timing"},
+		Author:      "system", CreatedAt: now,
+	}
+	e1 := &entity.Experiment{
+		ID: "E-0002", Hypothesis: h1.ID, Status: entity.ExpMeasured,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{"host_timing"},
+		Author:      "system", CreatedAt: now,
+	}
+	e2 := &entity.Experiment{
+		ID: "E-0003", Hypothesis: h2.ID, Status: entity.ExpMeasured,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "def456"},
+		Instruments: []string{"qemu_cycles"},
+		Author:      "system", CreatedAt: now,
+	}
+	for _, e := range []*entity.Experiment{base, e1, e2} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.WriteObservation(&entity.Observation{
+		ID: "O-0001", Experiment: base.ID, Instrument: "host_timing", MeasuredAt: now, Value: 1.0, Unit: "s", Samples: 3, Author: "system",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID: "O-0002", Experiment: e2.ID, Instrument: "qemu_cycles", MeasuredAt: now, Value: 100, Unit: "cycles", Samples: 3, Author: "system",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	c1 := &entity.Conclusion{
+		ID: "C-0001", Hypothesis: h1.ID, Verdict: entity.VerdictSupported,
+		CandidateExp: e1.ID, Effect: entity.Effect{Instrument: "host_timing", DeltaFrac: -0.1},
+		StatTest: "welch", Author: "agent:analyst", CreatedAt: now,
+	}
+	c2 := &entity.Conclusion{
+		ID: "C-0002", Hypothesis: h2.ID, Verdict: entity.VerdictSupported,
+		CandidateExp: e2.ID, Effect: entity.Effect{Instrument: "qemu_cycles", DeltaFrac: -0.2},
+		StatTest: "welch", Author: "agent:analyst", CreatedAt: now,
+	}
+	for _, c := range []*entity.Conclusion{c1, c2} {
+		if err := s.WriteConclusion(c); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	l1 := &entity.Lesson{
+		ID: "L-0001", Claim: "goal 1 lesson", Scope: entity.LessonScopeHypothesis, Subjects: []string{h1.ID},
+		Status: entity.LessonStatusActive, Author: "agent:analyst", CreatedAt: now,
+	}
+	l2 := &entity.Lesson{
+		ID: "L-0002", Claim: "system lesson", Scope: entity.LessonScopeSystem,
+		Status: entity.LessonStatusActive, Author: "agent:analyst", CreatedAt: now,
+	}
+	l3 := &entity.Lesson{
+		ID: "L-0003", Claim: "goal 2 lesson", Scope: entity.LessonScopeHypothesis, Subjects: []string{c2.ID},
+		Status: entity.LessonStatusActive, Author: "agent:analyst", CreatedAt: now,
+	}
+	for _, l := range []*entity.Lesson{l1, l2, l3} {
+		if err := s.WriteLesson(l); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	events := []store.Event{
+		{Ts: now, Kind: "goal.new", Actor: "human", Subject: g1.ID},
+		{Ts: now, Kind: "goal.new", Actor: "human", Subject: g2.ID},
+		{Ts: now, Kind: "hypothesis.add", Actor: "human", Subject: h1.ID},
+		{Ts: now, Kind: "hypothesis.add", Actor: "human", Subject: h2.ID},
+		{Ts: now, Kind: "experiment.baseline", Actor: "system", Subject: base.ID, Data: jsonRaw(map[string]any{"goal": g1.ID})},
+		{Ts: now, Kind: "observation.record", Actor: "system", Subject: "O-0001"},
+		{Ts: now, Kind: "lesson.add", Actor: "agent:analyst", Subject: l1.ID},
+		{Ts: now, Kind: "lesson.add", Actor: "agent:analyst", Subject: l2.ID},
+		{Ts: now, Kind: "pause", Actor: "human"},
+	}
+	for _, ev := range events {
+		if err := s.AppendEvent(ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return s
+}
+
+func ptrFloat(v float64) *float64 { return &v }
+
+func TestResolveGoalScope_DefaultsAndAll(t *testing.T) {
+	s, err := store.Create(t.TempDir(), store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scope, err := resolveGoalScope(s, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !scope.All {
+		t.Fatalf("empty scope with no active goal should default to all, got %+v", scope)
+	}
+
+	now := time.Now().UTC()
+	goal := &entity.Goal{
+		ID: "G-0001", Status: entity.GoalStatusActive, CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	if err := s.WriteGoal(goal); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpdateState(func(st *store.State) error {
+		st.CurrentGoalID = goal.ID
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	scope, err = resolveGoalScope(s, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scope.All || scope.GoalID != goal.ID {
+		t.Fatalf("default scope = %+v, want %s", scope, goal.ID)
+	}
+
+	scope, err = resolveGoalScope(s, goalScopeAll)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !scope.All {
+		t.Fatalf("--goal all should resolve to all, got %+v", scope)
+	}
+
+	if _, err := resolveGoalScope(s, "G-9999"); err == nil {
+		t.Fatal("expected unknown explicit goal to fail")
+	}
+}
+
+func TestGoalScopeResolver_FiltersBaselineLessonsAndEvents(t *testing.T) {
+	s := scopedFixtureStore(t)
+	r := newGoalScopeResolver(s, goalScope{GoalID: "G-0001"})
+
+	exps, err := s.ListExperiments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	exps, err = r.filterExperiments(exps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exps) != 2 {
+		t.Fatalf("scoped experiments = %d, want 2", len(exps))
+	}
+	if exps[0].ID != "E-0001" || exps[1].ID != "E-0002" {
+		t.Fatalf("unexpected scoped experiments: %s, %s", exps[0].ID, exps[1].ID)
+	}
+
+	obs, err := s.ListObservations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	obs, err = r.filterObservations(obs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(obs) != 1 || obs[0].ID != "O-0001" {
+		t.Fatalf("scoped observations = %+v, want O-0001 only", obs)
+	}
+
+	lessons, err := s.ListLessons()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lessons, err = r.filterLessons(lessons)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(lessons) != 2 {
+		t.Fatalf("scoped lessons = %d, want 2", len(lessons))
+	}
+	if lessons[0].ID != "L-0001" || lessons[1].ID != "L-0002" {
+		t.Fatalf("unexpected lesson scope: %s, %s", lessons[0].ID, lessons[1].ID)
+	}
+
+	events, err := s.Events(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err = r.filterEvents(events)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]bool{
+		"goal.new:G-0001":            true,
+		"hypothesis.add:H-0001":      true,
+		"experiment.baseline:E-0001": true,
+		"observation.record:O-0001":  true,
+		"lesson.add:L-0001":          true,
+		"lesson.add:L-0002":          true,
+	}
+	if len(events) != len(want) {
+		t.Fatalf("scoped events = %d, want %d", len(events), len(want))
+	}
+	for _, ev := range events {
+		key := ev.Kind + ":" + ev.Subject
+		if !want[key] {
+			t.Fatalf("unexpected scoped event %s", key)
+		}
+	}
+}
+
+func TestCaptureDashboard_DefaultScopeTracksActiveGoal(t *testing.T) {
+	s := scopedFixtureStore(t)
+
+	snap, err := captureDashboard(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.ScopeAll || snap.ScopeGoalID != "G-0002" {
+		t.Fatalf("dashboard scope = %+v, want goal G-0002", snap)
+	}
+	if got := snap.Counts["hypotheses"]; got != 1 {
+		t.Fatalf("scoped hypothesis count = %d, want 1", got)
+	}
+	if len(snap.Tree) != 1 || snap.Tree[0].ID != "H-0002" {
+		t.Fatalf("scoped tree = %+v, want H-0002 only", snap.Tree)
+	}
+	if got := len(snap.RecentLessons); got != 2 {
+		t.Fatalf("scoped lessons = %d, want goal lesson + system lesson", got)
+	}
+
+	allSnap, err := captureDashboardScoped(s, goalScope{All: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allSnap.ScopeAll {
+		t.Fatalf("all-goal dashboard should report scope_all=true")
+	}
+	if got := allSnap.Counts["hypotheses"]; got != 2 {
+		t.Fatalf("all-goal hypothesis count = %d, want 2", got)
+	}
+	if got := len(allSnap.RecentLessons); got != 3 {
+		t.Fatalf("all-goal lessons = %d, want 3", got)
+	}
+}

--- a/internal/cli/tree.go
+++ b/internal/cli/tree.go
@@ -7,17 +7,17 @@ import (
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
-	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
 )
 
 func treeCommands() []*cobra.Command {
-	var goalID string
+	var goalFlag string
 	c := &cobra.Command{
 		Use:   "tree",
-		Short: "Render the hypothesis tree for the active goal (or --goal G-NNNN)",
+		Short: "Render the hypothesis tree for the active goal (or --goal G-NNNN|all)",
 		Long: `Render the hypothesis forest scoped to a single goal. Defaults to
-the active goal; pass --goal G-NNNN to view a historical goal's tree.
+the active goal; pass --goal G-NNNN to view a historical goal's tree, or
+--goal all to broaden the view across goals.
 Hypotheses are bound to a goal at creation time; the tree view never
 mixes contexts.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,7 +26,7 @@ mixes contexts.`,
 			if err != nil {
 				return err
 			}
-			scopeID, err := resolveGoalScope(s, goalID)
+			scope, err := resolveGoalScope(s, goalFlag)
 			if err != nil {
 				return err
 			}
@@ -34,18 +34,16 @@ mixes contexts.`,
 			if err != nil {
 				return err
 			}
-			filtered := filterHypothesesByGoal(all, scopeID)
+			filtered := filterHypothesesByScope(all, scope)
 			roots, children := buildHypothesisForest(filtered)
 
 			if w.IsJSON() {
-				return w.JSON(map[string]any{
-					"goal_id": scopeID,
+				return w.JSON(mergeGoalScopePayload(map[string]any{
+					"goal_id": scope.GoalID,
 					"tree":    buildTreeJSON(roots, children),
-				})
+				}, scope))
 			}
-			if scopeID != "" {
-				w.Textf("[goal: %s]\n", scopeID)
-			}
+			w.Textf("[goal: %s]\n", scope.label())
 			if len(roots) == 0 && len(filtered) == 0 {
 				w.Textln("(no hypotheses)")
 				return nil
@@ -54,30 +52,8 @@ mixes contexts.`,
 			return nil
 		},
 	}
-	c.Flags().StringVar(&goalID, "goal", "", "goal to scope the tree to (defaults to active goal)")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the tree to (defaults to active goal; use 'all' for every goal)")
 	return []*cobra.Command{c}
-}
-
-// resolveGoalScope picks the goal id a read-only view should scope to. An
-// explicit --goal flag is verified against the store; an empty flag falls
-// back to the active goal id from state (which may itself be empty when
-// the store has no goal yet — callers must handle that).
-func resolveGoalScope(s *store.Store, flag string) (string, error) {
-	if flag != "" {
-		ok, err := s.GoalExists(flag)
-		if err != nil {
-			return "", err
-		}
-		if !ok {
-			return "", fmt.Errorf("--goal %s: goal does not exist", flag)
-		}
-		return flag, nil
-	}
-	st, err := s.State()
-	if err != nil {
-		return "", err
-	}
-	return st.CurrentGoalID, nil
 }
 
 // filterHypothesesByGoal keeps only hypotheses bound to goalID. When goalID
@@ -88,9 +64,16 @@ func filterHypothesesByGoal(all []*entity.Hypothesis, goalID string) []*entity.H
 	if goalID == "" {
 		return all
 	}
+	return filterHypothesesByScope(all, goalScope{GoalID: goalID})
+}
+
+func filterHypothesesByScope(all []*entity.Hypothesis, scope goalScope) []*entity.Hypothesis {
+	if scope.All {
+		return all
+	}
 	out := make([]*entity.Hypothesis, 0, len(all))
 	for _, h := range all {
-		if h.GoalID == goalID {
+		if h != nil && h.GoalID == scope.GoalID {
 			out = append(out, h)
 		}
 	}

--- a/internal/cli/tui_app.go
+++ b/internal/cli/tui_app.go
@@ -23,6 +23,9 @@ type tuiPushMsg struct{ v tuiView }
 // resetMsg clears the stack back to just the dashboard.
 type tuiResetMsg struct{}
 
+// setScopeMsg updates the TUI's read-only session scope.
+type tuiSetScopeMsg struct{ scope goalScope }
+
 // chromeLoadedMsg carries the cheap state+config+counts read that the header
 // needs on every tick. It's read independently of the active view so the
 // header stays fresh no matter which view is on top.
@@ -161,6 +164,21 @@ func (m *tuiModel) jumpTo(v tuiView, s *store.Store) tea.Cmd {
 	return v.init(s)
 }
 
+func (m *tuiModel) applyScope(scope goalScope) tea.Cmd {
+	m.scope = scope
+	dashboard := newDashboardView(scope)
+	goals := newGoalListView(scope)
+	m.stack = []tuiView{dashboard, goals}
+	if m.store == nil {
+		return nil
+	}
+	return tea.Batch(
+		dashboard.init(m.store),
+		goals.init(m.store),
+		fetchChrome(m.store, m.scope),
+	)
+}
+
 func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
@@ -190,6 +208,9 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tuiResetMsg:
 		m.stack = []tuiView{newDashboardView(m.scope)}
 		return m, m.top().init(m.store)
+
+	case tuiSetScopeMsg:
+		return m, m.applyScope(msg.scope)
 
 	case tea.KeyMsg:
 		if m.showHelp {
@@ -223,7 +244,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "F":
 			return m, m.jumpTo(newFrontierView(m.scope), m.store)
 		case "O":
-			return m, m.jumpTo(newGoalListView(), m.store)
+			return m, m.jumpTo(newGoalListView(m.scope), m.store)
 		case "S":
 			return m, m.jumpTo(newStatusView(m.scope), m.store)
 		case "A":
@@ -273,6 +294,10 @@ func (m tuiModel) View() string {
 // tuiPush returns a tea.Cmd that emits a tuiPushMsg.
 func tuiPush(v tuiView) tea.Cmd {
 	return func() tea.Msg { return tuiPushMsg{v: v} }
+}
+
+func tuiSetScope(scope goalScope) tea.Cmd {
+	return func() tea.Msg { return tuiSetScopeMsg{scope: scope} }
 }
 
 // clampLines truncates s to at most n lines and pads shorter content so the
@@ -458,6 +483,10 @@ func (m tuiModel) renderHelp() string {
 		"  ↑/↓ or j/k    move cursor",
 		"  Enter         open detail",
 		"  f             cycle filter",
+		"",
+		"Within goal views:",
+		"  s             scope the TUI to the selected goal",
+		"  a             broaden scope to all goals",
 		"",
 		"Within hypothesis detail / list:",
 		"  r             open markdown report",

--- a/internal/cli/tui_app.go
+++ b/internal/cli/tui_app.go
@@ -61,6 +61,7 @@ type tuiView interface {
 
 type tuiModel struct {
 	store    *store.Store
+	scope    goalScope
 	stack    []tuiView
 	width    int
 	height   int
@@ -71,10 +72,11 @@ type tuiModel struct {
 	chrome chromeLoadedMsg
 }
 
-func newTuiModel(s *store.Store, refresh time.Duration) tuiModel {
+func newTuiModel(s *store.Store, scope goalScope, refresh time.Duration) tuiModel {
 	return tuiModel{
 		store:   s,
-		stack:   []tuiView{newDashboardView()},
+		scope:   scope,
+		stack:   []tuiView{newDashboardView(scope)},
 		refresh: refresh,
 	}
 }
@@ -82,7 +84,7 @@ func newTuiModel(s *store.Store, refresh time.Duration) tuiModel {
 func (m tuiModel) Init() tea.Cmd {
 	return tea.Batch(
 		m.top().init(m.store),
-		fetchChrome(m.store),
+		fetchChrome(m.store, m.scope),
 		tuiTick(m.refresh),
 	)
 }
@@ -97,7 +99,7 @@ func tuiTick(d time.Duration) tea.Cmd {
 // fetchChrome reads the cheap state+config+counts summary used by the header
 // status bar. It is scheduled independently of the active view so the header
 // stays fresh on every tick regardless of what's on top of the stack.
-func fetchChrome(s *store.Store) tea.Cmd {
+func fetchChrome(s *store.Store, scope goalScope) tea.Cmd {
 	return func() tea.Msg {
 		msg := chromeLoadedMsg{}
 		if s == nil {
@@ -110,8 +112,23 @@ func fetchChrome(s *store.Store) tea.Cmd {
 		if cfg, err := s.Config(); err == nil {
 			msg.mode = cfg.Mode
 		}
-		if counts, err := s.Counts(); err == nil {
-			msg.counts = counts
+		resolver := newGoalScopeResolver(s, scope)
+		hyps, herr := s.ListHypotheses()
+		exps, eerr := s.ListExperiments()
+		obs, oerr := s.ListObservations()
+		concls, cerr := s.ListConclusions()
+		if herr == nil && eerr == nil && oerr == nil && cerr == nil {
+			exps, eerr = resolver.filterExperiments(exps)
+			obs, oerr = resolver.filterObservations(obs)
+			concls, cerr = resolver.filterConclusions(concls)
+			if eerr == nil && oerr == nil && cerr == nil {
+				msg.counts = map[string]int{
+					"hypotheses":   len(resolver.filterHypotheses(hyps)),
+					"experiments":  len(exps),
+					"observations": len(obs),
+					"conclusions":  len(concls),
+				}
+			}
 		}
 		return msg
 	}
@@ -140,7 +157,7 @@ func (m *tuiModel) jumpTo(v tuiView, s *store.Store) tea.Cmd {
 			return nil
 		}
 	}
-	m.stack = []tuiView{newDashboardView(), v}
+	m.stack = []tuiView{newDashboardView(m.scope), v}
 	return v.init(s)
 }
 
@@ -160,7 +177,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		top := m.top()
 		nv, cmd := top.update(msg, m.store)
 		m.setTop(nv)
-		return m, tea.Batch(cmd, fetchChrome(m.store), tuiTick(m.refresh))
+		return m, tea.Batch(cmd, fetchChrome(m.store, m.scope), tuiTick(m.refresh))
 
 	case chromeLoadedMsg:
 		m.chrome = msg
@@ -171,7 +188,7 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, msg.v.init(m.store)
 
 	case tuiResetMsg:
-		m.stack = []tuiView{newDashboardView()}
+		m.stack = []tuiView{newDashboardView(m.scope)}
 		return m, m.top().init(m.store)
 
 	case tea.KeyMsg:
@@ -192,29 +209,29 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case "H":
-			return m, m.jumpTo(newHypothesisListView(), m.store)
+			return m, m.jumpTo(newHypothesisListView(m.scope), m.store)
 		case "E":
-			return m, m.jumpTo(newExperimentListView(), m.store)
+			return m, m.jumpTo(newExperimentListView(m.scope), m.store)
 		case "C":
-			return m, m.jumpTo(newConclusionListView(), m.store)
+			return m, m.jumpTo(newConclusionListView(m.scope), m.store)
 		case "L":
-			return m, m.jumpTo(newEventListView(), m.store)
+			return m, m.jumpTo(newEventListView(m.scope), m.store)
 		case "N":
-			return m, m.jumpTo(newLessonListView(), m.store)
+			return m, m.jumpTo(newLessonListView(m.scope), m.store)
 		case "T":
-			return m, m.jumpTo(newTreeView(), m.store)
+			return m, m.jumpTo(newTreeView(m.scope), m.store)
 		case "F":
-			return m, m.jumpTo(newFrontierView(), m.store)
+			return m, m.jumpTo(newFrontierView(m.scope), m.store)
 		case "O":
-			return m, m.jumpTo(newGoalView(), m.store)
+			return m, m.jumpTo(newGoalListView(), m.store)
 		case "S":
-			return m, m.jumpTo(newStatusView(), m.store)
+			return m, m.jumpTo(newStatusView(m.scope), m.store)
 		case "A":
-			return m, m.jumpTo(newArtifactListView(), m.store)
+			return m, m.jumpTo(newArtifactListView(m.scope), m.store)
 		case "I":
 			return m, m.jumpTo(newInstrumentListView(), m.store)
 		case "R":
-			return m, m.jumpTo(newHypothesisListViewForReport(), m.store)
+			return m, m.jumpTo(newHypothesisListViewForReport(m.scope), m.store)
 		case "D":
 			return m, func() tea.Msg { return tuiResetMsg{} }
 		}
@@ -353,6 +370,7 @@ func (m tuiModel) renderHeader() string {
 			m.chrome.counts["observations"],
 			m.chrome.counts["conclusions"]))
 	}
+	rightOrder = append(rightOrder, tuiDim.Render("scope=")+m.scope.label())
 	if m.refresh > 0 {
 		rightOrder = append(rightOrder, tuiDim.Render("↻"+m.refresh.String()))
 	}
@@ -433,7 +451,7 @@ func (m tuiModel) renderHelp() string {
 		"Jump to view:",
 		"  H hypotheses   E experiments   C conclusions",
 		"  L event log    T tree          F frontier",
-		"  O goal         S status         A artifacts",
+		"  O goals        S status         A artifacts",
 		"  I instruments  R report picker  N notebook",
 		"",
 		"Within a list:",

--- a/internal/cli/tui_command.go
+++ b/internal/cli/tui_command.go
@@ -12,6 +12,7 @@ import (
 
 func dashboardTuiCmd() *cobra.Command {
 	var refresh int
+	var goalFlag string
 	c := &cobra.Command{
 		Use:   "tui",
 		Short: "Interactive read-only TUI over the research state",
@@ -26,7 +27,7 @@ main agent session, which translates intent into CLI calls.
 
 Press ? inside the TUI for a full key reference. Top-level jumps:
 H hypotheses  E experiments  C conclusions  L log
-T tree  F frontier  O goal  S status  D dashboard
+T tree  F frontier  O goals  S status  D dashboard
 A artifacts  I instruments  R report picker`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !term.IsTerminal(int(os.Stdout.Fd())) {
@@ -36,16 +37,21 @@ A artifacts  I instruments  R report picker`,
 			if err != nil {
 				return err
 			}
+			scope, err := resolveGoalScope(s, goalFlag)
+			if err != nil {
+				return err
+			}
 			if refresh < 1 {
 				// Default cadence when --refresh is omitted or set to 0.
 				refresh = 2
 			}
-			m := newTuiModel(s, time.Duration(refresh)*time.Second)
+			m := newTuiModel(s, scope, time.Duration(refresh)*time.Second)
 			p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
 			_, err = p.Run()
 			return err
 		},
 	}
 	c.Flags().IntVar(&refresh, "refresh", 2, "seconds between background refreshes (min 1)")
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope the TUI to (defaults to active goal; use 'all' for every goal)")
 	return c
 }

--- a/internal/cli/tui_scope_test.go
+++ b/internal/cli/tui_scope_test.go
@@ -1,0 +1,97 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestTUI_GoalListViewShowsSessionScope(t *testing.T) {
+	v := newGoalListView(goalScope{GoalID: "G-0002"})
+	goals := []*entity.Goal{
+		{ID: "G-0001", Status: entity.GoalStatusConcluded, Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"}},
+		{ID: "G-0002", Status: entity.GoalStatusActive, Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}},
+	}
+	nv, _ := v.update(goalListLoadedMsg{all: goals, current: "G-0002"}, nil)
+	gv := nv.(*goalListView)
+	if got := gv.cursor; got != 1 {
+		t.Fatalf("goal list cursor = %d, want scoped goal row", got)
+	}
+
+	out := stripANSI(nv.view(100, 20))
+	for _, want := range []string{"scope=G-0002", ">* G-0002", "qemu_cycles"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("goal list missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTUI_GoalDetailViewShowsSessionScope(t *testing.T) {
+	v := newGoalDetailView("G-0001", goalScope{GoalID: "G-0001"})
+	g := &entity.Goal{
+		ID:         "G-0001",
+		Status:     entity.GoalStatusActive,
+		Objective:  entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"},
+		Completion: &entity.Completion{Threshold: 0.2, OnThreshold: entity.GoalOnThresholdAskHuman},
+	}
+	nv, _ := v.update(goalDetailLoadedMsg{g: g}, nil)
+	out := stripANSI(nv.view(100, 20))
+	if !strings.Contains(out, "scope=G-0001") {
+		t.Fatalf("goal detail should show session scope:\n%s", out)
+	}
+}
+
+func TestTUI_GoalListCanRetargetScope(t *testing.T) {
+	goals := []*entity.Goal{
+		{ID: "G-0001", Status: entity.GoalStatusConcluded, Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"}},
+		{ID: "G-0002", Status: entity.GoalStatusActive, Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}},
+	}
+	v := newGoalListView(goalScope{All: true})
+	nv, _ := v.update(goalListLoadedMsg{all: goals, current: "G-0002"}, nil)
+	gv := nv.(*goalListView)
+	gv.cursor = 1
+
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
+	m.stack = []tuiView{newDashboardView(goalScope{All: true}), gv}
+
+	model, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if cmd == nil {
+		t.Fatal("goal list scope change should emit a command")
+	}
+	m = model.(tuiModel)
+
+	model, _ = m.Update(cmd())
+	m = model.(tuiModel)
+	if got := m.scope; got.All || got.GoalID != "G-0002" {
+		t.Fatalf("scope after goal-list retarget = %+v, want G-0002", got)
+	}
+	if got := m.top().kind(); got != kindGoalList {
+		t.Fatalf("scope retarget should land on goal list, top=%s", got)
+	}
+}
+
+func TestTUI_GoalDetailCanBroadenScope(t *testing.T) {
+	m := newTuiModel(nil, goalScope{GoalID: "G-0001"}, 2*time.Second)
+	m.stack = []tuiView{
+		newDashboardView(goalScope{GoalID: "G-0001"}),
+		newGoalDetailView("G-0001", goalScope{GoalID: "G-0001"}),
+	}
+
+	model, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if cmd == nil {
+		t.Fatal("goal detail all-scope change should emit a command")
+	}
+	m = model.(tuiModel)
+
+	model, _ = m.Update(cmd())
+	m = model.(tuiModel)
+	if !m.scope.All {
+		t.Fatalf("scope after broadening = %+v, want all", m.scope)
+	}
+	if got := m.top().kind(); got != kindGoalList {
+		t.Fatalf("broadening scope should land on goal list, top=%s", got)
+	}
+}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -64,7 +64,7 @@ func tuiRichSnapshot() *dashboardSnapshot {
 }
 
 func TestTUI_DashboardRenders(t *testing.T) {
-	v := newDashboardView()
+	v := newDashboardView(goalScope{All: true})
 	nv, _ := v.update(dashLoadedMsg{snap: tuiRichSnapshot()}, nil)
 	out := nv.view(140, 40)
 	for _, want := range []string{
@@ -81,7 +81,7 @@ func TestTUI_DashboardRenders(t *testing.T) {
 }
 
 func TestTUI_DashboardNarrowFallback(t *testing.T) {
-	v := newDashboardView()
+	v := newDashboardView(goalScope{All: true})
 	nv, _ := v.update(dashLoadedMsg{snap: tuiRichSnapshot()}, nil)
 	out := stripANSI(nv.view(80, 40))
 	// Narrow width still renders the key sections in single-column layout.
@@ -93,7 +93,7 @@ func TestTUI_DashboardNarrowFallback(t *testing.T) {
 }
 
 func TestTUI_HypothesisList(t *testing.T) {
-	v := newHypothesisListView()
+	v := newHypothesisListView(goalScope{All: true})
 	hs := []*entity.Hypothesis{
 		{ID: "H-0001", Claim: "one", Status: entity.StatusOpen, Author: "human"},
 		{ID: "H-0002", Claim: "two", Status: entity.StatusSupported, Author: "agent"},
@@ -169,7 +169,7 @@ func TestTUI_HypothesisDetailOpensLinkedEntities(t *testing.T) {
 }
 
 func TestTUI_ExperimentList(t *testing.T) {
-	v := newExperimentListView()
+	v := newExperimentListView(goalScope{All: true})
 	es := []*entity.Experiment{
 		{ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpImplemented, Instruments: []string{"qemu_cycles"}},
 	}
@@ -240,7 +240,7 @@ func TestTUI_ObservationDetail(t *testing.T) {
 }
 
 func TestTUI_ConclusionList(t *testing.T) {
-	v := newConclusionListView()
+	v := newConclusionListView(goalScope{All: true})
 	cs := []*entity.Conclusion{
 		{ID: "C-0001", Hypothesis: "H-0001", Verdict: entity.VerdictSupported,
 			Effect: entity.Effect{DeltaFrac: -0.25, PValue: 0.01}},
@@ -275,7 +275,7 @@ func TestTUI_ConclusionDetail(t *testing.T) {
 }
 
 func TestTUI_EventListAndDetail(t *testing.T) {
-	v := newEventListView()
+	v := newEventListView(goalScope{All: true})
 	es := []store.Event{
 		{Ts: time.Now().UTC(), Kind: "experiment.implement", Actor: "agent:impl", Subject: "E-0007",
 			Data: []byte(`{"worktree":"/tmp/wt","branch":"autoresearch/E-0007","samples":5,"pass":true}`)},
@@ -373,7 +373,7 @@ func TestTUI_PrettyJSON(t *testing.T) {
 }
 
 func TestTUI_TreeView(t *testing.T) {
-	v := newTreeView()
+	v := newTreeView(goalScope{All: true})
 	nodes := []*treeNode{
 		{ID: "H-0001", Claim: "root hyp", Status: entity.StatusOpen},
 		{ID: "H-0002", Claim: "another", Status: entity.StatusSupported},
@@ -388,7 +388,7 @@ func TestTUI_TreeView(t *testing.T) {
 }
 
 func TestTUI_FrontierView(t *testing.T) {
-	v := newFrontierView()
+	v := newFrontierView(goalScope{GoalID: "G-0001"})
 	g := &entity.Goal{Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}}
 	rows := []frontierRow{{Conclusion: "C-0001", Hypothesis: "H-0001", Value: 750067, DeltaFrac: -0.25}}
 	nv, _ := v.update(frontierLoadedMsg{
@@ -405,28 +405,45 @@ func TestTUI_FrontierView(t *testing.T) {
 	}
 }
 
-func TestTUI_GoalView(t *testing.T) {
-	v := newGoalView()
+func TestTUI_GoalDetailView(t *testing.T) {
+	v := newGoalDetailView("G-0001")
 	flash := 65536.0
 	g := &entity.Goal{
+		ID:          "G-0001",
+		Status:      entity.GoalStatusActive,
 		Objective:   entity.Objective{Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease"},
 		Completion:  &entity.Completion{Threshold: 0.2, OnThreshold: entity.GoalOnThresholdAskHuman},
 		Constraints: []entity.Constraint{{Instrument: "size_flash", Max: &flash}, {Instrument: "host_test", Require: "pass"}},
 	}
-	nv, _ := v.update(goalLoadedMsg{g: g}, nil)
+	nv, _ := v.update(goalDetailLoadedMsg{g: g}, nil)
 	out := stripANSI(nv.view(100, 20))
-	for _, want := range []string{"Objective:", "decrease qemu_cycles", "Completion:", "threshold=0.2 -> ask_human", "size_flash", "host_test", "require=pass"} {
+	for _, want := range []string{"G-0001", "Objective:", "decrease qemu_cycles", "Completion:", "threshold=0.2 -> ask_human", "size_flash", "host_test", "require=pass"} {
 		if !strings.Contains(out, want) {
-			t.Errorf("goal view missing %q:\n%s", want, out)
+			t.Errorf("goal detail missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestTUI_GoalListView(t *testing.T) {
+	v := newGoalListView()
+	goals := []*entity.Goal{
+		{ID: "G-0001", Status: entity.GoalStatusConcluded, Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"}},
+		{ID: "G-0002", Status: entity.GoalStatusActive, Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}},
+	}
+	nv, _ := v.update(goalListLoadedMsg{all: goals, current: "G-0002"}, nil)
+	out := stripANSI(nv.view(100, 20))
+	for _, want := range []string{"2 goals", "G-0001", "G-0002", "qemu_cycles"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("goal list missing %q:\n%s", want, out)
 		}
 	}
 }
 
 func TestTUI_StatusView(t *testing.T) {
-	v := newStatusView()
+	v := newStatusView(goalScope{All: true})
 	nv, _ := v.update(dashLoadedMsg{snap: tuiRichSnapshot()}, nil)
 	out := stripANSI(nv.view(100, 30))
-	for _, want := range []string{"State:", "active", "Mode:", "strict", "Main checkout:", "clean", "Budget:", "5/20 experiments", "Counts:"} {
+	for _, want := range []string{"Scope:", "all", "State:", "active", "Mode:", "strict", "Main checkout:", "clean", "Budget:", "5/20 experiments", "Counts:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("status view missing %q:\n%s", want, out)
 		}
@@ -438,7 +455,7 @@ func TestTUI_DashboardAndStatusShowDirtyMainCheckout(t *testing.T) {
 	snap.MainCheckoutDirty = true
 	snap.MainCheckoutDirtyPaths = []string{"bootstrap.sh"}
 
-	dash := newDashboardView()
+	dash := newDashboardView(goalScope{All: true})
 	nv, _ := dash.update(dashLoadedMsg{snap: snap}, nil)
 	out := stripANSI(nv.view(140, 40))
 	for _, want := range []string{"Main checkout dirty:", "bootstrap.sh"} {
@@ -447,7 +464,7 @@ func TestTUI_DashboardAndStatusShowDirtyMainCheckout(t *testing.T) {
 		}
 	}
 
-	status := newStatusView()
+	status := newStatusView(goalScope{All: true})
 	nv, _ = status.update(dashLoadedMsg{snap: snap}, nil)
 	out = stripANSI(nv.view(100, 30))
 	for _, want := range []string{"Main checkout:", "dirty outside autoresearch-managed files", "bootstrap.sh"} {
@@ -458,7 +475,7 @@ func TestTUI_DashboardAndStatusShowDirtyMainCheckout(t *testing.T) {
 }
 
 func TestTUI_ModelHeaderAndHints(t *testing.T) {
-	m := newTuiModel(nil, 2*time.Second)
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
 	m.width, m.height = 120, 30
 	// Feed a loaded snapshot to the dashboard so it renders non-empty.
 	top := m.top()
@@ -473,7 +490,7 @@ func TestTUI_ModelHeaderAndHints(t *testing.T) {
 }
 
 func TestTUI_ArtifactList(t *testing.T) {
-	v := newArtifactListView()
+	v := newArtifactListView(goalScope{All: true})
 	rows := []artifactRow{
 		{Observation: "O-0001", Instrument: "qemu_cycles", Name: "primary", SHA: "abc123def45678", Bytes: 2048, Path: "artifacts/ab/abc123def45678"},
 		{Observation: "O-0002", Instrument: "host_test", Name: "primary", SHA: "fed987abc12345", Bytes: 512000, Path: "artifacts/fe/fed987abc12345"},
@@ -573,18 +590,18 @@ func TestTUI_ExperimentDetailWithStats(t *testing.T) {
 }
 
 func TestTUI_JumpToCanonicalizes(t *testing.T) {
-	m := newTuiModel(nil, 2*time.Second)
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
 	// Start: [dashboard]
 	if got := len(m.stack); got != 1 {
 		t.Fatalf("initial stack depth = %d, want 1", got)
 	}
 	// Jump to hypotheses: [dashboard, hypotheses]
-	m.jumpTo(newHypothesisListView(), nil)
+	m.jumpTo(newHypothesisListView(goalScope{All: true}), nil)
 	if got := len(m.stack); got != 2 || m.top().kind() != kindHypothesisList {
 		t.Fatalf("after H: depth=%d top=%s", got, m.top().kind())
 	}
 	// Jump to hypotheses again: still [dashboard, hypotheses], not 3-deep.
-	m.jumpTo(newHypothesisListView(), nil)
+	m.jumpTo(newHypothesisListView(goalScope{All: true}), nil)
 	if got := len(m.stack); got != 2 {
 		t.Errorf("H after H: depth=%d want 2", got)
 	}
@@ -594,7 +611,7 @@ func TestTUI_JumpToCanonicalizes(t *testing.T) {
 		t.Fatalf("after push detail: depth=%d want 3", got)
 	}
 	// Jump to hypotheses again: truncates to [dashboard, hypotheses], dropping the detail.
-	m.jumpTo(newHypothesisListView(), nil)
+	m.jumpTo(newHypothesisListView(goalScope{All: true}), nil)
 	if got := len(m.stack); got != 2 {
 		t.Errorf("H from detail: depth=%d want 2", got)
 	}
@@ -602,19 +619,19 @@ func TestTUI_JumpToCanonicalizes(t *testing.T) {
 		t.Errorf("top = %s, want hypothesis.list", m.top().kind())
 	}
 	// Jump to experiments from hypotheses: [dashboard, experiments].
-	m.jumpTo(newExperimentListView(), nil)
+	m.jumpTo(newExperimentListView(goalScope{All: true}), nil)
 	if got := len(m.stack); got != 2 || m.top().kind() != kindExperimentList {
 		t.Fatalf("E after H: depth=%d top=%s", got, m.top().kind())
 	}
 	// R opens the report-mode hypothesis list — a different kind, so it pushes.
-	m.jumpTo(newHypothesisListViewForReport(), nil)
+	m.jumpTo(newHypothesisListViewForReport(goalScope{All: true}), nil)
 	if got := len(m.stack); got != 2 || m.top().kind() != kindHypothesisReport {
 		t.Errorf("R after E: depth=%d top=%s", got, m.top().kind())
 	}
 }
 
 func TestTUI_EventListKeysDoNotConflictWithRootShortcuts(t *testing.T) {
-	v := newEventListView()
+	v := newEventListView(goalScope{All: true})
 	es := []store.Event{
 		{Ts: time.Now().UTC(), Kind: "init", Subject: "A"},
 		{Ts: time.Now().UTC(), Kind: "hypothesis.add", Subject: "B"},
@@ -624,8 +641,8 @@ func TestTUI_EventListKeysDoNotConflictWithRootShortcuts(t *testing.T) {
 	ev.cursor = 0
 	ev.follow = false
 
-	m := newTuiModel(nil, 2*time.Second)
-	m.stack = []tuiView{newDashboardView(), ev}
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
+	m.stack = []tuiView{newDashboardView(goalScope{All: true}), ev}
 
 	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
 	m = model.(tuiModel)
@@ -649,16 +666,16 @@ func TestTUI_EventListKeysDoNotConflictWithRootShortcuts(t *testing.T) {
 }
 
 func TestTUI_GoalShortcutUsesO(t *testing.T) {
-	m := newTuiModel(nil, 2*time.Second)
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
 	model, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'O'}})
 	m = model.(tuiModel)
-	if m.top().kind() != kindGoal {
+	if m.top().kind() != kindGoalList {
 		t.Fatalf("O should jump to goal view, top=%s", m.top().kind())
 	}
 }
 
 func TestTUI_DashboardForwardsLoadMsgToOverlay(t *testing.T) {
-	d := newDashboardView()
+	d := newDashboardView(goalScope{All: true})
 	// Prime the dashboard with a snapshot so focus/cursor are meaningful.
 	snap := tuiRichSnapshot()
 	nv, _ := d.update(dashLoadedMsg{snap: snap}, nil)
@@ -687,7 +704,7 @@ func TestTUI_DashboardForwardsLoadMsgToOverlay(t *testing.T) {
 }
 
 func TestTUI_DashboardTreePanelTitleUsesBorder(t *testing.T) {
-	d := newDashboardView()
+	d := newDashboardView(goalScope{All: true})
 	d.snap = tuiRichSnapshot()
 
 	out := stripANSI(d.renderTreePanel(60, 8))
@@ -716,12 +733,12 @@ func TestTUI_DashboardRecentEventsPaging(t *testing.T) {
 		}
 	}
 
-	d := newDashboardView()
+	d := newDashboardView(goalScope{All: true})
 	nv, _ := d.update(dashLoadedMsg{snap: baseSnapshot()}, s)
 	d = nv.(*dashboardView)
 	d.focus = dashFocusEvents
 
-	msg := loadDashboardEventsCmd(s, 0, dashboardRecentEventsPageSize, true)()
+	msg := loadDashboardEventsCmd(s, goalScope{All: true}, 0, dashboardRecentEventsPageSize, true)()
 	nv, _ = d.update(msg, s)
 	d = nv.(*dashboardView)
 
@@ -755,7 +772,7 @@ func TestTUI_DashboardRecentEventsPaging(t *testing.T) {
 }
 
 func TestTUI_DashboardRightColumnGivesEventsRemainder(t *testing.T) {
-	d := newDashboardView()
+	d := newDashboardView(goalScope{All: true})
 	d.snap = tuiRichSnapshot()
 
 	frontierH, inFlightH, eventsH := d.rightColumnHeights(30)
@@ -787,7 +804,7 @@ func TestTUI_DashboardVisualDump(t *testing.T) {
 	snap.Paused = true
 	snap.PauseReason = "10/10 experiment budget reached"
 
-	m := newTuiModel(nil, 2*time.Second)
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
 	m.width, m.height = 130, 40
 	m.chrome = chromeLoadedMsg{
 		paused: true, pauseReason: "10/10 experiment budget reached",

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -440,13 +440,31 @@ func TestTUI_GoalListView(t *testing.T) {
 }
 
 func TestTUI_StatusView(t *testing.T) {
+	snap := tuiRichSnapshot()
+	snap.ScopeAll = true
+
 	v := newStatusView(goalScope{All: true})
-	nv, _ := v.update(dashLoadedMsg{snap: tuiRichSnapshot()}, nil)
+	nv, _ := v.update(dashLoadedMsg{snap: snap}, nil)
 	out := stripANSI(nv.view(100, 30))
 	for _, want := range []string{"Scope:", "all", "State:", "active", "Mode:", "strict", "Main checkout:", "clean", "Budget:", "5/20 experiments", "Counts:"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("status view missing %q:\n%s", want, out)
 		}
+	}
+	if strings.Contains(out, "stalled") {
+		t.Fatalf("all-goal status view should not show stalled meter:\n%s", out)
+	}
+}
+
+func TestTUI_StatusViewShowsStalledMeterForGoalScope(t *testing.T) {
+	snap := tuiRichSnapshot()
+	snap.ScopeGoalID = "G-0002"
+
+	v := newStatusView(goalScope{GoalID: "G-0002"})
+	nv, _ := v.update(dashLoadedMsg{snap: snap}, nil)
+	out := stripANSI(nv.view(100, 30))
+	if !strings.Contains(out, "stalled 2/5") {
+		t.Fatalf("goal-scoped status view should show stalled meter:\n%s", out)
 	}
 }
 

--- a/internal/cli/tui_view_artifact.go
+++ b/internal/cli/tui_view_artifact.go
@@ -29,11 +29,12 @@ type artifactRow struct {
 // ---- artifact list view ----
 
 type artifactListView struct {
-	all      []artifactRow
-	filtered []artifactRow
-	cursor   int
+	scope      goalScope
+	all        []artifactRow
+	filtered   []artifactRow
+	cursor     int
 	instFilter string
-	err      error
+	err        error
 }
 
 type artifactListLoadedMsg struct {
@@ -41,13 +42,17 @@ type artifactListLoadedMsg struct {
 	err  error
 }
 
-func newArtifactListView() *artifactListView { return &artifactListView{} }
+func newArtifactListView(scope goalScope) *artifactListView { return &artifactListView{scope: scope} }
 
 func (v *artifactListView) title() string { return "Artifacts" }
 
 func (v *artifactListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		obs, err := s.ListObservations()
+		if err != nil {
+			return artifactListLoadedMsg{err: err}
+		}
+		obs, err = newGoalScopeResolver(s, v.scope).filterObservations(obs)
 		if err != nil {
 			return artifactListLoadedMsg{err: err}
 		}
@@ -186,12 +191,12 @@ const (
 )
 
 type artifactView struct {
-	row      artifactRow
-	sha      string
-	absPath  string
-	relPath  string
-	mode     artifactMode
-	lines    []string
+	row       artifactRow
+	sha       string
+	absPath   string
+	relPath   string
+	mode      artifactMode
+	lines     []string
 	total     int
 	fsBytes   int64
 	grep      string
@@ -510,4 +515,3 @@ func colorizeDiff(lines []string) string {
 	}
 	return buf.String()
 }
-

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -13,6 +13,7 @@ import (
 // ---- list view ----
 
 type conclusionListView struct {
+	scope    goalScope
 	all      []*entity.Conclusion
 	filtered []*entity.Conclusion
 	cursor   int
@@ -25,13 +26,18 @@ type concListLoadedMsg struct {
 	err  error
 }
 
-func newConclusionListView() *conclusionListView { return &conclusionListView{} }
+func newConclusionListView(scope goalScope) *conclusionListView {
+	return &conclusionListView{scope: scope}
+}
 
 func (v *conclusionListView) title() string { return "Conclusions" }
 
 func (v *conclusionListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		list, err := s.ListConclusions()
+		if err == nil {
+			list, err = newGoalScopeResolver(s, v.scope).filterConclusions(list)
+		}
 		return concListLoadedMsg{list: list, err: err}
 	}
 }

--- a/internal/cli/tui_view_dashboard.go
+++ b/internal/cli/tui_view_dashboard.go
@@ -16,8 +16,9 @@ import (
 // four panels (tree, frontier, in-flight, events) and Enter on a selected row
 // replaces the right column with a compact detail panel for that entity.
 type dashboardView struct {
-	snap *dashboardSnapshot
-	err  error
+	scope goalScope
+	snap  *dashboardSnapshot
+	err   error
 
 	focus        dashFocus
 	cursors      [dashPanelCount]int
@@ -60,8 +61,8 @@ const (
 	dashboardCompactPanelMinHeight    = 4
 )
 
-func newDashboardView() *dashboardView {
-	return &dashboardView{}
+func newDashboardView(scope goalScope) *dashboardView {
+	return &dashboardView{scope: scope}
 }
 
 func (v *dashboardView) title() string { return "Dashboard" }
@@ -69,8 +70,8 @@ func (v *dashboardView) title() string { return "Dashboard" }
 func (v *dashboardView) init(s *store.Store) tea.Cmd {
 	v.eventsLoading = true
 	return tea.Batch(
-		loadDashboardSnapshotCmd(s),
-		loadDashboardEventsCmd(s, 0, dashboardRecentEventsPageSize, true),
+		loadDashboardSnapshotCmd(s, v.scope),
+		loadDashboardEventsCmd(s, v.scope, 0, dashboardRecentEventsPageSize, true),
 	)
 }
 
@@ -100,10 +101,10 @@ func (v *dashboardView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	case tuiTickMsg:
 		// Refresh both the dashboard and any open right-column overlay so
 		// drilled-down details stay live.
-		cmds := []tea.Cmd{loadDashboardSnapshotCmd(s)}
+		cmds := []tea.Cmd{loadDashboardSnapshotCmd(s, v.scope)}
 		if !v.eventsLoading {
 			v.eventsLoading = true
-			cmds = append(cmds, loadDashboardEventsCmd(s, 0, max(len(v.currentEvents()), dashboardRecentEventsPageSize), true))
+			cmds = append(cmds, loadDashboardEventsCmd(s, v.scope, 0, max(len(v.currentEvents()), dashboardRecentEventsPageSize), true))
 		}
 		if v.rightOverlay != nil {
 			nv, cmd := v.rightOverlay.update(msg, s)
@@ -520,16 +521,20 @@ func (v *dashboardView) renderEventsPanel(width, height int) string {
 	return boxPanel(title, strings.Join(lines, "\n"), width, height, active)
 }
 
-func loadDashboardSnapshotCmd(s *store.Store) tea.Cmd {
+func loadDashboardSnapshotCmd(s *store.Store, scope goalScope) tea.Cmd {
 	return func() tea.Msg {
-		snap, err := captureDashboard(s)
+		snap, err := captureDashboardScoped(s, scope)
 		return dashLoadedMsg{snap: snap, err: err}
 	}
 }
 
-func loadDashboardEventsCmd(s *store.Store, offsetNewest, limit int, replace bool) tea.Cmd {
+func loadDashboardEventsCmd(s *store.Store, scope goalScope, offsetNewest, limit int, replace bool) tea.Cmd {
 	return func() tea.Msg {
 		all, err := s.Events(0)
+		if err != nil {
+			return dashEventsLoadedMsg{err: err}
+		}
+		all, err = newGoalScopeResolver(s, scope).filterEvents(all)
 		if err != nil {
 			return dashEventsLoadedMsg{err: err}
 		}
@@ -581,7 +586,7 @@ func (v *dashboardView) maybeLoadMoreEvents(s *store.Store) tea.Cmd {
 		return nil
 	}
 	v.eventsLoading = true
-	return loadDashboardEventsCmd(s, len(v.events), dashboardRecentEventsPageSize, false)
+	return loadDashboardEventsCmd(s, v.scope, len(v.events), dashboardRecentEventsPageSize, false)
 }
 
 func dashboardEventKey(e store.Event) string {

--- a/internal/cli/tui_view_event.go
+++ b/internal/cli/tui_view_event.go
@@ -11,6 +11,7 @@ import (
 // ---- list view ----
 
 type eventListView struct {
+	scope      goalScope
 	all        []store.Event
 	filtered   []store.Event
 	cursor     int
@@ -24,13 +25,18 @@ type eventListLoadedMsg struct {
 	err  error
 }
 
-func newEventListView() *eventListView { return &eventListView{follow: true} }
+func newEventListView(scope goalScope) *eventListView {
+	return &eventListView{scope: scope, follow: true}
+}
 
 func (v *eventListView) title() string { return "Event log" }
 
 func (v *eventListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		list, err := s.Events(0)
+		if err == nil {
+			list, err = newGoalScopeResolver(s, v.scope).filterEvents(list)
+		}
 		return eventListLoadedMsg{list: list, err: err}
 	}
 }

--- a/internal/cli/tui_view_experiment.go
+++ b/internal/cli/tui_view_experiment.go
@@ -14,11 +14,12 @@ import (
 // ---- list view ----
 
 type experimentListView struct {
-	all      []*entity.Experiment
-	filtered []*entity.Experiment
-	cursor   int
+	scope        goalScope
+	all          []*entity.Experiment
+	filtered     []*entity.Experiment
+	cursor       int
 	statusFilter string
-	err      error
+	err          error
 }
 
 type expListLoadedMsg struct {
@@ -26,13 +27,18 @@ type expListLoadedMsg struct {
 	err  error
 }
 
-func newExperimentListView() *experimentListView { return &experimentListView{} }
+func newExperimentListView(scope goalScope) *experimentListView {
+	return &experimentListView{scope: scope}
+}
 
 func (v *experimentListView) title() string { return "Experiments" }
 
 func (v *experimentListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		list, err := s.ListExperiments()
+		if err == nil {
+			list, err = newGoalScopeResolver(s, v.scope).filterExperiments(list)
+		}
 		return expListLoadedMsg{list: list, err: err}
 	}
 }
@@ -277,5 +283,3 @@ func (v *experimentDetailView) view(width, height int) string {
 	}
 	return clampLines(strings.Join(lines, "\n"), height, width)
 }
-
-

--- a/internal/cli/tui_view_hypothesis.go
+++ b/internal/cli/tui_view_hypothesis.go
@@ -13,6 +13,7 @@ import (
 // ---- list view ----
 
 type hypothesisListView struct {
+	scope        goalScope
 	all          []*entity.Hypothesis
 	filtered     []*entity.Hypothesis
 	cursor       int
@@ -26,13 +27,15 @@ type hypListLoadedMsg struct {
 	err  error
 }
 
-func newHypothesisListView() *hypothesisListView { return &hypothesisListView{} }
+func newHypothesisListView(scope goalScope) *hypothesisListView {
+	return &hypothesisListView{scope: scope}
+}
 
 // newHypothesisListViewForReport is the hypothesis list whose Enter key
 // opens the report view instead of the detail view. Used when the user hits
 // the top-level `R` shortcut.
-func newHypothesisListViewForReport() *hypothesisListView {
-	return &hypothesisListView{reportMode: true}
+func newHypothesisListViewForReport(scope goalScope) *hypothesisListView {
+	return &hypothesisListView{scope: scope, reportMode: true}
 }
 
 func (v *hypothesisListView) title() string {
@@ -45,6 +48,9 @@ func (v *hypothesisListView) title() string {
 func (v *hypothesisListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		list, err := s.ListHypotheses()
+		if err == nil {
+			list = newGoalScopeResolver(s, v.scope).filterHypotheses(list)
+		}
 		return hypListLoadedMsg{list: list, err: err}
 	}
 }

--- a/internal/cli/tui_view_kinds.go
+++ b/internal/cli/tui_view_kinds.go
@@ -18,7 +18,8 @@ const (
 	kindEventDetail       = "event.detail"
 	kindTree              = "tree"
 	kindFrontier          = "frontier"
-	kindGoal              = "goal"
+	kindGoalList          = "goal.list"
+	kindGoalDetail        = "goal.detail"
 	kindStatus            = "status"
 	kindArtifactList      = "artifact.list"
 	kindArtifactView      = "artifact.view"
@@ -46,7 +47,8 @@ func (v *eventListView) kind() string         { return kindEventList }
 func (v *eventDetailView) kind() string       { return kindEventDetail }
 func (v *treeView) kind() string              { return kindTree }
 func (v *frontierView) kind() string          { return kindFrontier }
-func (v *goalView) kind() string              { return kindGoal }
+func (v *goalListView) kind() string          { return kindGoalList }
+func (v *goalDetailView) kind() string        { return kindGoalDetail }
 func (v *statusView) kind() string            { return kindStatus }
 func (v *artifactListView) kind() string      { return kindArtifactList }
 func (v *artifactView) kind() string          { return kindArtifactView }

--- a/internal/cli/tui_view_lesson.go
+++ b/internal/cli/tui_view_lesson.go
@@ -13,12 +13,13 @@ import (
 // ---- list view ----
 
 type lessonListView struct {
-	all      []*entity.Lesson
-	filtered []*entity.Lesson
-	cursor   int
-	scope    string // "" means all
-	status   string // "" means all
-	err      error
+	goalScope goalScope
+	all       []*entity.Lesson
+	filtered  []*entity.Lesson
+	cursor    int
+	scope     string // "" means all
+	status    string // "" means all
+	err       error
 }
 
 type lessonListLoadedMsg struct {
@@ -26,13 +27,16 @@ type lessonListLoadedMsg struct {
 	err  error
 }
 
-func newLessonListView() *lessonListView { return &lessonListView{} }
+func newLessonListView(scope goalScope) *lessonListView { return &lessonListView{goalScope: scope} }
 
 func (v *lessonListView) title() string { return "Lessons" }
 
 func (v *lessonListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
 		list, err := s.ListLessons()
+		if err == nil {
+			list, err = newGoalScopeResolver(s, v.goalScope).filterLessons(list)
+		}
 		if err == nil {
 			views := make([]*entity.Lesson, 0, len(list))
 			for _, l := range list {

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -85,6 +85,7 @@ func (v *instrumentListView) view(width, height int) string {
 // ---- tree view (full hypothesis forest, scrollable, Enter -> hypothesis detail) ----
 
 type treeView struct {
+	scope  goalScope
 	flat   []*treeNode
 	cursor int
 	err    error
@@ -95,7 +96,7 @@ type treeLoadedMsg struct {
 	err   error
 }
 
-func newTreeView() *treeView { return &treeView{} }
+func newTreeView(scope goalScope) *treeView { return &treeView{scope: scope} }
 
 func (v *treeView) title() string { return "Tree" }
 
@@ -105,7 +106,7 @@ func (v *treeView) init(s *store.Store) tea.Cmd {
 		if err != nil {
 			return treeLoadedMsg{err: err}
 		}
-		roots, children := buildHypothesisForest(all)
+		roots, children := buildHypothesisForest(filterHypothesesByScope(all, v.scope))
 		return treeLoadedMsg{roots: buildTreeJSON(roots, children)}
 	}
 }
@@ -185,6 +186,7 @@ func (v *treeView) view(width, height int) string {
 // ---- frontier view ----
 
 type frontierView struct {
+	scope      goalScope
 	goal       *entity.Goal
 	rows       []frontierRow
 	assessment frontierGoalAssessment
@@ -201,17 +203,24 @@ type frontierLoadedMsg struct {
 	err        error
 }
 
-func newFrontierView() *frontierView { return &frontierView{} }
+func newFrontierView(scope goalScope) *frontierView { return &frontierView{scope: scope} }
 
 func (v *frontierView) title() string { return "Frontier" }
 
 func (v *frontierView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
-		goal, err := s.ActiveGoal()
+		if v.scope.All {
+			return frontierLoadedMsg{}
+		}
+		goal, err := s.ReadGoal(v.scope.GoalID)
 		if err != nil {
 			return frontierLoadedMsg{err: err}
 		}
 		concls, err := s.ListConclusions()
+		if err != nil {
+			return frontierLoadedMsg{err: err}
+		}
+		concls, err = newGoalScopeResolver(s, v.scope).filterConclusions(concls)
 		if err != nil {
 			return frontierLoadedMsg{err: err}
 		}
@@ -264,6 +273,9 @@ func (v *frontierView) view(width, height int) string {
 	if v.err != nil {
 		return tuiRed.Render("error: " + v.err.Error())
 	}
+	if v.scope.All {
+		return tuiDim.Render("(frontier is goal-specific; start the TUI with --goal G-NNNN to inspect one)")
+	}
 	if v.goal == nil {
 		return tuiDim.Render("(no goal set)")
 	}
@@ -300,32 +312,109 @@ func (v *frontierView) view(width, height int) string {
 	return renderFilteredListBody(header, rows, v.cursor, width, height)
 }
 
-// ---- goal view ----
+// ---- goal views ----
 
-type goalView struct {
-	g   *entity.Goal
-	err error
+type goalListView struct {
+	all     []*entity.Goal
+	current string
+	cursor  int
+	err     error
 }
 
-type goalLoadedMsg struct {
-	g   *entity.Goal
-	err error
+type goalListLoadedMsg struct {
+	all     []*entity.Goal
+	current string
+	err     error
 }
 
-func newGoalView() *goalView { return &goalView{} }
+func newGoalListView() *goalListView { return &goalListView{} }
 
-func (v *goalView) title() string { return "Goal" }
+func (v *goalListView) title() string { return "Goals" }
 
-func (v *goalView) init(s *store.Store) tea.Cmd {
+func (v *goalListView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
-		g, err := s.ActiveGoal()
-		return goalLoadedMsg{g: g, err: err}
+		all, err := s.ListGoals()
+		if err != nil {
+			return goalListLoadedMsg{err: err}
+		}
+		st, err := s.State()
+		if err != nil {
+			return goalListLoadedMsg{err: err}
+		}
+		return goalListLoadedMsg{all: all, current: st.CurrentGoalID}
 	}
 }
 
-func (v *goalView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
+func (v *goalListView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	switch msg := msg.(type) {
-	case goalLoadedMsg:
+	case goalListLoadedMsg:
+		v.all = msg.all
+		v.current = msg.current
+		v.err = msg.err
+		v.cursor = clampCursor(v.cursor, len(v.all))
+		return v, nil
+	case tuiTickMsg:
+		return v, v.init(s)
+	case tea.KeyMsg:
+		if handleListNav(msg, &v.cursor, len(v.all)) {
+			return v, nil
+		}
+		if msg.String() == "enter" && v.cursor >= 0 && v.cursor < len(v.all) {
+			return v, tuiPush(newGoalDetailView(v.all[v.cursor].ID))
+		}
+	}
+	return v, nil
+}
+
+func (v *goalListView) hints() []tuiHint {
+	return []tuiHint{{"↑↓", "move"}, {"Enter", "open"}}
+}
+
+func (v *goalListView) view(width, height int) string {
+	if v.err != nil {
+		return tuiRed.Render("error: " + v.err.Error())
+	}
+	if len(v.all) == 0 {
+		return tuiDim.Render("(no goals)")
+	}
+	header := tuiBold.Render(fmt.Sprintf("%d goals", len(v.all)))
+	rows := make([]string, len(v.all))
+	for i, g := range v.all {
+		marker := " "
+		if g.ID == v.current {
+			marker = "*"
+		}
+		rows[i] = fmt.Sprintf("%s %-8s %-10s %s", marker, g.ID, g.Status, formatGoalObjective(g))
+	}
+	return renderFilteredListBody(header, rows, v.cursor, width, height)
+}
+
+type goalDetailView struct {
+	id  string
+	g   *entity.Goal
+	err error
+}
+
+type goalDetailLoadedMsg struct {
+	g   *entity.Goal
+	err error
+}
+
+func newGoalDetailView(id string) *goalDetailView { return &goalDetailView{id: id} }
+
+func (v *goalDetailView) title() string { return "Goal " + v.id }
+
+func (v *goalDetailView) init(s *store.Store) tea.Cmd {
+	id := v.id
+	return func() tea.Msg {
+		g, err := s.ReadGoal(id)
+		return goalDetailLoadedMsg{g: g, err: err}
+	}
+}
+
+func (v *goalDetailView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
+	switch msg := msg.(type) {
+	case goalDetailLoadedMsg:
 		v.g = msg.g
 		v.err = msg.err
 		return v, nil
@@ -335,17 +424,28 @@ func (v *goalView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	return v, nil
 }
 
-func (v *goalView) hints() []tuiHint { return nil }
+func (v *goalDetailView) hints() []tuiHint { return nil }
 
-func (v *goalView) view(width, height int) string {
+func (v *goalDetailView) view(width, height int) string {
 	if v.err != nil {
 		return tuiRed.Render("error: " + v.err.Error())
 	}
-	if v.g == nil {
+	return renderGoalDetail(v.g, width, height)
+}
+
+func renderGoalDetail(g *entity.Goal, width, height int) string {
+	if g == nil {
 		return tuiDim.Render("(no goal set)")
 	}
-	g := v.g
 	lines := []string{}
+	lines = append(lines, tuiBold.Render(g.ID)+"  "+tuiCyan.Render(g.Status))
+	if g.DerivedFrom != "" {
+		lines = append(lines, tuiDim.Render("derived_from=")+g.DerivedFrom)
+	}
+	if g.Trigger != "" {
+		lines = append(lines, tuiDim.Render("trigger=")+g.Trigger)
+	}
+	lines = append(lines, "")
 	lines = append(lines, tuiBold.Render("Objective:"))
 	lines = append(lines, "  "+tuiCyan.Render(formatGoalObjective(g)))
 	lines = append(lines, "")
@@ -372,17 +472,18 @@ func (v *goalView) view(width, height int) string {
 // ---- status view ----
 
 type statusView struct {
-	snap *dashboardSnapshot
-	err  error
+	scope goalScope
+	snap  *dashboardSnapshot
+	err   error
 }
 
-func newStatusView() *statusView { return &statusView{} }
+func newStatusView(scope goalScope) *statusView { return &statusView{scope: scope} }
 
 func (v *statusView) title() string { return "Status" }
 
 func (v *statusView) init(s *store.Store) tea.Cmd {
 	return func() tea.Msg {
-		snap, err := captureDashboard(s)
+		snap, err := captureDashboardScoped(s, v.scope)
 		return dashLoadedMsg{snap: snap, err: err}
 	}
 }
@@ -409,7 +510,7 @@ func (v *statusView) view(width, height int) string {
 		return tuiDim.Render("loading…")
 	}
 	snap := v.snap
-	lines := []string{}
+	lines := []string{tuiBold.Render("Scope:") + " " + v.scope.label()}
 	state := tuiGreen.Render("active")
 	if snap.Paused {
 		label := "PAUSED"

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -315,10 +315,12 @@ func (v *frontierView) view(width, height int) string {
 // ---- goal views ----
 
 type goalListView struct {
-	all     []*entity.Goal
-	current string
-	cursor  int
-	err     error
+	scope     goalScope
+	all       []*entity.Goal
+	current   string
+	focusGoal string
+	cursor    int
+	err       error
 }
 
 type goalListLoadedMsg struct {
@@ -327,7 +329,13 @@ type goalListLoadedMsg struct {
 	err     error
 }
 
-func newGoalListView() *goalListView { return &goalListView{} }
+func newGoalListView(scopes ...goalScope) *goalListView {
+	scope := goalScope{}
+	if len(scopes) > 0 {
+		scope = scopes[0]
+	}
+	return &goalListView{scope: scope, focusGoal: scope.GoalID}
+}
 
 func (v *goalListView) title() string { return "Goals" }
 
@@ -351,6 +359,15 @@ func (v *goalListView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 		v.all = msg.all
 		v.current = msg.current
 		v.err = msg.err
+		if v.focusGoal != "" {
+			for i, g := range v.all {
+				if g != nil && g.ID == v.focusGoal {
+					v.cursor = i
+					break
+				}
+			}
+			v.focusGoal = ""
+		}
 		v.cursor = clampCursor(v.cursor, len(v.all))
 		return v, nil
 	case tuiTickMsg:
@@ -359,15 +376,24 @@ func (v *goalListView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 		if handleListNav(msg, &v.cursor, len(v.all)) {
 			return v, nil
 		}
-		if msg.String() == "enter" && v.cursor >= 0 && v.cursor < len(v.all) {
-			return v, tuiPush(newGoalDetailView(v.all[v.cursor].ID))
+		switch msg.String() {
+		case "enter":
+			if v.cursor >= 0 && v.cursor < len(v.all) {
+				return v, tuiPush(newGoalDetailView(v.all[v.cursor].ID, v.scope))
+			}
+		case "s":
+			if v.cursor >= 0 && v.cursor < len(v.all) {
+				return v, tuiSetScope(goalScope{GoalID: v.all[v.cursor].ID})
+			}
+		case "a":
+			return v, tuiSetScope(goalScope{All: true})
 		}
 	}
 	return v, nil
 }
 
 func (v *goalListView) hints() []tuiHint {
-	return []tuiHint{{"↑↓", "move"}, {"Enter", "open"}}
+	return []tuiHint{{"↑↓", "move"}, {"Enter", "open"}, {"s", "scope"}, {"a", "all"}}
 }
 
 func (v *goalListView) view(width, height int) string {
@@ -377,22 +403,27 @@ func (v *goalListView) view(width, height int) string {
 	if len(v.all) == 0 {
 		return tuiDim.Render("(no goals)")
 	}
-	header := tuiBold.Render(fmt.Sprintf("%d goals", len(v.all)))
+	header := tuiBold.Render(fmt.Sprintf("%d goals  ·  scope=%s  ·  > scoped  * active", len(v.all), v.scope.label()))
 	rows := make([]string, len(v.all))
 	for i, g := range v.all {
-		marker := " "
-		if g.ID == v.current {
-			marker = "*"
+		scopeMarker := " "
+		activeMarker := " "
+		if !v.scope.All && g.ID == v.scope.GoalID {
+			scopeMarker = ">"
 		}
-		rows[i] = fmt.Sprintf("%s %-8s %-10s %s", marker, g.ID, g.Status, formatGoalObjective(g))
+		if g.ID == v.current {
+			activeMarker = "*"
+		}
+		rows[i] = fmt.Sprintf("%s%s %-8s %-10s %s", scopeMarker, activeMarker, g.ID, g.Status, formatGoalObjective(g))
 	}
 	return renderFilteredListBody(header, rows, v.cursor, width, height)
 }
 
 type goalDetailView struct {
-	id  string
-	g   *entity.Goal
-	err error
+	id    string
+	scope goalScope
+	g     *entity.Goal
+	err   error
 }
 
 type goalDetailLoadedMsg struct {
@@ -400,7 +431,13 @@ type goalDetailLoadedMsg struct {
 	err error
 }
 
-func newGoalDetailView(id string) *goalDetailView { return &goalDetailView{id: id} }
+func newGoalDetailView(id string, scopes ...goalScope) *goalDetailView {
+	scope := goalScope{}
+	if len(scopes) > 0 {
+		scope = scopes[0]
+	}
+	return &goalDetailView{id: id, scope: scope}
+}
 
 func (v *goalDetailView) title() string { return "Goal " + v.id }
 
@@ -420,25 +457,35 @@ func (v *goalDetailView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) 
 		return v, nil
 	case tuiTickMsg:
 		return v, v.init(s)
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "s":
+			return v, tuiSetScope(goalScope{GoalID: v.id})
+		case "a":
+			return v, tuiSetScope(goalScope{All: true})
+		}
 	}
 	return v, nil
 }
 
-func (v *goalDetailView) hints() []tuiHint { return nil }
+func (v *goalDetailView) hints() []tuiHint {
+	return []tuiHint{{"s", "scope"}, {"a", "all"}}
+}
 
 func (v *goalDetailView) view(width, height int) string {
 	if v.err != nil {
 		return tuiRed.Render("error: " + v.err.Error())
 	}
-	return renderGoalDetail(v.g, width, height)
+	return renderGoalDetail(v.g, v.scope, width, height)
 }
 
-func renderGoalDetail(g *entity.Goal, width, height int) string {
+func renderGoalDetail(g *entity.Goal, scope goalScope, width, height int) string {
 	if g == nil {
 		return tuiDim.Render("(no goal set)")
 	}
 	lines := []string{}
 	lines = append(lines, tuiBold.Render(g.ID)+"  "+tuiCyan.Render(g.Status))
+	lines = append(lines, tuiDim.Render("scope=")+scope.label())
 	if g.DerivedFrom != "" {
 		lines = append(lines, tuiDim.Render("derived_from=")+g.DerivedFrom)
 	}

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -547,7 +547,7 @@ func (v *statusView) view(width, height int) string {
 			fmt.Sprintf("%.1fh/%dh elapsed", snap.Budgets.Usage.ElapsedH, snap.Budgets.Limits.MaxWallTimeH),
 		)))
 	}
-	if snap.Budgets.Limits.FrontierStallK > 0 {
+	if snap.Budgets.Limits.FrontierStallK > 0 && !snap.ScopeAll {
 		lines = append(lines, fmt.Sprintf("  %s", tuiMeterColor(
 			float64(snap.StalledFor),
 			float64(snap.Budgets.Limits.FrontierStallK),

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -112,9 +112,11 @@ by hand, you are lying to future-you — don't.
 
 Every hypothesis is bound to the goal that was active when it was
 added (its ` + "`goal_id`" + ` field); experiments, observations, and
-conclusions inherit that binding by chain. Read-only views like
-` + "`tree`" + ` and ` + "`frontier`" + ` default to the active goal and accept
-` + "`--goal G-NNNN`" + ` to page through closed goals' histories.
+conclusions inherit that binding by chain. Read-only views that aggregate
+goal-derived entities default to the active goal and accept
+` + "`--goal G-NNNN`" + ` to page through closed goals' histories or
+` + "`--goal all`" + ` to broaden the view across goals. System lessons stay
+visible in scoped views.
 
 Backward transitions are explicit and auditable:
 
@@ -154,8 +156,8 @@ only when this reference does not answer the question you have.
 
 ### Lifecycle
     autoresearch init       --build-cmd ... --test-cmd ...
-    autoresearch status
-    autoresearch log        [--tail N] [--kind prefix] [--since RFC3339]
+    autoresearch status     [--goal G-NNNN|all]
+    autoresearch log        [--goal G-NNNN|all] [--tail N] [--kind prefix] [--since RFC3339]
     autoresearch pause      [--reason "..."]
     autoresearch resume
 
@@ -222,7 +224,7 @@ the firewall sees.
         --claim "..." \
         --predicts-instrument NAME --predicts-target T --predicts-direction {increase|decrease} --predicts-min-effect F \
         --kill-if "..." [--kill-if "..."] [--inspired-by L-XXXX,L-YYYY] [--parent H-XXXX] [--author human:alice]
-    autoresearch hypothesis list    [--status ...] [--parent ...]
+    autoresearch hypothesis list    [--goal G-NNNN|all] [--status ...] [--parent ...]
     autoresearch hypothesis show    <hyp-id>
     autoresearch hypothesis kill    <hyp-id> --reason "..."
     autoresearch hypothesis reopen  <hyp-id> --reason "..."
@@ -230,8 +232,8 @@ the firewall sees.
     autoresearch hypothesis worktree <hyp-id> [--conclusion C-NNNN]  # worktree of winning experiment
     autoresearch hypothesis diff     <hyp-id> [--conclusion C-NNNN]  # unified diff vs baseline
     autoresearch hypothesis apply    <hyp-id> [--conclusion C-NNNN] [--merge]  # ship it (requires reviewed conclusion)
-    autoresearch tree               [--root H-XXXX]
-    autoresearch frontier                                  # best-first, stalled_for, goal_assessment
+    autoresearch tree               [--goal G-NNNN|all]
+    autoresearch frontier           [--goal G-NNNN|all]   # best-first, stalled_for, goal_assessment
     autoresearch report             <hyp-id>               # markdown writeup
 
 The active goal defines the optimization problem. ` + "`predicts.instrument`" + ` must
@@ -246,7 +248,7 @@ unless the goal names them.
     autoresearch experiment implement  <exp-id>
     autoresearch experiment reset      <exp-id> --reason "..."
     autoresearch experiment worktree   <exp-id>
-    autoresearch experiment list       [--status ...] [--hypothesis ...]
+    autoresearch experiment list       [--goal G-NNNN|all] [--status ...] [--hypothesis ...]
     autoresearch experiment show       <exp-id>
 
 Instrument dependencies: instruments may declare ` + "`--requires`" + ` dependencies
@@ -268,7 +270,7 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
         # (frontier best). JSON output includes both effect and incremental_effect.
 
 ### Conclusions (review and gate reviewer)
-    autoresearch conclusion list       [--hypothesis H-XXXX] [--verdict X]
+    autoresearch conclusion list       [--goal G-NNNN|all] [--hypothesis H-XXXX] [--verdict X]
     autoresearch conclusion show       <C-id>
     autoresearch conclusion accept     <C-id> --reviewed-by ... --rationale "..."
         # Gate reviewer's acceptance: sets reviewed_by, promotes hypothesis
@@ -284,7 +286,7 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provisional until gate review resolves them via ` + "`conclusion accept`" + ` or ` + "`conclusion downgrade`" + `. If a delegated one-cycle ` + "`research-orchestrator`" + ` returns a decisive conclusion, the parent/main session owns the next handoff: dispatch ` + "`research-gate-reviewer`" + ` from the parent, do not nest another orchestrator, and do not start another cycle while the chain is still ` + "`unreviewed`" + `. If you cannot dispatch a reviewer, stop after writing the conclusion and yield to the human/main session.
 
 ### Artifact navigation (bounded by default)
-    autoresearch artifact list   [--experiment E-XXXX | --observation O-XXXX]
+    autoresearch artifact list   [--goal G-NNNN|all] [--experiment E-XXXX | --observation O-XXXX]
     autoresearch artifact stat   <sha-or-prefix>
     autoresearch artifact path   <sha-or-prefix>
     autoresearch artifact head   <sha> [--lines N]         # default 50
@@ -411,7 +413,7 @@ Verbs:
 
     autoresearch lesson add --claim "..." --body "..." [--from C-NNNN,H-NNNN] [--scope ...] [--tag ...]
         [--predict-instrument X --predict-direction {increase|decrease} --predict-min-effect N [--predict-max-effect M]]
-    autoresearch lesson list [--scope ...] [--status ...] [--subject ...] [--tag ...]
+    autoresearch lesson list [--goal G-NNNN|all] [--scope ...] [--status ...] [--subject ...] [--tag ...]
     autoresearch lesson show <L-id>
     autoresearch lesson supersede <L-old> --by <L-new> --reason "..."
     autoresearch lesson accuracy   # compare predicted effects vs actual outcomes (read-only)
@@ -584,16 +586,20 @@ the main store from a worktree context, pass ` + "`-C <project-root>`" + ` expli
 When you want to see what's happening across the whole research state without
 spamming four separate verbs:
 
-    autoresearch dashboard              # one-shot composite snapshot
-    autoresearch dashboard --refresh 2  # live, auto-refreshes every 2 seconds
-    autoresearch log --follow           # tail events.jsonl as new events land
+    autoresearch dashboard                   # one-shot composite snapshot (scoped to active goal)
+    autoresearch dashboard --goal all        # broaden the snapshot across goals
+    autoresearch dashboard --refresh 2       # live, auto-refreshes every 2 seconds
+    autoresearch dashboard tui --goal G-0007 # read-only TUI pinned to one goal
+    autoresearch log --follow                # tail events.jsonl as new events land
 
 The dashboard composes goal + budget + hypothesis tree + frontier + in-flight
 experiments + recent events into one frame. It is **read-only**: it works
 while the store is paused and it is not a steering surface. Humans steer by
 talking to the main session, which translates intent into CLI calls; leave
 ` + "`autoresearch dashboard --refresh 2`" + ` running in a second terminal or tmux
-pane while you drive research.
+pane while you drive research. Read surfaces that aggregate goal-derived
+entities default to the active goal; pass ` + "`--goal G-NNNN`" + ` to inspect a
+closed goal or ` + "`--goal all`" + ` to broaden the view across goals.
 
 ` + "`autoresearch dashboard --json`" + ` emits a structured snapshot for external
 tooling (` + "`--refresh`" + ` is refused in JSON mode — use a polling loop


### PR DESCRIPTION
## Summary
- default goal-derived read surfaces to the active goal and add `--goal all`
- thread scoped goal filtering through the dashboard, status, log, CLI lists, and TUI views
- replace the TUI goal screen with a goals list + detail flow and add in-TUI scope switching (`s` scopes to the selected goal, `a` broadens back to all goals)
- refresh scoped `log --follow` filtering for baselines created after follow starts and suppress the TUI stalled meter in all-goal scope
- update docs and tests

## Testing
- `GOCACHE=/tmp/autoresearch-go-build-cache go test ./...`

Closes #12.
