### PR TITLE
Fix #20: add instrument delete verb

### DIFF
--- a/internal/cli/instrument.go
+++ b/internal/cli/instrument.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
+	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/output"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
@@ -15,7 +17,7 @@ func instrumentCommands() []*cobra.Command {
 		Use:   "instrument",
 		Short: "Manage measurement instruments",
 	}
-	i.AddCommand(instrumentListCmd(), instrumentRegisterCmd())
+	i.AddCommand(instrumentListCmd(), instrumentRegisterCmd(), instrumentDeleteCmd())
 	return []*cobra.Command{i}
 }
 
@@ -131,5 +133,120 @@ func instrumentRegisterCmd() *cobra.Command {
 	c.Flags().StringArrayVar(&requires, "requires", nil, "prerequisite as 'instrument=pass' (repeatable); observe will refuse to run this instrument until prerequisites have passing observations")
 	c.Flags().IntVar(&minSamples, "min-samples", 0, "minimum samples required (strict mode)")
 	addAuthorFlag(c, &author, "")
+	return c
+}
+
+func instrumentDeleteCmd() *cobra.Command {
+	var (
+		reason string
+		force  bool
+		author string
+	)
+	c := &cobra.Command{
+		Use:   "delete <name>",
+		Short: "Delete an instrument from .research/config.yaml",
+		Long: `Delete removes an instrument definition from the project config.
+
+By default, delete refuses to remove an instrument that is still
+referenced by an active goal's objective, an active goal's constraint,
+any hypothesis's prediction, or any recorded observation. Deleting a
+referenced instrument would orphan the reference; for those cases the
+right action is usually a new goal, or a hypothesis kill/supersede
+rather than stripping the instrument out from under them.
+
+--force bypasses the reference check except for active-goal-objective
+references, which are never bypassable (the goal becomes structurally
+unmeasurable). Use --force with intent; the event payload records
+what was orphaned.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := output.Default(globalJSON)
+			name := args[0]
+
+			s, err := openStoreLive()
+			if err != nil {
+				return err
+			}
+
+			insts, err := s.ListInstruments()
+			if err != nil {
+				return err
+			}
+			if _, ok := insts[name]; !ok {
+				return fmt.Errorf("instrument %q: %w", name, store.ErrInstrumentNotFound)
+			}
+
+			goals, err := s.ListGoals()
+			if err != nil {
+				return fmt.Errorf("list goals: %w", err)
+			}
+			hyps, err := s.ListHypotheses()
+			if err != nil {
+				return fmt.Errorf("list hypotheses: %w", err)
+			}
+			obs, err := s.ListObservations()
+			if err != nil {
+				return fmt.Errorf("list observations: %w", err)
+			}
+
+			usage := firewall.CheckInstrumentSafeToDelete(name, goals, hyps, obs)
+
+			if !usage.Ok() {
+				if usage.BlocksEvenWithForce() {
+					return fmt.Errorf("refusing to delete instrument %q: referenced by active goal objective (%s). Start a new goal rather than remove the objective instrument",
+						name, strings.Join(usage.GoalObjectives, ", "))
+				}
+				if !force {
+					return fmt.Errorf("refusing to delete instrument %q: still referenced (%s). Re-run with --force to delete anyway (orphaned references will be listed in the event payload), or prefer killing the referencing hypotheses / concluding the goal first",
+						name, usage.Summary())
+				}
+			}
+
+			if reason == "" {
+				reason = "(no reason given)"
+			}
+			action := fmt.Sprintf("delete instrument %q", name)
+			if force && !usage.Ok() {
+				action = fmt.Sprintf("force-delete instrument %q (orphaning %s)", name, usage.Summary())
+			}
+
+			eventData := map[string]any{
+				"name":   name,
+				"reason": reason,
+				"forced": force && !usage.Ok(),
+			}
+			if !usage.Ok() {
+				eventData["orphaned"] = map[string]any{
+					"goal_constraints": usage.GoalConstraints,
+					"hypotheses":       usage.Hypotheses,
+					"observations":     usage.Observations,
+				}
+			}
+
+			if err := dryRun(w, action, eventData); err != nil {
+				return err
+			}
+
+			deleted, err := s.DeleteInstrument(name)
+			if err != nil {
+				if errors.Is(err, store.ErrInstrumentNotFound) {
+					return fmt.Errorf("instrument %q: %w", name, err)
+				}
+				return err
+			}
+
+			if err := emitEvent(s, "instrument.delete", or(author, "human"), name, eventData); err != nil {
+				return err
+			}
+
+			return w.Emit(
+				fmt.Sprintf("deleted instrument %q", name),
+				map[string]any{"status": "ok", "name": name, "instrument": deleted, "forced": force && !usage.Ok()},
+			)
+		},
+	}
+	c.Flags().StringVar(&reason, "reason", "", "why the instrument is being removed (recorded on the instrument.delete event)")
+	c.Flags().BoolVar(&force, "force", false, "override the reference check (does not override active-goal-objective references)")
+	addAuthorFlag(c, &author, "human")
 	return c
 }

--- a/internal/cli/instrument_delete_test.go
+++ b/internal/cli/instrument_delete_test.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+// registerExtraInstrument adds an unreferenced instrument named `name` to
+// the store so tests can exercise delete without having to design a new
+// goal around it.
+func registerExtraInstrument(t *testing.T, s *store.Store, name string) {
+	t.Helper()
+	if err := s.RegisterInstrument(name, store.Instrument{
+		Cmd: []string{"true"}, Parser: "builtin:passfail", Unit: "bool",
+	}); err != nil {
+		t.Fatalf("register %s: %v", name, err)
+	}
+}
+
+func TestInstrumentDelete_HappyPath(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+	registerExtraInstrument(t, s, "extra")
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "extra",
+		"--reason", "typo",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	insts, err := s.ListInstruments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := insts["extra"]; ok {
+		t.Error("instrument still present after delete")
+	}
+
+	ev := findLastEvent(t, s, "instrument.delete")
+	if ev == nil {
+		t.Fatal("instrument.delete event not found")
+	}
+	payload := decodePayload(t, ev)
+	if payload["name"] != "extra" {
+		t.Errorf("name = %v, want extra", payload["name"])
+	}
+	if payload["reason"] != "typo" {
+		t.Errorf("reason = %v, want typo", payload["reason"])
+	}
+	if payload["forced"] != false {
+		t.Errorf("forced = %v, want false", payload["forced"])
+	}
+}
+
+func TestInstrumentDelete_RefusesUnknown(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupGoalStore(t)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "nonexistent",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown instrument")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("err = %v, want 'not found'", err)
+	}
+}
+
+func TestInstrumentDelete_RefusesGoalObjective(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupGoalStore(t)
+
+	// setupGoalStore's objective instrument is "timing"
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "timing",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when deleting goal-objective instrument")
+	}
+	if !strings.Contains(err.Error(), "active goal objective") {
+		t.Errorf("err = %v, want 'active goal objective'", err)
+	}
+}
+
+func TestInstrumentDelete_ForceDoesNotOverrideObjective(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupGoalStore(t)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "timing",
+		"--force",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error: --force should not override objective ref")
+	}
+	if !strings.Contains(err.Error(), "active goal objective") {
+		t.Errorf("err = %v, want 'active goal objective'", err)
+	}
+}
+
+func TestInstrumentDelete_RefusesReferencedByHypothesis(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	// Create a hypothesis that predicts on "binary_size" (a constraint
+	// instrument from setupGoalStore).
+	h := &entity.Hypothesis{
+		ID:     "H-0001",
+		GoalID: "G-0001",
+		Claim:  "shrink",
+		Predicts: entity.Predicts{
+			Instrument: "binary_size",
+			Target:     "firmware",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+		KillIf: []string{"tests fail"},
+		Status: entity.StatusOpen,
+		Author: "human",
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "binary_size",
+	})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error when deleting instrument referenced by a hypothesis + constraint")
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Errorf("err should suggest --force, got %v", err)
+	}
+}
+
+func TestInstrumentDelete_ForceOrphans(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	// "host_test" is only a goal constraint — no hypothesis yet.
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "delete", "host_test",
+		"--force",
+		"--reason", "deprecated",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("force-delete: %v", err)
+	}
+
+	insts, err := s.ListInstruments()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := insts["host_test"]; ok {
+		t.Error("host_test still present after --force delete")
+	}
+
+	ev := findLastEvent(t, s, "instrument.delete")
+	if ev == nil {
+		t.Fatal("instrument.delete event not found")
+	}
+	payload := decodePayload(t, ev)
+	if payload["forced"] != true {
+		t.Errorf("forced = %v, want true", payload["forced"])
+	}
+	orphaned, ok := payload["orphaned"].(map[string]any)
+	if !ok {
+		t.Fatalf("orphaned payload missing or wrong type: %v", payload["orphaned"])
+	}
+	constraints, _ := orphaned["goal_constraints"].([]any)
+	if len(constraints) == 0 {
+		t.Errorf("expected goal_constraints to list G-0001, got %v", orphaned)
+	}
+}

--- a/internal/firewall/validators.go
+++ b/internal/firewall/validators.go
@@ -296,6 +296,101 @@ func CheckInstrumentDependencies(instName string, cfg *store.Config, observation
 	return nil
 }
 
+// InstrumentUsage enumerates where a named instrument is still referenced
+// by goals, hypotheses, or observations. An empty usage means the
+// instrument can be removed without orphaning anything.
+type InstrumentUsage struct {
+	// Goals whose objective.instrument == name. Deleting one of these
+	// would leave the goal unmeasurable; this is never bypassable.
+	GoalObjectives []string
+	// Goals whose constraints[].instrument == name. Deleting is a
+	// weakening of the goal's definition but does not strand it.
+	GoalConstraints []string
+	// Hypothesis IDs whose predicts.instrument == name. Deleting
+	// invalidates their predictions.
+	Hypotheses []string
+	// Observation IDs recorded with instrument == name. Deleting
+	// orphans the recorded data from the instrument definition.
+	Observations []string
+}
+
+func (u InstrumentUsage) Ok() bool {
+	return len(u.GoalObjectives) == 0 &&
+		len(u.GoalConstraints) == 0 &&
+		len(u.Hypotheses) == 0 &&
+		len(u.Observations) == 0
+}
+
+// BlocksEvenWithForce is true when usage contains a reference that must
+// never be bypassed — currently, a goal objective pointing at the
+// instrument. Losing the objective instrument leaves the goal
+// structurally broken, so `instrument delete --force` refuses too.
+func (u InstrumentUsage) BlocksEvenWithForce() bool {
+	return len(u.GoalObjectives) > 0
+}
+
+// Summary formats the usage as a human-readable, multi-line explanation
+// suitable for an error message or event payload. Empty usage returns "".
+func (u InstrumentUsage) Summary() string {
+	if u.Ok() {
+		return ""
+	}
+	var parts []string
+	if len(u.GoalObjectives) > 0 {
+		parts = append(parts, "goal objective: "+strings.Join(u.GoalObjectives, ", "))
+	}
+	if len(u.GoalConstraints) > 0 {
+		parts = append(parts, "goal constraint: "+strings.Join(u.GoalConstraints, ", "))
+	}
+	if len(u.Hypotheses) > 0 {
+		parts = append(parts, "hypothesis predictions: "+strings.Join(u.Hypotheses, ", "))
+	}
+	if len(u.Observations) > 0 {
+		parts = append(parts, "observations: "+strings.Join(u.Observations, ", "))
+	}
+	return strings.Join(parts, "; ")
+}
+
+// CheckInstrumentSafeToDelete scans the supplied entities for references
+// to the named instrument and returns the usage. Callers interpret the
+// result: a non-empty Ok()==false usage should block deletion by default,
+// but `--force` may accept usage.BlocksEvenWithForce()==false. Existence
+// of the instrument itself is checked by the store (ErrInstrumentNotFound).
+func CheckInstrumentSafeToDelete(name string, goals []*entity.Goal, hyps []*entity.Hypothesis, obs []*entity.Observation) InstrumentUsage {
+	var u InstrumentUsage
+	for _, g := range goals {
+		if g == nil || g.Status != entity.GoalStatusActive {
+			continue
+		}
+		if g.Objective.Instrument == name {
+			u.GoalObjectives = append(u.GoalObjectives, g.ID)
+		}
+		for _, c := range g.Constraints {
+			if c.Instrument == name {
+				u.GoalConstraints = append(u.GoalConstraints, g.ID)
+				break
+			}
+		}
+	}
+	for _, h := range hyps {
+		if h == nil {
+			continue
+		}
+		if h.Predicts.Instrument == name {
+			u.Hypotheses = append(u.Hypotheses, h.ID)
+		}
+	}
+	for _, o := range obs {
+		if o == nil {
+			continue
+		}
+		if o.Instrument == name {
+			u.Observations = append(u.Observations, o.ID)
+		}
+	}
+	return u
+}
+
 // ValidateLesson checks the structural rules of a lesson: non-empty claim,
 // valid scope, required Subjects for scope=hypothesis, and well-formed ID
 // prefixes on Subjects and SupersedesID. Existence of referenced entities is

--- a/internal/firewall/validators_test.go
+++ b/internal/firewall/validators_test.go
@@ -712,3 +712,104 @@ func TestCheckInspiredByLessonsReviewed(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckInstrumentSafeToDelete(t *testing.T) {
+	goal := func(id string, status string, obj string, constraints ...string) *entity.Goal {
+		g := &entity.Goal{ID: id, Status: status, Objective: entity.Objective{Instrument: obj, Direction: "decrease"}}
+		for _, c := range constraints {
+			g.Constraints = append(g.Constraints, entity.Constraint{Instrument: c})
+		}
+		return g
+	}
+	hyp := func(id, inst string) *entity.Hypothesis {
+		return &entity.Hypothesis{ID: id, Predicts: entity.Predicts{Instrument: inst, Direction: "decrease"}}
+	}
+	obs := func(id, inst string) *entity.Observation {
+		return &entity.Observation{ID: id, Instrument: inst}
+	}
+
+	t.Run("unreferenced instrument is safe", func(t *testing.T) {
+		goals := []*entity.Goal{goal("G-0001", entity.GoalStatusActive, "timing")}
+		hyps := []*entity.Hypothesis{hyp("H-0001", "timing")}
+		os := []*entity.Observation{obs("O-0001", "timing")}
+		u := firewall.CheckInstrumentSafeToDelete("binary_size", goals, hyps, os)
+		if !u.Ok() {
+			t.Errorf("unreferenced should be Ok, got %+v", u)
+		}
+	})
+
+	t.Run("goal objective reference blocks even with --force", func(t *testing.T) {
+		goals := []*entity.Goal{goal("G-0001", entity.GoalStatusActive, "timing")}
+		u := firewall.CheckInstrumentSafeToDelete("timing", goals, nil, nil)
+		if u.Ok() {
+			t.Fatal("goal-objective reference should block")
+		}
+		if !u.BlocksEvenWithForce() {
+			t.Errorf("goal-objective reference should block --force, got %+v", u)
+		}
+		if len(u.GoalObjectives) != 1 || u.GoalObjectives[0] != "G-0001" {
+			t.Errorf("expected [G-0001] objective ref, got %v", u.GoalObjectives)
+		}
+	})
+
+	t.Run("goal constraint reference blocks by default", func(t *testing.T) {
+		goals := []*entity.Goal{goal("G-0001", entity.GoalStatusActive, "timing", "binary_size")}
+		u := firewall.CheckInstrumentSafeToDelete("binary_size", goals, nil, nil)
+		if u.Ok() {
+			t.Fatal("goal-constraint reference should block by default")
+		}
+		if u.BlocksEvenWithForce() {
+			t.Errorf("goal-constraint reference should be force-overridable, got %+v", u)
+		}
+	})
+
+	t.Run("inactive goal references do not block", func(t *testing.T) {
+		goals := []*entity.Goal{goal("G-0001", entity.GoalStatusConcluded, "timing", "binary_size")}
+		u := firewall.CheckInstrumentSafeToDelete("timing", goals, nil, nil)
+		if !u.Ok() {
+			t.Errorf("concluded-goal references should not block, got %+v", u)
+		}
+	})
+
+	t.Run("hypothesis prediction blocks by default", func(t *testing.T) {
+		hyps := []*entity.Hypothesis{hyp("H-0001", "binary_size"), hyp("H-0002", "timing")}
+		u := firewall.CheckInstrumentSafeToDelete("binary_size", nil, hyps, nil)
+		if u.Ok() || u.BlocksEvenWithForce() {
+			t.Fatalf("hypothesis ref should be blocking-but-forceable, got %+v", u)
+		}
+		if len(u.Hypotheses) != 1 || u.Hypotheses[0] != "H-0001" {
+			t.Errorf("expected [H-0001], got %v", u.Hypotheses)
+		}
+	})
+
+	t.Run("observation blocks by default", func(t *testing.T) {
+		os := []*entity.Observation{obs("O-0001", "binary_size")}
+		u := firewall.CheckInstrumentSafeToDelete("binary_size", nil, nil, os)
+		if u.Ok() || u.BlocksEvenWithForce() {
+			t.Fatalf("observation ref should be blocking-but-forceable, got %+v", u)
+		}
+		if len(u.Observations) != 1 {
+			t.Errorf("expected 1 observation ref, got %v", u.Observations)
+		}
+	})
+
+	t.Run("summary lists every reference class", func(t *testing.T) {
+		goals := []*entity.Goal{goal("G-0001", entity.GoalStatusActive, "timing", "binary_size")}
+		hyps := []*entity.Hypothesis{hyp("H-0001", "binary_size")}
+		os := []*entity.Observation{obs("O-0001", "binary_size")}
+		u := firewall.CheckInstrumentSafeToDelete("binary_size", goals, hyps, os)
+		s := u.Summary()
+		for _, want := range []string{"G-0001", "H-0001", "O-0001"} {
+			if !strings.Contains(s, want) {
+				t.Errorf("summary missing %q: %s", want, s)
+			}
+		}
+	})
+
+	t.Run("empty summary when safe", func(t *testing.T) {
+		u := firewall.CheckInstrumentSafeToDelete("x", nil, nil, nil)
+		if u.Summary() != "" {
+			t.Errorf("safe usage should have empty summary, got %q", u.Summary())
+		}
+	})
+}

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -303,6 +303,11 @@ Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provision
         [--pattern 'regex with one capture group']  # required for builtin:scalar
         --unit U [--requires inst=pass,...] [--min-samples N]
     autoresearch instrument list
+    autoresearch instrument delete <name> [--reason "..."] [--force]
+        # delete refuses while the instrument is referenced by the active
+        # goal's objective/constraints, any hypothesis prediction, or any
+        # observation. --force overrides the check EXCEPT for goal-
+        # objective references (those leave the goal unmeasurable).
 
 Built-in parsers:
 

--- a/internal/store/instruments.go
+++ b/internal/store/instruments.go
@@ -1,6 +1,13 @@
 package store
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInstrumentNotFound is returned by DeleteInstrument when the named
+// instrument is not in config.yaml.
+var ErrInstrumentNotFound = errors.New("instrument not found")
 
 func (s *Store) RegisterInstrument(name string, inst Instrument) error {
 	if name == "" {
@@ -15,6 +22,29 @@ func (s *Store) RegisterInstrument(name string, inst Instrument) error {
 	}
 	cfg.Instruments[name] = inst
 	return s.writeConfig(*cfg)
+}
+
+// DeleteInstrument removes the named instrument from config.yaml and
+// returns the removed Instrument. Callers must check safety first via
+// firewall.CheckInstrumentSafeToDelete; this method is purely the
+// persistence half of the delete.
+func (s *Store) DeleteInstrument(name string) (Instrument, error) {
+	if name == "" {
+		return Instrument{}, fmt.Errorf("instrument name is required")
+	}
+	cfg, err := s.Config()
+	if err != nil {
+		return Instrument{}, err
+	}
+	inst, ok := cfg.Instruments[name]
+	if !ok {
+		return Instrument{}, ErrInstrumentNotFound
+	}
+	delete(cfg.Instruments, name)
+	if err := s.writeConfig(*cfg); err != nil {
+		return Instrument{}, err
+	}
+	return inst, nil
 }
 
 func (s *Store) ListInstruments() (map[string]Instrument, error) {


### PR DESCRIPTION
Closes #20.

No supported way existed to remove an instrument from `.research/config.yaml`. Recovery from a typo or deprecation required `rm -rf .research && autoresearch init`, losing all goal/hypothesis/experiment/observation history.

## Summary
- `autoresearch instrument delete <name> [--reason …] [--force]`, following the existing mutating-verb conventions (pause gate, `--dry-run`, `--json`, `instrument.delete` event).
- New `firewall.CheckInstrumentSafeToDelete(name, goals, hypotheses, observations)` returns an `InstrumentUsage` classifying references into four buckets:
  - **goal objective** — blocks even with `--force` (removing it leaves the goal structurally unmeasurable)
  - **goal constraint** — forceable
  - **hypothesis prediction** — forceable
  - **observation** — forceable
- Default: refuses deletion with an error listing the referrers and suggesting the right recovery verb (usually kill/conclude the referring entity, not strip the instrument).
- `--force`: overrides except for goal-objective refs. The event payload captures an `orphaned` field listing what was left dangling, so the audit log tells the truth.
- Store: `DeleteInstrument(name)` + `ErrInstrumentNotFound`.
- Agent docs updated (`claude_doc.go`) to advertise the verb with its behavior.

## Test plan
- [x] `make test` — green
- [x] Firewall tests: 7 cases covering every reference class, including BlocksEvenWithForce semantics and cross-class summary formatting
- [x] CLI tests: happy path, unknown-name refusal, objective-ref refusal (default and `--force`), hypothesis-ref refusal with `--force` hint, force-orphan with event-payload verification