### PR TITLE
Fix #18: preserve commas in instrument register --cmd

### DIFF
--- a/internal/cli/instrument.go
+++ b/internal/cli/instrument.go
@@ -124,7 +124,7 @@ func instrumentRegisterCmd() *cobra.Command {
 			)
 		},
 	}
-	c.Flags().StringSliceVar(&cmdStr, "cmd", nil, "shell argv of the instrument (comma-separated)")
+	c.Flags().StringArrayVar(&cmdStr, "cmd", nil, "shell argv element; repeat once per element (e.g. --cmd make --cmd -f --cmd Makefile). Commas in a value are preserved, so pipelines like `awk '{gsub(/ /,\"\",x)}'` pass through as a single element.")
 	c.Flags().StringVar(&parser, "parser", "", "parser name (builtin:passfail | builtin:timing | builtin:size | builtin:scalar)")
 	c.Flags().StringVar(&pattern, "pattern", "", "regex with exactly one capture group (required for builtin:scalar)")
 	c.Flags().StringVar(&unit, "unit", "", "unit of measurement (e.g. cycles, bytes, seconds, instructions)")

--- a/internal/cli/instrument_test.go
+++ b/internal/cli/instrument_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"testing"
+)
+
+// TestInstrumentRegister_CmdPreservesCommas is a regression anchor for the
+// CSV hazard: before this fix, --cmd used StringSliceVar which split argv
+// elements on commas, shredding shell pipelines like `awk '{gsub(/ /,"",x)}'`
+// into multiple argv elements.
+func TestInstrumentRegister_CmdPreservesCommas(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	awkArg := `awk {gsub(/ /,"",x)}`
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "register", "awkprobe",
+		"--cmd", awkArg,
+		"--parser", "builtin:passfail",
+		"--unit", "bool",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	cfg, err := s.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst, ok := cfg.Instruments["awkprobe"]
+	if !ok {
+		t.Fatal("awkprobe not registered")
+	}
+	if len(inst.Cmd) != 1 {
+		t.Fatalf("Cmd split into %d elements, want 1: %q", len(inst.Cmd), inst.Cmd)
+	}
+	if inst.Cmd[0] != awkArg {
+		t.Errorf("Cmd[0] = %q, want %q", inst.Cmd[0], awkArg)
+	}
+}
+
+// TestInstrumentRegister_CmdRepeatableArgv verifies the repeated-flag form
+// still works (one --cmd per argv element).
+func TestInstrumentRegister_CmdRepeatableArgv(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "register", "make_test",
+		"--cmd", "make",
+		"--cmd", "-f",
+		"--cmd", "Makefile.sim",
+		"--cmd", "test",
+		"--parser", "builtin:passfail",
+		"--unit", "bool",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	cfg, err := s.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst := cfg.Instruments["make_test"]
+	want := []string{"make", "-f", "Makefile.sim", "test"}
+	if len(inst.Cmd) != len(want) {
+		t.Fatalf("Cmd = %q, want %q", inst.Cmd, want)
+	}
+	for i, w := range want {
+		if inst.Cmd[i] != w {
+			t.Errorf("Cmd[%d] = %q, want %q", i, inst.Cmd[i], w)
+		}
+	}
+}

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -298,7 +298,7 @@ Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provision
 
 ### Instruments
     autoresearch instrument register <name> \
-        --cmd a,b,c \
+        --cmd a --cmd b --cmd c \                      # repeat --cmd once per argv element; commas in a value are preserved
         --parser builtin:{passfail|timing|size|scalar} \
         [--pattern 'regex with one capture group']  # required for builtin:scalar
         --unit U [--requires inst=pass,...] [--min-samples N]
@@ -323,21 +323,28 @@ Examples of ` + "`builtin:scalar`" + ` instruments (the name is your choice):
 
     # Cycles reported by semihosting from firmware running under qemu:
     autoresearch instrument register qemu_cycles \
-        --cmd qemu-system-arm,-machine,mps2-an386,-kernel,firmware.elf,-icount,shift=0,-nographic,-semihosting-config,enable=on,target=native \
+        --cmd qemu-system-arm --cmd -machine --cmd mps2-an386 \
+        --cmd -kernel --cmd firmware.elf \
+        --cmd -icount --cmd shift=0 \
+        --cmd -nographic \
+        --cmd -semihosting-config --cmd enable=on,target=native \
         --parser builtin:scalar \
         --pattern 'cycles:\s*(\d+)' \
         --unit cycles --requires test=pass --min-samples 3
 
-    # Retired instructions from perf stat on host:
+    # Retired instructions from perf stat on host (shell pipeline as one argv element):
     autoresearch instrument register perf_instructions \
-        --cmd sh,-c,"perf stat -e instructions ./build/main 2>&1" \
+        --cmd sh --cmd -c \
+        --cmd 'perf stat -e instructions ./build/main 2>&1' \
         --parser builtin:scalar \
         --pattern '([0-9,]+)\s+instructions' \
         --unit instructions --min-samples 5
 
-    # Cyclomatic complexity reported by lizard:
+    # Cyclomatic complexity reported by lizard. The pipeline uses an awk
+    # expression with commas; put it in a committed helper so the quoting
+    # stays sane and experiment worktrees can reach it:
     autoresearch instrument register ccn_avg_x100 \
-        --cmd sh,-c,"lizard -C 0 src/ | awk '/Avg.CCN/ {printf \"avg_ccn_x100: %d\\n\", $1*100}'" \
+        --cmd tools/autoresearch/ccn_avg.sh \
         --parser builtin:scalar \
         --pattern 'avg_ccn_x100:\s*(\d+)' \
         --unit ccn_x100


### PR DESCRIPTION
Closes #18.

`--cmd` was declared with `StringSliceVar`, which splits values on commas. Shell pipelines that happen to contain commas — `awk '{gsub(/ /,"",x)}'`, `sed 's/a,b/c/'` — got shredded into multiple argv elements and the instrument ran with malformed args.

## Summary
- Switch `--cmd` to `StringArrayVar` so repeated `--cmd foo --cmd bar --cmd 'baz,qux'` is the only input form, and values pass through intact.
- Update agent-facing examples in `claude_doc.go` to the repeated form. Replaced the lizard example (which had a complex `sh -c 'awk …'` with embedded commas) with a pointer to a committed helper script — cleaner quoting, and experiment worktrees spawn from git refs so the helper has to be tracked regardless.
- Regression test covers both the "single argv element containing commas" case and the repeated-flag form.

## Test plan
- [x] `make test` — green
- [x] Manual: `autoresearch instrument register awkprobe --cmd 'awk {gsub(/ /,"",x)}' ...` stores the argv as one element
- [x] Manual: repeated `--cmd make --cmd -f --cmd Makefile` stores four elements