### PR TITLE
Fix #19: make --dry-run actually short-circuit mutating verbs

### DIFF
--- a/cmd/autoresearch/main.go
+++ b/cmd/autoresearch/main.go
@@ -10,7 +10,7 @@ import (
 
 // Exit codes:
 //
-//   0 — success
+//   0 — success (including --dry-run, which short-circuits before mutating)
 //   1 — generic error
 //   2 — cobra usage error (set by cobra on bad flags; we don't override)
 //   3 — autoresearch is paused (cli.ErrPaused)
@@ -20,6 +20,12 @@ import (
 // versus fail loudly.
 func main() {
 	if err := cli.Root().Execute(); err != nil {
+		// ErrDryRun means the verb printed its "[dry-run] would ..."
+		// preview and short-circuited before mutating state. That is
+		// success, not failure — exit 0 with no additional output.
+		if errors.Is(err, cli.ErrDryRun) {
+			return
+		}
 		fmt.Fprintln(os.Stderr, "error:", err)
 		switch {
 		case errors.Is(err, cli.ErrPaused):

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -1,0 +1,237 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+// researchHash walks .research/ under dir and returns a content hash over
+// (relpath + size + mode + sha256 of bytes). Used to assert that a
+// --dry-run invocation leaves the durable store byte-for-byte unchanged.
+func researchHash(t *testing.T, dir string) string {
+	t.Helper()
+	root := filepath.Join(dir, ".research")
+	h := sha256.New()
+	var entries []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		if d.IsDir() {
+			entries = append(entries, "d:"+rel)
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		fh := sha256.Sum256(data)
+		entries = append(entries, fmt.Sprintf("f:%s:%d:%o:%x", rel, info.Size(), info.Mode(), fh))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	sort.Strings(entries)
+	for _, e := range entries {
+		h.Write([]byte(e))
+		h.Write([]byte{0})
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// TestDryRun_ShortCircuitsAllMutatingVerbs drives a representative sample of
+// mutating verbs with --dry-run and asserts (1) the RunE returns ErrDryRun
+// (so main() exits 0) and (2) the .research/ tree is byte-for-byte
+// unchanged.
+//
+// Regression anchor for #19: the shared dryRun() helper previously returned
+// whatever w.Emit() returned (nil on success), so every `if err :=
+// dryRun(...); err != nil { return err }` guard fell through and the
+// mutation ran despite the preview being printed.
+func TestDryRun_ShortCircuitsAllMutatingVerbs(t *testing.T) {
+	type verbCase struct {
+		name string
+		// setup runs against an already-initialized store with an active
+		// goal and returns any extra args the verb needs (e.g. a
+		// hypothesis ID the verb will mutate).
+		setup func(t *testing.T, dir string) []string
+		// argsTail is appended to the base args after setup.
+		argsTail func(ids []string) []string
+	}
+
+	cases := []verbCase{
+		{
+			name: "hypothesis_add",
+			argsTail: func(_ []string) []string {
+				return []string{
+					"hypothesis", "add",
+					"--claim", "tighten inner loop",
+					"--predicts-instrument", "timing",
+					"--predicts-target", "fir",
+					"--predicts-direction", "decrease",
+					"--predicts-min-effect", "0.05",
+					"--kill-if", "tests fail",
+				}
+			},
+		},
+		{
+			name:  "hypothesis_kill",
+			setup: setupHypothesis,
+			argsTail: func(ids []string) []string {
+				return []string{"hypothesis", "kill", ids[0], "--reason", "stale"}
+			},
+		},
+		{
+			name:  "hypothesis_reopen",
+			setup: setupKilledHypothesis,
+			argsTail: func(ids []string) []string {
+				return []string{"hypothesis", "reopen", ids[0], "--reason", "back on"}
+			},
+		},
+		{
+			name: "instrument_register",
+			argsTail: func(_ []string) []string {
+				return []string{
+					"instrument", "register", "extra",
+					"--cmd", "true",
+					"--parser", "builtin:passfail",
+					"--unit", "bool",
+				}
+			},
+		},
+		{
+			name: "pause",
+			argsTail: func(_ []string) []string {
+				return []string{"pause", "--reason", "dry-run probe"}
+			},
+		},
+		{
+			name:  "resume",
+			setup: setupPaused,
+			argsTail: func(_ []string) []string {
+				return []string{"resume"}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			saveGlobals(t)
+			dir, _ := setupGoalStore(t)
+
+			var ids []string
+			if tc.setup != nil {
+				ids = tc.setup(t, dir)
+			}
+
+			root := Root()
+			args := append([]string{"-C", dir, "--dry-run"}, tc.argsTail(ids)...)
+			root.SetArgs(args)
+
+			before := researchHash(t, dir)
+
+			err := root.Execute()
+			if err == nil {
+				t.Fatalf("expected ErrDryRun, got nil")
+			}
+			if !errors.Is(err, ErrDryRun) {
+				t.Fatalf("expected ErrDryRun, got %v", err)
+			}
+
+			after := researchHash(t, dir)
+			if before != after {
+				t.Errorf(".research/ changed under --dry-run\n  before=%s\n   after=%s", before, after)
+			}
+		})
+	}
+}
+
+func setupHypothesis(t *testing.T, dir string) []string {
+	t.Helper()
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"hypothesis", "add",
+		"--claim", "setup hypothesis",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "fir",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.05",
+		"--kill-if", "tests fail",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup hypothesis add: %v", err)
+	}
+	return []string{"H-0001"}
+}
+
+func setupKilledHypothesis(t *testing.T, dir string) []string {
+	t.Helper()
+	ids := setupHypothesis(t, dir)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"hypothesis", "kill", ids[0],
+		"--reason", "prereq for test",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup kill: %v", err)
+	}
+	return ids
+}
+
+func setupPaused(t *testing.T, dir string) []string {
+	t.Helper()
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"pause", "--reason", "setup",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("setup pause: %v", err)
+	}
+	return nil
+}
+
+// TestDryRun_NonDryRunStillMutates sanity-checks that the fix didn't
+// accidentally break the non-dry-run path — a mutating verb without
+// --dry-run must still mutate state.
+func TestDryRun_NonDryRunStillMutates(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupGoalStore(t)
+
+	before := researchHash(t, dir)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"hypothesis", "add",
+		"--claim", "non-dry-run",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "fir",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.05",
+		"--kill-if", "tests fail",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("hypothesis add: %v", err)
+	}
+
+	after := researchHash(t, dir)
+	if before == after {
+		t.Error("non-dry-run hypothesis add did not change .research/")
+	}
+}

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -14,4 +14,12 @@ var (
 	// max_wall_time_h on experiment design). Orchestrators treat exit code
 	// 4 as "budget exhausted" and stop the loop cleanly.
 	ErrBudgetExhausted = errors.New("budget exhausted")
+
+	// ErrDryRun is the sentinel dryRun() returns after emitting the
+	// "[dry-run] would ..." preview. RunE handlers treat it as a
+	// short-circuit (return err); main() maps it to exit 0 with no
+	// additional error text, since the preview has already been printed.
+	// It is NOT a failure — it signals that the verb stopped intentionally
+	// before mutating state.
+	ErrDryRun = errors.New("dry-run")
 )

--- a/internal/cli/util.go
+++ b/internal/cli/util.go
@@ -64,12 +64,19 @@ func emitEvent(s *store.Store, kind, actor, subject string, data any) error {
 	})
 }
 
-// dryRun checks globalDryRun and, if set, emits a "[dry-run] would ..."
-// message and returns a non-nil sentinel. Callers use it as a guard:
+// dryRun checks globalDryRun and, if set, emits the "[dry-run] would ..."
+// preview and returns ErrDryRun. Callers use it as a guard:
 //
 //	if err := dryRun(w, "add hypothesis", payload); err != nil { return err }
 //
-// When globalDryRun is false it returns nil and the caller continues.
+// main() recognizes ErrDryRun and exits 0 silently (the preview has
+// already been emitted). When globalDryRun is false it returns nil and
+// the caller continues to the mutation path.
+//
+// Returning a real sentinel here — rather than just nil after the Emit —
+// is load-bearing. Previously the function returned w.Emit(...), which
+// is nil on success, so every caller's `if err := dryRun(...); err != nil`
+// guard fell straight through and the mutation ran anyway.
 func dryRun(w *output.Writer, action string, payload map[string]any) error {
 	if !globalDryRun {
 		return nil
@@ -78,7 +85,10 @@ func dryRun(w *output.Writer, action string, payload map[string]any) error {
 		payload = map[string]any{}
 	}
 	payload["status"] = "dry-run"
-	return w.Emit(fmt.Sprintf("[dry-run] would %s", action), payload)
+	if err := w.Emit(fmt.Sprintf("[dry-run] would %s", action), payload); err != nil {
+		return err
+	}
+	return ErrDryRun
 }
 
 func jsonRaw(v any) json.RawMessage {


### PR DESCRIPTION
Closes #19. **High severity** — every `--dry-run` in the tool currently prints the preview and then mutates anyway.

## Summary
- `dryRun()` in `internal/cli/util.go` returned `w.Emit(...)`, which is `nil` on success. Every caller's one-line guard (`if err := dryRun(...); err != nil { return err }`) therefore fell through and the mutation ran despite the `[dry-run] would …` line being printed. Impacts 24 call sites across 12 files — every mutating verb.
- Introduce `cli.ErrDryRun` sentinel. `dryRun()` emits the preview and returns the sentinel so the existing guard idiom short-circuits. Every call site is unchanged.
- `main.go` recognizes `errors.Is(err, cli.ErrDryRun)` and exits 0 silently — the preview is the success output, no additional error print.
- New `dryrun_test.go` is the regression anchor: exercises a representative sample of mutating verbs (hypothesis add / kill / reopen, instrument register, pause, resume) with `--dry-run` and asserts (1) `ErrDryRun` is returned and (2) a sha256-over-walk of `.research/` is byte-identical before and after. A companion test verifies non-dry-run still mutates.

## Test plan
- [x] `make test` — green
- [x] Manual: `instrument register foo --dry-run` now prints preview AND leaves `.research/` unchanged (exit 0)
- [x] The table-driven test catches the regression: reverting the sentinel to `nil` fails all six sub-tests with "expected ErrDryRun, got nil"