### PR TITLE
Goal-level rescuers: "decrease X or Y, as long as X doesn't regress" (#27)

### DIFF
--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -135,8 +135,8 @@ downgraded since there is no comparator).`,
 			if err != nil {
 				return err
 			}
-			goal, err := s.ActiveGoal()
-			if err == nil {
+			goal, goalErr := s.ActiveGoal()
+			if goalErr == nil {
 				concls, _ := s.ListConclusions()
 				frontierRows, _ := computeFrontier(s, goal, concls)
 				if len(frontierRows) > 0 {
@@ -176,34 +176,63 @@ downgraded since there is no comparator).`,
 				}
 			}
 
-			// Apply strict firewall (always against absolute baseline).
-			decision := firewall.CheckStrictVerdict(verdict, hyp, cmp)
+			// Apply strict firewall (always against absolute baseline). When an
+			// active goal declares rescuers, build a callback that lets the
+			// firewall compute the same-baseline comparison on any rescuer
+			// instrument; the firewall uses it to decide whether a failing
+			// primary can be rescued by a goal-level secondary.
+			strictCtx := firewall.StrictContext{}
+			if goal != nil && len(goal.Rescuers) > 0 && goal.NeutralBandFrac > 0 {
+				candAll, _ := s.ListObservationsForExperiment(candExp)
+				var baseAll []*entity.Observation
+				if baselineExp != "" {
+					baseAll, _ = s.ListObservationsForExperiment(baselineExp)
+				}
+				strictCtx = firewall.StrictContext{
+					Goal: goal,
+					RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+						cs := samplesForInstrument(candAll, instrument)
+						if len(cs) == 0 {
+							return nil, fmt.Sprintf("no observations on %q for candidate %s", instrument, candExp)
+						}
+						bs := samplesForInstrument(baseAll, instrument)
+						if len(bs) == 0 {
+							return nil, fmt.Sprintf("no observations on %q for baseline %s", instrument, baselineExp)
+						}
+						v := stats.CompareSamples(cs, bs, iters, 0)
+						return &v, ""
+					},
+				}
+			}
+			decision := firewall.CheckStrictVerdictWithContext(verdict, hyp, cmp, strictCtx)
 
 			// Build conclusion record.
 			effect := buildEffect(hyp.Predicts.Instrument, cSamples, bSamples, cmp)
 
 			strictRec := entity.Strict{
-				Passed:  decision.Passed,
-				Reasons: decision.Reasons,
+				Passed:    decision.Passed,
+				RescuedBy: decision.RescuedBy,
+				Reasons:   decision.Reasons,
 			}
 			if decision.Downgraded {
 				strictRec.RequestedFrom = verdict
 			}
 
 			concl := &entity.Conclusion{
-				Hypothesis:     hypID,
-				Verdict:        decision.FinalVerdict,
-				Observations:   obsList,
-				CandidateExp:   candExp,
-				BaselineExp:    baselineExp,
-				Effect:         effect,
-				IncrementalExp: incrementalExp,
-				StatTest:       "mann_whitney_u",
-				Strict:         strictRec,
-				Author:         or(author, "agent:analyst"),
-				ReviewedBy:     reviewedBy,
-				CreatedAt:      nowUTC(),
-				Body:           interpretationBody(interpretation, verdict, decision),
+				Hypothesis:      hypID,
+				Verdict:         decision.FinalVerdict,
+				Observations:    obsList,
+				CandidateExp:    candExp,
+				BaselineExp:     baselineExp,
+				Effect:          effect,
+				IncrementalExp:  incrementalExp,
+				SecondaryChecks: decision.ClauseChecks,
+				StatTest:        "mann_whitney_u",
+				Strict:          strictRec,
+				Author:          or(author, "agent:analyst"),
+				ReviewedBy:      reviewedBy,
+				CreatedAt:       nowUTC(),
+				Body:            interpretationBody(interpretation, verdict, decision),
 			}
 			if incrCmp != nil {
 				incrEffect := buildEffect(hyp.Predicts.Instrument, cSamples, flattenSamples(incrObs), incrCmp)
@@ -277,6 +306,9 @@ downgraded since there is no comparator).`,
 					eventData["incremental_delta_frac"] = concl.IncrementalEffect.DeltaFrac
 				}
 			}
+			if decision.RescuedBy != "" {
+				eventData["rescued_by"] = decision.RescuedBy
+			}
 			kind := "conclusion.write"
 			if decision.Downgraded {
 				kind = "conclusion.downgrade"
@@ -296,6 +328,12 @@ downgraded since there is no comparator).`,
 			}
 			if decision.Downgraded {
 				w.Textf("⚠ DOWNGRADED: requested %q → %q\n", verdict, decision.FinalVerdict)
+				for _, r := range decision.Reasons {
+					w.Textf("  - %s\n", r)
+				}
+				w.Textln("")
+			} else if decision.RescuedBy != "" {
+				w.Textf("⚕ RESCUED: primary was neutral; verdict supported by %s\n", decision.RescuedBy)
 				for _, r := range decision.Reasons {
 					w.Textf("  - %s\n", r)
 				}
@@ -360,7 +398,26 @@ func downgradeLabel(d firewall.VerdictDecision) string {
 	if d.Downgraded {
 		return "(downgraded) "
 	}
+	if d.RescuedBy != "" {
+		return "(rescued) "
+	}
 	return ""
+}
+
+// samplesForInstrument flattens every per-sample slice across observations
+// on the given instrument into a single float slice. Used to assemble the
+// candidate/baseline sample pair for a goal rescuer at conclude time.
+func samplesForInstrument(obs []*entity.Observation, instrument string) []float64 {
+	var filtered []*entity.Observation
+	for _, o := range obs {
+		if o.Instrument == instrument {
+			filtered = append(filtered, o)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return flattenSamples(filtered)
 }
 
 // buildEffect constructs an Effect from samples and an optional comparison.

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -63,6 +63,8 @@ func conclusionListCmd() *cobra.Command {
 				dg := ""
 				if c.Strict.RequestedFrom != "" {
 					dg = fmt.Sprintf("  [downgraded from %s]", c.Strict.RequestedFrom)
+				} else if c.Strict.RescuedBy != "" {
+					dg = fmt.Sprintf("  [rescued by %s]", c.Strict.RescuedBy)
 				}
 				w.Textf("  %-8s  %-12s  hyp=%-8s  delta_frac=%+.4f  p=%.4g%s\n",
 					c.ID, c.Verdict, c.Hypothesis, c.Effect.DeltaFrac, c.Effect.PValue, dg)
@@ -101,6 +103,29 @@ func conclusionShowCmd() *cobra.Command {
 				w.Textf("downgraded:   from %q with reasons:\n", c.Strict.RequestedFrom)
 				for _, r := range c.Strict.Reasons {
 					w.Textf("  - %s\n", r)
+				}
+			} else if c.Strict.RescuedBy != "" {
+				w.Textf("rescued_by:   %s  (primary was neutral; rescuer carried the verdict)\n", c.Strict.RescuedBy)
+				for _, r := range c.Strict.Reasons {
+					w.Textf("  - %s\n", r)
+				}
+			}
+			if len(c.SecondaryChecks) > 0 {
+				w.Textln("secondary_checks:")
+				for _, cc := range c.SecondaryChecks {
+					status := "fail"
+					if cc.Passed {
+						status = "pass"
+					}
+					if cc.Effect != nil {
+						w.Textf("  - %s (%s) %s: delta_frac=%+.4f  CI [%+.4f, %+.4f]\n",
+							cc.Instrument, cc.Role, status, cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac)
+					} else {
+						w.Textf("  - %s (%s) %s\n", cc.Instrument, cc.Role, status)
+					}
+					for _, r := range cc.Reasons {
+						w.Textf("      %s\n", r)
+					}
 				}
 			}
 			w.Textf("candidate:    %s  (n=%d)\n", c.CandidateExp, c.Effect.NCandidate)

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"math"
 	"sort"
 
 	"github.com/bytter/autoresearch/internal/entity"
@@ -185,7 +186,11 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 			if i == 0 {
 				marker = "* "
 			}
-			w.Textf("%s%s  %s  %s=%.6g\n", marker, r.Conclusion, r.Hypothesis, f.Goal.Objective.Instrument, r.Value)
+			w.Textf("%s%s  %s  %s=%.6g", marker, r.Conclusion, r.Hypothesis, f.Goal.Objective.Instrument, r.Value)
+			if r.RescuedBy != "" {
+				w.Textf("  [rescued by %s]", r.RescuedBy)
+			}
+			w.Textln("")
 		}
 		w.Textln("")
 	}
@@ -217,6 +222,17 @@ type frontierRow struct {
 	Candidate  string  `json:"candidate_experiment"`
 	Value      float64 `json:"value"`
 	DeltaFrac  float64 `json:"delta_frac"`
+	// RescuedBy is non-empty when the backing conclusion was supported via
+	// a goal rescuer rather than a clean primary win. Renderers display a
+	// "rescued by <instrument>" annotation so the reader cannot mistake a
+	// rescued row for a clean primary-metric improvement.
+	RescuedBy string `json:"rescued_by,omitempty"`
+	// TiebreakValues holds one candidate value per goal.Rescuers clause, in
+	// declared order. Used when two rows are within goal.NeutralBandFrac on
+	// primary — the sort then picks the row that wins on the first rescuer
+	// whose value differs. Absent rescuer data is represented as NaN so the
+	// tiebreak skips cleanly over it.
+	TiebreakValues []float64 `json:"-"`
 }
 
 type frontierGoalAssessment struct {
@@ -249,15 +265,17 @@ func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 			continue
 		}
 		rows = append(rows, frontierRow{
-			Conclusion: c.ID,
-			Hypothesis: c.Hypothesis,
-			Candidate:  c.CandidateExp,
-			Value:      val,
-			DeltaFrac:  c.Effect.DeltaFrac,
+			Conclusion:     c.ID,
+			Hypothesis:     c.Hypothesis,
+			Candidate:      c.CandidateExp,
+			Value:          val,
+			DeltaFrac:      c.Effect.DeltaFrac,
+			RescuedBy:      c.Strict.RescuedBy,
+			TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
 		})
 	}
 	sort.Slice(rows, func(i, j int) bool {
-		return betterFrontierValue(goal.Objective.Direction, rows[i].Value, rows[j].Value)
+		return frontierRowBetter(goal, rows[i], rows[j])
 	})
 
 	sortedByTime := make([]*entity.Conclusion, len(concls))
@@ -265,7 +283,7 @@ func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	sort.Slice(sortedByTime, func(i, j int) bool { return sortedByTime[i].CreatedAt.Before(sortedByTime[j].CreatedAt) })
 
 	hasBest := false
-	var bestValue float64
+	var bestRow frontierRow
 	for _, c := range sortedByTime {
 		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
 		if !ok {
@@ -274,20 +292,84 @@ func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 			}
 			continue
 		}
+		cur := frontierRow{
+			Value:          val,
+			TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+		}
 		if !hasBest {
 			hasBest = true
-			bestValue = val
+			bestRow = cur
 			stalledFor = 0
 			continue
 		}
-		if betterFrontierValue(goal.Objective.Direction, val, bestValue) {
-			bestValue = val
+		if frontierRowBetter(goal, cur, bestRow) {
+			bestRow = cur
 			stalledFor = 0
 		} else {
 			stalledFor++
 		}
 	}
 	return rows, stalledFor
+}
+
+// rescuerTiebreakValues extracts one candidate value per goal rescuer, in
+// declared order. Missing observations (the candidate wasn't measured on a
+// rescuer instrument) are represented as NaN so the tiebreak comparator can
+// skip them cleanly.
+func rescuerTiebreakValues(goal *entity.Goal, obs []*entity.Observation) []float64 {
+	if goal == nil || len(goal.Rescuers) == 0 {
+		return nil
+	}
+	out := make([]float64, len(goal.Rescuers))
+	for i, r := range goal.Rescuers {
+		v, ok := candidateObjectiveValue(obs, r.Instrument)
+		if !ok {
+			out[i] = math.NaN()
+			continue
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// frontierRowBetter reports whether a is strictly better than b on the goal.
+// When the primary values are within goal.NeutralBandFrac of each other, the
+// comparison falls through to rescuers in goal-declared order; the first
+// rescuer whose value differs decides. This is a limited Pareto-tiebreak,
+// not a full multi-objective frontier.
+func frontierRowBetter(goal *entity.Goal, a, b frontierRow) bool {
+	if goal == nil {
+		return false
+	}
+	if !withinPrimaryNeutralBand(goal, a.Value, b.Value) {
+		return betterFrontierValue(goal.Objective.Direction, a.Value, b.Value)
+	}
+	for i, r := range goal.Rescuers {
+		if i >= len(a.TiebreakValues) || i >= len(b.TiebreakValues) {
+			continue
+		}
+		av, bv := a.TiebreakValues[i], b.TiebreakValues[i]
+		if math.IsNaN(av) || math.IsNaN(bv) {
+			continue
+		}
+		if av == bv {
+			continue
+		}
+		return betterFrontierValue(r.Direction, av, bv)
+	}
+	return false
+}
+
+// withinPrimaryNeutralBand reports whether two primary values are close
+// enough (relative to the larger magnitude) that the goal considers them
+// "tied" on the primary metric. Returns false whenever the goal doesn't
+// declare a neutral band, preserving v3-goal behaviour exactly.
+func withinPrimaryNeutralBand(goal *entity.Goal, a, b float64) bool {
+	if goal == nil || goal.NeutralBandFrac <= 0 {
+		return false
+	}
+	denom := math.Max(math.Max(math.Abs(a), math.Abs(b)), 1e-9)
+	return math.Abs(a-b)/denom <= goal.NeutralBandFrac
 }
 
 func frontierRequireConstraints(goal *entity.Goal) map[string]string {

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -60,6 +60,8 @@ type goalFlags struct {
 	constraintMax    []string
 	constraintMin    []string
 	constraintReq    []string
+	rescuers         []string
+	neutralBandFrac  float64
 	steeringText     string
 }
 
@@ -73,6 +75,8 @@ func addGoalBodyFlags(c *cobra.Command, f *goalFlags) {
 	c.Flags().StringArrayVar(&f.constraintMax, "constraint-max", nil, "max constraint as 'instrument=value' (repeatable)")
 	c.Flags().StringArrayVar(&f.constraintMin, "constraint-min", nil, "min constraint as 'instrument=value' (repeatable)")
 	c.Flags().StringArrayVar(&f.constraintReq, "constraint-require", nil, "require constraint as 'instrument=value' (repeatable, e.g. 'host_test=pass')")
+	c.Flags().StringArrayVar(&f.rescuers, "rescuer", nil, "goal rescuer as 'instrument:direction:min_effect' (repeatable, e.g. 'sim_total_bytes:decrease:0.02'); requires --neutral-band-frac")
+	c.Flags().Float64Var(&f.neutralBandFrac, "neutral-band-frac", 0, "|delta_frac| within this band on the primary counts as \"neutral\" for rescue purposes (required when --rescuer is set)")
 	c.Flags().StringVar(&f.steeringText, "steering", "", "initial steering note to place in the # Steering section")
 }
 
@@ -82,7 +86,8 @@ func loadGoalFromFlags(f *goalFlags) (*entity.Goal, error) {
 	fileMode := f.file != ""
 	flagMode := f.objInstrument != "" || f.objDirection != "" ||
 		f.successThreshold != 0 || f.onSuccess != "" ||
-		len(f.constraintMax) > 0 || len(f.constraintMin) > 0 || len(f.constraintReq) > 0
+		len(f.constraintMax) > 0 || len(f.constraintMin) > 0 || len(f.constraintReq) > 0 ||
+		len(f.rescuers) > 0 || f.neutralBandFrac != 0
 	if fileMode && flagMode {
 		return nil, errors.New("--file and goal-construction flags are mutually exclusive")
 	}
@@ -97,7 +102,7 @@ func loadGoalFromFlags(f *goalFlags) (*entity.Goal, error) {
 		return entity.ParseGoal(data)
 	}
 	return buildGoalFromFlags(f.objInstrument, f.objTarget, f.objDirection, f.successThreshold, f.onSuccess,
-		f.constraintMax, f.constraintMin, f.constraintReq, f.steeringText)
+		f.constraintMax, f.constraintMin, f.constraintReq, f.rescuers, f.neutralBandFrac, f.steeringText)
 }
 
 func goalSetCmd() *cobra.Command {
@@ -411,7 +416,8 @@ func buildGoalFromFlags(
 	instrument, target, direction string,
 	successThreshold float64,
 	onSuccess string,
-	maxSpecs, minSpecs, reqSpecs []string,
+	maxSpecs, minSpecs, reqSpecs, rescuerSpecs []string,
+	neutralBandFrac float64,
 	steering string,
 ) (*entity.Goal, error) {
 	if successThreshold < 0 {
@@ -467,6 +473,20 @@ func buildGoalFromFlags(
 	if len(g.Constraints) == 0 {
 		return nil, errors.New("at least one --constraint-max / --constraint-min / --constraint-require is required")
 	}
+	for _, spec := range rescuerSpecs {
+		r, err := parseRescuerSpec(spec)
+		if err != nil {
+			return nil, err
+		}
+		g.Rescuers = append(g.Rescuers, r)
+	}
+	if len(g.Rescuers) > 0 && neutralBandFrac <= 0 {
+		return nil, errors.New("--neutral-band-frac must be > 0 when --rescuer is set")
+	}
+	if len(g.Rescuers) == 0 && neutralBandFrac > 0 {
+		return nil, errors.New("--neutral-band-frac is only meaningful with at least one --rescuer")
+	}
+	g.NeutralBandFrac = neutralBandFrac
 	body := "# Steering\n\n"
 	if strings.TrimSpace(steering) != "" {
 		body += "- " + strings.TrimSpace(steering) + "\n"
@@ -475,6 +495,34 @@ func buildGoalFromFlags(
 	}
 	g.Body = body
 	return g, nil
+}
+
+// parseRescuerSpec parses "instrument:direction:min_effect" into a Rescuer.
+// Example: "sim_total_bytes:decrease:0.02". Direction must be
+// increase|decrease; min_effect must be a positive float.
+func parseRescuerSpec(spec string) (entity.Rescuer, error) {
+	spec = strings.TrimSpace(spec)
+	parts := strings.Split(spec, ":")
+	if len(parts) != 3 {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: expected 'instrument:direction:min_effect'", spec)
+	}
+	inst := strings.TrimSpace(parts[0])
+	dir := strings.TrimSpace(parts[1])
+	minStr := strings.TrimSpace(parts[2])
+	if inst == "" {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: instrument is empty", spec)
+	}
+	if dir != "increase" && dir != "decrease" {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: direction must be 'increase' or 'decrease', got %q", spec, dir)
+	}
+	min, err := strconv.ParseFloat(minStr, 64)
+	if err != nil {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: min_effect %q is not a float: %w", spec, minStr, err)
+	}
+	if min <= 0 {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: min_effect must be > 0", spec)
+	}
+	return entity.Rescuer{Instrument: inst, Direction: dir, MinEffect: min}, nil
 }
 
 func parseConstraintKV(spec, op string) (entity.Constraint, error) {

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -16,6 +16,8 @@ func TestBuildGoalFromFlags_DefaultsThresholdPolicy(t *testing.T) {
 		[]string{"size_flash=131072"},
 		nil,
 		nil,
+		nil,
+		0,
 		"",
 	)
 	if err != nil {
@@ -39,6 +41,8 @@ func TestBuildGoalFromFlags_RejectsOnSuccessWithoutThreshold(t *testing.T) {
 		[]string{"size_flash=131072"},
 		nil,
 		nil,
+		nil,
+		0,
 		"",
 	)
 	if err == nil {
@@ -56,10 +60,85 @@ func TestBuildGoalFromFlags_RejectsNegativeThreshold(t *testing.T) {
 		[]string{"size_flash=131072"},
 		nil,
 		nil,
+		nil,
+		0,
 		"",
 	)
 	if err == nil {
 		t.Fatal("expected negative threshold to be rejected")
+	}
+}
+
+func TestBuildGoalFromFlags_RescuersRequireNeutralBand(t *testing.T) {
+	_, err := buildGoalFromFlags(
+		"host_timing", "dsp_fir", "decrease",
+		0, "",
+		[]string{"size_flash=131072"}, nil, nil,
+		[]string{"sim_total_bytes:decrease:0.02"},
+		0,
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected rescuer without --neutral-band-frac to be rejected")
+	}
+}
+
+func TestBuildGoalFromFlags_NeutralBandWithoutRescuerRejected(t *testing.T) {
+	_, err := buildGoalFromFlags(
+		"host_timing", "dsp_fir", "decrease",
+		0, "",
+		[]string{"size_flash=131072"}, nil, nil,
+		nil,
+		0.02,
+		"",
+	)
+	if err == nil {
+		t.Fatal("expected --neutral-band-frac without rescuer to be rejected")
+	}
+}
+
+func TestBuildGoalFromFlags_RescuerAccepted(t *testing.T) {
+	g, err := buildGoalFromFlags(
+		"host_timing", "dsp_fir", "decrease",
+		0, "",
+		[]string{"size_flash=131072"}, nil, nil,
+		[]string{"sim_total_bytes:decrease:0.02"},
+		0.02,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("buildGoalFromFlags: %v", err)
+	}
+	if len(g.Rescuers) != 1 || g.Rescuers[0].Instrument != "sim_total_bytes" || g.Rescuers[0].Direction != "decrease" || g.Rescuers[0].MinEffect != 0.02 {
+		t.Errorf("rescuer populated incorrectly: %+v", g.Rescuers)
+	}
+	if g.NeutralBandFrac != 0.02 {
+		t.Errorf("neutral_band_frac = %g, want 0.02", g.NeutralBandFrac)
+	}
+}
+
+func TestFrontierRowBetter_RescuerTiebreak(t *testing.T) {
+	goal := &entity.Goal{
+		Objective:       entity.Objective{Instrument: "ns_per_eval", Direction: "decrease"},
+		NeutralBandFrac: 0.02,
+		Rescuers: []entity.Rescuer{
+			{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0.02},
+		},
+	}
+	// Same primary value, but a has smaller size → a should win.
+	a := frontierRow{Value: 100.0, TiebreakValues: []float64{512}}
+	b := frontierRow{Value: 100.5, TiebreakValues: []float64{600}} // within 1% band
+	if !frontierRowBetter(goal, a, b) {
+		t.Errorf("a should beat b via rescuer tiebreak")
+	}
+	if frontierRowBetter(goal, b, a) {
+		t.Errorf("b should not beat a")
+	}
+	// If primary gap exceeds neutral band, primary wins regardless of size.
+	c := frontierRow{Value: 80.0, TiebreakValues: []float64{9999}}
+	d := frontierRow{Value: 100.0, TiebreakValues: []float64{10}}
+	if !frontierRowBetter(goal, c, d) {
+		t.Errorf("primary-dominant candidate should win over size-dominant one when outside the neutral band")
 	}
 }
 

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -246,9 +246,19 @@ func renderReportMarkdown(r *reportData) string {
 	} else {
 		sb.WriteString("## Conclusions\n\n")
 		for _, c := range r.Conclusions {
-			fmt.Fprintf(&sb, "### %s — %s\n\n", c.ID, c.Verdict)
+			heading := c.Verdict
+			if c.Strict.RescuedBy != "" {
+				heading = fmt.Sprintf("%s (rescued by `%s`)", c.Verdict, c.Strict.RescuedBy)
+			}
+			fmt.Fprintf(&sb, "### %s — %s\n\n", c.ID, heading)
 			if c.Strict.RequestedFrom != "" {
 				fmt.Fprintf(&sb, "> **Downgraded** from `%s` — strict firewall rejected the requested verdict:\n", c.Strict.RequestedFrom)
+				for _, r := range c.Strict.Reasons {
+					fmt.Fprintf(&sb, "> - %s\n", r)
+				}
+				sb.WriteString("\n")
+			} else if c.Strict.RescuedBy != "" {
+				fmt.Fprintf(&sb, "> **Rescued** — primary was neutral (within the goal's `neutral_band_frac`); verdict carried by rescuer `%s`:\n", c.Strict.RescuedBy)
 				for _, r := range c.Strict.Reasons {
 					fmt.Fprintf(&sb, "> - %s\n", r)
 				}

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -100,6 +100,8 @@ func (v *conclusionListView) view(width, height int) string {
 		extras := ""
 		if c.Strict.RequestedFrom != "" {
 			extras = tuiDim.Render("  ↓from " + c.Strict.RequestedFrom)
+		} else if c.Strict.RescuedBy != "" {
+			extras = tuiYellow.Render("  ⚕rescued:" + c.Strict.RescuedBy)
 		}
 		review := " "
 		if c.ReviewedBy != "" {
@@ -178,6 +180,31 @@ func (v *conclusionDetailView) view(width, height int) string {
 		lines = append(lines, tuiBoldYellow.Render("⚠ downgraded from "+c.Strict.RequestedFrom))
 		for _, r := range c.Strict.Reasons {
 			lines = append(lines, "  · "+r)
+		}
+	} else if c.Strict.RescuedBy != "" {
+		lines = append(lines, "")
+		lines = append(lines, tuiBoldYellow.Render("⚕ rescued by "+c.Strict.RescuedBy+" — primary was neutral"))
+		for _, r := range c.Strict.Reasons {
+			lines = append(lines, "  · "+r)
+		}
+	}
+	if len(c.SecondaryChecks) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, tuiBold.Render("Secondary checks:"))
+		for _, cc := range c.SecondaryChecks {
+			status := tuiRed.Render("fail")
+			if cc.Passed {
+				status = tuiGreen.Render("pass")
+			}
+			header := fmt.Sprintf("  %s (%s) %s", cc.Instrument, cc.Role, status)
+			if cc.Effect != nil {
+				header += fmt.Sprintf("  Δfrac=%+.4f  CI[%+.4f,%+.4f]",
+					cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac)
+			}
+			lines = append(lines, header)
+			for _, r := range cc.Reasons {
+				lines = append(lines, "    · "+r)
+			}
 		}
 	}
 	lines = append(lines, "")

--- a/internal/cli/tui_view_hypothesis.go
+++ b/internal/cli/tui_view_hypothesis.go
@@ -322,6 +322,8 @@ func (v *hypothesisDetailView) renderLines(width int) ([]string, []hypDetailLink
 			extras := ""
 			if c.Strict.RequestedFrom != "" {
 				extras = tuiDim.Render("  (downgraded from " + c.Strict.RequestedFrom + ")")
+			} else if c.Strict.RescuedBy != "" {
+				extras = tuiYellow.Render("  (rescued by " + c.Strict.RescuedBy + ")")
 			}
 			lines = append(lines, fmt.Sprintf("  %s  %s  delta_frac=%.4f  p=%.4g%s",
 				c.ID, tuiVerdictBadge(c.Verdict), c.Effect.DeltaFrac, c.Effect.PValue, extras))

--- a/internal/entity/conclusion.go
+++ b/internal/entity/conclusion.go
@@ -26,14 +26,31 @@ type Conclusion struct {
 	// "how much did this improve over the current best?" as opposed to
 	// the absolute baseline which answers "how much did this improve
 	// over the original unoptimized code?"
-	IncrementalExp    string  `yaml:"incremental_experiment,omitempty" json:"incremental_experiment,omitempty"`
-	IncrementalEffect *Effect `yaml:"incremental_effect,omitempty"     json:"incremental_effect,omitempty"`
-	StatTest          string  `yaml:"stat_test"                     json:"stat_test"`
-	Strict            Strict  `yaml:"strict_check"                  json:"strict_check"`
-	Author            string  `yaml:"author"                        json:"author"`
-	ReviewedBy        string  `yaml:"reviewed_by,omitempty"         json:"reviewed_by,omitempty"`
-	CreatedAt         time.Time `yaml:"created_at"                    json:"created_at"`
-	Body              string    `yaml:"-"                             json:"body,omitempty"`
+	IncrementalExp    string        `yaml:"incremental_experiment,omitempty" json:"incremental_experiment,omitempty"`
+	IncrementalEffect *Effect       `yaml:"incremental_effect,omitempty"     json:"incremental_effect,omitempty"`
+	SecondaryChecks   []ClauseCheck `yaml:"secondary_checks,omitempty"       json:"secondary_checks,omitempty"`
+	StatTest          string        `yaml:"stat_test"                        json:"stat_test"`
+	Strict            Strict        `yaml:"strict_check"                     json:"strict_check"`
+	Author            string        `yaml:"author"                           json:"author"`
+	ReviewedBy        string        `yaml:"reviewed_by,omitempty"            json:"reviewed_by,omitempty"`
+	CreatedAt         time.Time     `yaml:"created_at"                       json:"created_at"`
+	Body              string        `yaml:"-"                                json:"body,omitempty"`
+}
+
+// ClauseCheck is the audit trail for a single non-primary prediction clause
+// (today: a goal rescuer) evaluated during conclude. It records which
+// instrument was checked, the effect relative to the same baseline used for
+// the primary check, whether the strict check passed, and any reasons —
+// notably "no_data" when observations for the clause's instrument are
+// missing on the candidate or baseline.
+type ClauseCheck struct {
+	Role       string   `yaml:"role"                json:"role"`
+	Instrument string   `yaml:"instrument"          json:"instrument"`
+	Direction  string   `yaml:"direction,omitempty" json:"direction,omitempty"`
+	MinEffect  float64  `yaml:"min_effect,omitempty" json:"min_effect,omitempty"`
+	Effect     *Effect  `yaml:"effect,omitempty"    json:"effect,omitempty"`
+	Passed     bool     `yaml:"passed"              json:"passed"`
+	Reasons    []string `yaml:"reasons,omitempty"   json:"reasons,omitempty"`
 }
 
 type Effect struct {
@@ -53,6 +70,7 @@ type Effect struct {
 type Strict struct {
 	Passed        bool     `yaml:"passed"                    json:"passed"`
 	RequestedFrom string   `yaml:"downgraded_from,omitempty" json:"downgraded_from,omitempty"`
+	RescuedBy     string   `yaml:"rescued_by,omitempty"      json:"rescued_by,omitempty"`
 	Reasons       []string `yaml:"reasons,omitempty"         json:"reasons,omitempty"`
 }
 

--- a/internal/entity/goal.go
+++ b/internal/entity/goal.go
@@ -12,7 +12,7 @@ const (
 	GoalStatusActive    = "active"
 	GoalStatusConcluded = "concluded"
 	GoalStatusAbandoned = "abandoned"
-	GoalSchemaVersion   = 3
+	GoalSchemaVersion   = 4
 
 	GoalOnThresholdAskHuman               = "ask_human"
 	GoalOnThresholdStop                   = "stop"
@@ -21,18 +21,32 @@ const (
 )
 
 type Goal struct {
-	SchemaVersion int          `yaml:"schema_version,omitempty" json:"schema_version,omitempty"`
-	ID            string       `yaml:"id,omitempty"             json:"id,omitempty"`
-	Status        string       `yaml:"status,omitempty"         json:"status,omitempty"`
-	DerivedFrom   string       `yaml:"derived_from,omitempty"   json:"derived_from,omitempty"`
-	Trigger       string       `yaml:"trigger,omitempty"        json:"trigger,omitempty"`
-	CreatedAt     *time.Time   `yaml:"created_at,omitempty"     json:"created_at,omitempty"`
-	ClosedAt      *time.Time   `yaml:"closed_at,omitempty"      json:"closed_at,omitempty"`
-	ClosureReason string       `yaml:"closure_reason,omitempty" json:"closure_reason,omitempty"`
-	Objective     Objective    `yaml:"objective"                json:"objective"`
-	Completion    *Completion  `yaml:"completion,omitempty"     json:"completion,omitempty"`
-	Constraints   []Constraint `yaml:"constraints"              json:"constraints"`
-	Body          string       `yaml:"-"                        json:"body,omitempty"`
+	SchemaVersion   int          `yaml:"schema_version,omitempty"    json:"schema_version,omitempty"`
+	ID              string       `yaml:"id,omitempty"                json:"id,omitempty"`
+	Status          string       `yaml:"status,omitempty"            json:"status,omitempty"`
+	DerivedFrom     string       `yaml:"derived_from,omitempty"      json:"derived_from,omitempty"`
+	Trigger         string       `yaml:"trigger,omitempty"           json:"trigger,omitempty"`
+	CreatedAt       *time.Time   `yaml:"created_at,omitempty"        json:"created_at,omitempty"`
+	ClosedAt        *time.Time   `yaml:"closed_at,omitempty"         json:"closed_at,omitempty"`
+	ClosureReason   string       `yaml:"closure_reason,omitempty"    json:"closure_reason,omitempty"`
+	Objective       Objective    `yaml:"objective"                   json:"objective"`
+	Completion      *Completion  `yaml:"completion,omitempty"        json:"completion,omitempty"`
+	Constraints     []Constraint `yaml:"constraints"                 json:"constraints"`
+	Rescuers        []Rescuer    `yaml:"rescuers,omitempty"          json:"rescuers,omitempty"`
+	NeutralBandFrac float64      `yaml:"neutral_band_frac,omitempty" json:"neutral_band_frac,omitempty"`
+	Body            string       `yaml:"-"                           json:"body,omitempty"`
+}
+
+// Rescuer is a secondary-objective clause on a Goal. When the primary
+// objective's strict check would fail *only* because |delta_frac| is within
+// goal.NeutralBandFrac (i.e. "didn't lose" on the primary), the firewall
+// consults each rescuer's own strict check on the same candidate/baseline
+// pair. If any rescuer passes, the verdict is kept as "supported" with
+// strict.rescued_by naming the winning rescuer.
+type Rescuer struct {
+	Instrument string  `yaml:"instrument"          json:"instrument"`
+	Direction  string  `yaml:"direction"           json:"direction"`
+	MinEffect  float64 `yaml:"min_effect"          json:"min_effect"`
 }
 
 type Objective struct {
@@ -66,17 +80,19 @@ func ParseGoal(data []byte) (*Goal, error) {
 		DeprecatedTargetEffect *float64 `yaml:"target_effect,omitempty"`
 	}
 	type rawGoal struct {
-		SchemaVersion int          `yaml:"schema_version,omitempty"`
-		ID            string       `yaml:"id,omitempty"`
-		Status        string       `yaml:"status,omitempty"`
-		DerivedFrom   string       `yaml:"derived_from,omitempty"`
-		Trigger       string       `yaml:"trigger,omitempty"`
-		CreatedAt     *time.Time   `yaml:"created_at,omitempty"`
-		ClosedAt      *time.Time   `yaml:"closed_at,omitempty"`
-		ClosureReason string       `yaml:"closure_reason,omitempty"`
-		Objective     rawObjective `yaml:"objective"`
-		Completion    *Completion  `yaml:"completion,omitempty"`
-		Constraints   []Constraint `yaml:"constraints"`
+		SchemaVersion   int          `yaml:"schema_version,omitempty"`
+		ID              string       `yaml:"id,omitempty"`
+		Status          string       `yaml:"status,omitempty"`
+		DerivedFrom     string       `yaml:"derived_from,omitempty"`
+		Trigger         string       `yaml:"trigger,omitempty"`
+		CreatedAt       *time.Time   `yaml:"created_at,omitempty"`
+		ClosedAt        *time.Time   `yaml:"closed_at,omitempty"`
+		ClosureReason   string       `yaml:"closure_reason,omitempty"`
+		Objective       rawObjective `yaml:"objective"`
+		Completion      *Completion  `yaml:"completion,omitempty"`
+		Constraints     []Constraint `yaml:"constraints"`
+		Rescuers        []Rescuer    `yaml:"rescuers,omitempty"`
+		NeutralBandFrac float64      `yaml:"neutral_band_frac,omitempty"`
 	}
 
 	var raw rawGoal
@@ -110,8 +126,10 @@ func ParseGoal(data []byte) (*Goal, error) {
 			Target:     raw.Objective.Target,
 			Direction:  raw.Objective.Direction,
 		},
-		Completion:  raw.Completion,
-		Constraints: raw.Constraints,
+		Completion:      raw.Completion,
+		Constraints:     raw.Constraints,
+		Rescuers:        raw.Rescuers,
+		NeutralBandFrac: raw.NeutralBandFrac,
 	}
 	g.Body = string(body)
 	if g.SchemaVersion == 0 {

--- a/internal/entity/goal_test.go
+++ b/internal/entity/goal_test.go
@@ -104,6 +104,80 @@ focus on the hot inner loop
 	}
 }
 
+func TestGoalRescuersRoundTrip(t *testing.T) {
+	flash := 131072.0
+	g := &entity.Goal{
+		SchemaVersion: entity.GoalSchemaVersion,
+		Objective: entity.Objective{
+			Instrument: "ns_per_eval",
+			Direction:  "decrease",
+		},
+		Constraints: []entity.Constraint{
+			{Instrument: "size_flash", Max: &flash},
+			{Instrument: "host_test", Require: "pass"},
+		},
+		Rescuers: []entity.Rescuer{
+			{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0.02},
+		},
+		NeutralBandFrac: 0.02,
+	}
+	data, err := g.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := entity.ParseGoal(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(back.Rescuers) != 1 {
+		t.Fatalf("rescuers round-trip: got %d, want 1", len(back.Rescuers))
+	}
+	r := back.Rescuers[0]
+	if r.Instrument != "sim_total_bytes" || r.Direction != "decrease" || r.MinEffect != 0.02 {
+		t.Errorf("rescuer mismatch: %+v", r)
+	}
+	if back.NeutralBandFrac != 0.02 {
+		t.Errorf("neutral_band_frac: got %g, want 0.02", back.NeutralBandFrac)
+	}
+	if back.SchemaVersion != entity.GoalSchemaVersion {
+		t.Errorf("schema_version round-trip: got %d, want %d", back.SchemaVersion, entity.GoalSchemaVersion)
+	}
+}
+
+func TestGoalLegacyV3ParsesAndUpgrades(t *testing.T) {
+	// A goal on disk before rescuers were a concept. schema_version=3, no
+	// rescuers or neutral_band_frac. It must parse cleanly and upgrade to
+	// the current schema version on read without losing any fields.
+	data := []byte(`---
+schema_version: 3
+objective:
+  instrument: ns_per_eval
+  target: bench
+  direction: decrease
+constraints:
+  - instrument: host_test
+    require: pass
+---
+
+# Steering
+
+focus on the hot inner loop
+`)
+	g, err := entity.ParseGoal(data)
+	if err != nil {
+		t.Fatalf("ParseGoal: %v", err)
+	}
+	if len(g.Rescuers) != 0 {
+		t.Errorf("v3 goal should parse with empty rescuers, got %+v", g.Rescuers)
+	}
+	if g.NeutralBandFrac != 0 {
+		t.Errorf("v3 goal should have zero neutral_band_frac, got %g", g.NeutralBandFrac)
+	}
+	if g.SchemaVersion != 3 {
+		t.Errorf("ParseGoal should preserve on-disk schema version; got %d, want 3", g.SchemaVersion)
+	}
+}
+
 func TestGoalDefaultsThresholdPolicyWhenOmitted(t *testing.T) {
 	data := []byte(`---
 objective:

--- a/internal/firewall/validators.go
+++ b/internal/firewall/validators.go
@@ -83,6 +83,54 @@ func ValidateGoal(g *entity.Goal, cfg *store.Config) error {
 			return fmt.Errorf("constraint[%d] must set at least one of max, min, or require", i)
 		}
 	}
+	if err := validateGoalRescuers(g, cfg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateGoalRescuers checks that rescuer clauses on a goal are
+// well-formed. A rescuer is optional, but when present must name a
+// registered instrument, declare a direction, and carry a positive
+// min_effect (rescue is still a scientific claim). Rescuers may overlap
+// with constraints — declaring a max cap on size AND marking size as a
+// rescuer is a valid pattern — but cannot equal the goal's objective
+// instrument (that would make the objective self-rescue, which is
+// nonsense). A goal with rescuers must also declare a positive
+// neutral_band_frac; rescue only fires when the primary is within that
+// band, so leaving it zero silently disables rescue.
+func validateGoalRescuers(g *entity.Goal, cfg *store.Config) error {
+	if g == nil || len(g.Rescuers) == 0 {
+		return nil
+	}
+	if g.NeutralBandFrac <= 0 {
+		return errors.New("goal declares rescuers but neutral_band_frac is unset (rescue only fires when |delta_frac| on the primary is within neutral_band_frac — set it explicitly)")
+	}
+	seen := map[string]struct{}{}
+	for i, r := range g.Rescuers {
+		inst := strings.TrimSpace(r.Instrument)
+		if inst == "" {
+			return fmt.Errorf("rescuer[%d] has no `instrument` field", i)
+		}
+		if inst == strings.TrimSpace(g.Objective.Instrument) {
+			return fmt.Errorf("rescuer[%d] instrument %q equals the goal objective — the primary cannot rescue itself", i, inst)
+		}
+		if _, ok := cfg.Instruments[inst]; !ok {
+			return fmt.Errorf("rescuer[%d] instrument %q is not registered in config.yaml", i, inst)
+		}
+		if _, dup := seen[inst]; dup {
+			return fmt.Errorf("rescuer[%d] instrument %q is declared more than once", i, inst)
+		}
+		seen[inst] = struct{}{}
+		switch r.Direction {
+		case "increase", "decrease":
+		default:
+			return fmt.Errorf("rescuer[%d] direction must be 'increase' or 'decrease', got %q", i, r.Direction)
+		}
+		if r.MinEffect <= 0 {
+			return fmt.Errorf("rescuer[%d] min_effect must be > 0 (rescue is still a scientific claim and needs a quantitative threshold)", i)
+		}
+	}
 	return nil
 }
 
@@ -112,6 +160,27 @@ type VerdictDecision struct {
 	Passed       bool
 	Downgraded   bool
 	Reasons      []string
+	// RescuedBy names the goal rescuer instrument whose strict check saved
+	// the verdict. Empty for the clean primary-wins path.
+	RescuedBy string
+	// ClauseChecks is the audit trail for any goal rescuers consulted. One
+	// entry per rescuer evaluated, whether it passed, failed, or was skipped
+	// for missing data. Empty when rescue was not consulted.
+	ClauseChecks []entity.ClauseCheck
+}
+
+// StrictContext carries the extra inputs the firewall needs to consider
+// goal-level rescuers on a failed primary check. It is optional: a
+// zero-value StrictContext makes CheckStrictVerdictWithContext behave
+// exactly like CheckStrictVerdict.
+type StrictContext struct {
+	Goal *entity.Goal
+	// RescuerComparison returns a stats.Comparison for the given rescuer
+	// instrument, computed against the same candidate/baseline pair used
+	// for the primary check. Returns (nil, "<reason>") when no comparison
+	// is possible (e.g. no observations on that instrument on either side).
+	// The reason is recorded in the rescuer's ClauseCheck.
+	RescuerComparison func(instrument string) (*stats.Comparison, string)
 }
 
 // CheckStrictVerdict applies the strict-mode firewall to a requested verdict
@@ -127,7 +196,20 @@ type VerdictDecision struct {
 //
 // When "supported" is requested and the evidence doesn't justify it, the
 // verdict is downgraded to "inconclusive" and the reasons are recorded.
+//
+// This form takes no goal-level context and therefore never rescues. Callers
+// that want goal-rescuer support should use CheckStrictVerdictWithContext.
 func CheckStrictVerdict(requested string, h *entity.Hypothesis, c *stats.Comparison) VerdictDecision {
+	return CheckStrictVerdictWithContext(requested, h, c, StrictContext{})
+}
+
+// CheckStrictVerdictWithContext is the rescuer-aware form of the strict
+// firewall. If the primary "supported" check fails AND |delta_frac| is within
+// goal.NeutralBandFrac AND ctx.Goal has rescuers AND ctx.RescuerComparison is
+// non-nil, each rescuer runs its own strict check on the same sample pair.
+// The first rescuer to pass rescues the verdict; d.RescuedBy names the
+// winner and d.ClauseChecks audits every rescuer considered.
+func CheckStrictVerdictWithContext(requested string, h *entity.Hypothesis, c *stats.Comparison, ctx StrictContext) VerdictDecision {
 	d := VerdictDecision{FinalVerdict: requested, Passed: true}
 	switch requested {
 	case entity.VerdictSupported:
@@ -152,6 +234,10 @@ func CheckStrictVerdict(requested string, h *entity.Hypothesis, c *stats.Compari
 			d.Reasons = append(d.Reasons, fmt.Sprintf("|delta_frac| %.4f < min_effect %.4f — effect too small to call supported", math.Abs(c.DeltaFrac), h.Predicts.MinEffect))
 		}
 		if len(d.Reasons) > 0 {
+			// Primary failed. Try rescue before finalizing the downgrade.
+			if rescued := tryRescue(h, c, ctx, d.Reasons); rescued != nil {
+				return *rescued
+			}
 			d.Passed = false
 			d.Downgraded = true
 			d.FinalVerdict = entity.VerdictInconclusive
@@ -181,6 +267,119 @@ func CheckStrictVerdict(requested string, h *entity.Hypothesis, c *stats.Compari
 		d.Reasons = append(d.Reasons, fmt.Sprintf("unknown verdict %q (want supported|refuted|inconclusive)", requested))
 	}
 	return d
+}
+
+// tryRescue attempts to salvage a failed "supported" primary check by
+// consulting goal-level rescuers. Returns a decision pointer when a rescuer
+// passes; nil otherwise (caller should finalize the downgrade). The primary
+// Reasons are preserved and annotated with the rescue citation so the audit
+// trail tells the full story.
+func tryRescue(_ *entity.Hypothesis, c *stats.Comparison, ctx StrictContext, primaryReasons []string) *VerdictDecision {
+	if ctx.Goal == nil || len(ctx.Goal.Rescuers) == 0 || ctx.RescuerComparison == nil {
+		return nil
+	}
+	if ctx.Goal.NeutralBandFrac <= 0 {
+		return nil
+	}
+	if c == nil {
+		return nil
+	}
+	if math.Abs(c.DeltaFrac) > ctx.Goal.NeutralBandFrac {
+		// Primary moved outside the user-declared neutral band — this is a
+		// real regression (or a real win that already failed some other gate).
+		// Rescue only saves neutrals, not losses.
+		return nil
+	}
+
+	var clauseChecks []entity.ClauseCheck
+	var winner *entity.ClauseCheck
+	for i := range ctx.Goal.Rescuers {
+		r := ctx.Goal.Rescuers[i]
+		clauseChecks = append(clauseChecks, evaluateRescuer(r, ctx))
+		if winner == nil && clauseChecks[len(clauseChecks)-1].Passed {
+			winner = &clauseChecks[len(clauseChecks)-1]
+		}
+	}
+	if winner == nil {
+		return nil
+	}
+
+	d := VerdictDecision{
+		FinalVerdict: entity.VerdictSupported,
+		Passed:       true,
+		Downgraded:   false,
+		RescuedBy:    winner.Instrument,
+		ClauseChecks: clauseChecks,
+	}
+	// Preserve the primary reasons so readers see why rescue was needed.
+	d.Reasons = append(d.Reasons, primaryReasons...)
+	d.Reasons = append(d.Reasons, fmt.Sprintf("rescued by %s: |delta_frac| %.4f <= neutral_band_frac %.4f on primary, and rescuer met its own strict check",
+		winner.Instrument, math.Abs(c.DeltaFrac), ctx.Goal.NeutralBandFrac))
+	return &d
+}
+
+// evaluateRescuer runs the same strict-check logic as the primary path on
+// a single rescuer clause, returning a ClauseCheck. Missing data or an
+// unrecognised direction yields a non-passing entry with an explanatory
+// reason so the audit trail is self-describing.
+func evaluateRescuer(r entity.Rescuer, ctx StrictContext) entity.ClauseCheck {
+	cc := entity.ClauseCheck{
+		Role:       "rescuer",
+		Instrument: r.Instrument,
+		Direction:  r.Direction,
+		MinEffect:  r.MinEffect,
+	}
+	cmp, missingReason := ctx.RescuerComparison(r.Instrument)
+	if cmp == nil {
+		if strings.TrimSpace(missingReason) == "" {
+			missingReason = "no comparison available for rescuer"
+		}
+		cc.Reasons = []string{missingReason}
+		return cc
+	}
+
+	effect := buildEffectFromComparison(r.Instrument, cmp)
+	cc.Effect = &effect
+
+	if cmp.NBaseline < 2 || cmp.NCandidate < 2 {
+		cc.Reasons = append(cc.Reasons, "no comparison available (baseline or candidate has fewer than 2 samples)")
+		return cc
+	}
+	switch r.Direction {
+	case "decrease":
+		if cmp.CIHighFrac >= 0 {
+			cc.Reasons = append(cc.Reasons, fmt.Sprintf("95%% CI upper bound on delta_frac is %+.4f — crosses zero (not a clean decrease)", cmp.CIHighFrac))
+		}
+	case "increase":
+		if cmp.CILowFrac <= 0 {
+			cc.Reasons = append(cc.Reasons, fmt.Sprintf("95%% CI lower bound on delta_frac is %+.4f — crosses zero (not a clean increase)", cmp.CILowFrac))
+		}
+	default:
+		cc.Reasons = append(cc.Reasons, fmt.Sprintf("unknown rescuer direction %q", r.Direction))
+	}
+	if math.Abs(cmp.DeltaFrac) < r.MinEffect {
+		cc.Reasons = append(cc.Reasons, fmt.Sprintf("|delta_frac| %.4f < min_effect %.4f — rescuer effect too small", math.Abs(cmp.DeltaFrac), r.MinEffect))
+	}
+	cc.Passed = len(cc.Reasons) == 0
+	return cc
+}
+
+// buildEffectFromComparison mirrors cli.buildEffect but stays inside the
+// firewall package so the firewall doesn't take a dependency on cli.
+func buildEffectFromComparison(instrument string, cmp *stats.Comparison) entity.Effect {
+	return entity.Effect{
+		Instrument: instrument,
+		DeltaAbs:   cmp.DeltaAbs,
+		DeltaFrac:  cmp.DeltaFrac,
+		CILowAbs:   cmp.CILowAbs,
+		CIHighAbs:  cmp.CIHighAbs,
+		CILowFrac:  cmp.CILowFrac,
+		CIHighFrac: cmp.CIHighFrac,
+		PValue:     cmp.PValue,
+		CIMethod:   cmp.CIMethod,
+		NCandidate: cmp.NCandidate,
+		NBaseline:  cmp.NBaseline,
+	}
 }
 
 // BudgetBreach describes which budget rule a would-be mutation violates.
@@ -680,6 +879,9 @@ func allowedHypothesisInstruments(goal *entity.Goal) []string {
 	add(goal.Objective.Instrument)
 	for _, c := range goal.Constraints {
 		add(c.Instrument)
+	}
+	for _, r := range goal.Rescuers {
+		add(r.Instrument)
 	}
 	return out
 }

--- a/internal/firewall/validators_test.go
+++ b/internal/firewall/validators_test.go
@@ -642,6 +642,199 @@ func TestCheckStrictVerdict(t *testing.T) {
 	})
 }
 
+func TestCheckStrictVerdictRescue(t *testing.T) {
+	// Primary hypothesis: decrease ns_per_eval by at least 5%.
+	hyp := &entity.Hypothesis{Predicts: entity.Predicts{
+		Instrument: "ns_per_eval",
+		Direction:  "decrease",
+		MinEffect:  0.05,
+	}}
+	// Goal declares size as a rescuer with a 2% min_effect and a 2%
+	// neutral band on the primary.
+	goal := &entity.Goal{
+		Objective:       entity.Objective{Instrument: "ns_per_eval", Direction: "decrease"},
+		NeutralBandFrac: 0.02,
+		Rescuers: []entity.Rescuer{{
+			Instrument: "sim_total_bytes",
+			Direction:  "decrease",
+			MinEffect:  0.02,
+		}},
+	}
+	mkCmp := func(deltaFrac, ciLow, ciHigh float64) *stats.Comparison {
+		return &stats.Comparison{
+			NBaseline: 10, NCandidate: 10,
+			DeltaFrac: deltaFrac, CILowFrac: ciLow, CIHighFrac: ciHigh,
+		}
+	}
+
+	t.Run("primary clean win does not consult rescuers", func(t *testing.T) {
+		ctx := firewall.StrictContext{
+			Goal: goal,
+			RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+				t.Fatalf("rescuer should not be consulted when primary passes")
+				return nil, ""
+			},
+		}
+		d := firewall.CheckStrictVerdictWithContext(entity.VerdictSupported, hyp,
+			mkCmp(-0.20, -0.30, -0.10), ctx)
+		if !d.Passed || d.Downgraded || d.RescuedBy != "" {
+			t.Fatalf("expected clean primary win, got %+v", d)
+		}
+	})
+
+	t.Run("primary neutral and rescuer wins rescues verdict", func(t *testing.T) {
+		// Primary delta is within the 2% band and CI crosses zero.
+		prim := mkCmp(0.005, -0.01, 0.02)
+		// Rescuer cleanly beats its own strict check.
+		resc := mkCmp(-0.10, -0.15, -0.05)
+		ctx := firewall.StrictContext{
+			Goal: goal,
+			RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+				if instrument != "sim_total_bytes" {
+					t.Fatalf("unexpected rescuer instrument %q", instrument)
+				}
+				return resc, ""
+			},
+		}
+		d := firewall.CheckStrictVerdictWithContext(entity.VerdictSupported, hyp, prim, ctx)
+		if !d.Passed || d.Downgraded {
+			t.Fatalf("expected rescue, got %+v", d)
+		}
+		if d.RescuedBy != "sim_total_bytes" {
+			t.Errorf("rescued_by = %q, want sim_total_bytes", d.RescuedBy)
+		}
+		if d.FinalVerdict != entity.VerdictSupported {
+			t.Errorf("final verdict = %q, want supported", d.FinalVerdict)
+		}
+		if len(d.ClauseChecks) != 1 || !d.ClauseChecks[0].Passed {
+			t.Errorf("expected one passing clause check, got %+v", d.ClauseChecks)
+		}
+	})
+
+	t.Run("primary neutral but no rescuer passes yields inconclusive", func(t *testing.T) {
+		prim := mkCmp(0.005, -0.01, 0.02)
+		// Rescuer trend is in the right direction but CI crosses zero.
+		resc := mkCmp(-0.10, -0.20, 0.01)
+		ctx := firewall.StrictContext{
+			Goal: goal,
+			RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+				return resc, ""
+			},
+		}
+		d := firewall.CheckStrictVerdictWithContext(entity.VerdictSupported, hyp, prim, ctx)
+		if d.Passed || !d.Downgraded {
+			t.Fatalf("expected downgrade (no rescuer passed), got %+v", d)
+		}
+		if d.RescuedBy != "" {
+			t.Errorf("rescued_by should be empty when no rescuer passes, got %q", d.RescuedBy)
+		}
+	})
+
+	t.Run("primary structurally regresses — rescue does not fire", func(t *testing.T) {
+		// Primary delta 5% above the neutral band; direction=decrease so this
+		// is a real regression. Rescue must not save it.
+		prim := mkCmp(0.05, 0.03, 0.08)
+		// Rescuer would pass cleanly if consulted.
+		resc := mkCmp(-0.10, -0.15, -0.05)
+		ctx := firewall.StrictContext{
+			Goal: goal,
+			RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+				return resc, ""
+			},
+		}
+		d := firewall.CheckStrictVerdictWithContext(entity.VerdictSupported, hyp, prim, ctx)
+		if d.Passed || !d.Downgraded {
+			t.Fatalf("expected downgrade despite passing rescuer (primary regressed), got %+v", d)
+		}
+		if d.RescuedBy != "" {
+			t.Errorf("rescued_by should be empty when primary regresses, got %q", d.RescuedBy)
+		}
+	})
+
+	t.Run("rescuer missing observations — clause check records no_data reason", func(t *testing.T) {
+		prim := mkCmp(0.005, -0.01, 0.02)
+		ctx := firewall.StrictContext{
+			Goal: goal,
+			RescuerComparison: func(instrument string) (*stats.Comparison, string) {
+				return nil, "no observations on \"sim_total_bytes\" for candidate E-0001"
+			},
+		}
+		d := firewall.CheckStrictVerdictWithContext(entity.VerdictSupported, hyp, prim, ctx)
+		if d.Passed || !d.Downgraded {
+			t.Fatalf("expected downgrade when rescuer has no data, got %+v", d)
+		}
+		if d.RescuedBy != "" {
+			t.Errorf("rescued_by should be empty, got %q", d.RescuedBy)
+		}
+	})
+
+	t.Run("plain CheckStrictVerdict without context never rescues", func(t *testing.T) {
+		prim := mkCmp(0.005, -0.01, 0.02)
+		d := firewall.CheckStrictVerdict(entity.VerdictSupported, hyp, prim)
+		if d.Passed || !d.Downgraded {
+			t.Fatalf("plain form should downgrade, got %+v", d)
+		}
+	})
+}
+
+func TestValidateGoalRescuers(t *testing.T) {
+	cfg := &store.Config{Instruments: map[string]store.Instrument{
+		"ns_per_eval":     {},
+		"sim_total_bytes": {},
+		"host_test":       {},
+	}}
+	baseGoal := func() *entity.Goal {
+		return &entity.Goal{
+			Objective:   entity.Objective{Instrument: "ns_per_eval", Direction: "decrease"},
+			Constraints: []entity.Constraint{{Instrument: "host_test", Require: "pass"}},
+		}
+	}
+
+	t.Run("no rescuers is fine", func(t *testing.T) {
+		if err := firewall.ValidateGoal(baseGoal(), cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("rescuers without neutral_band_frac rejected", func(t *testing.T) {
+		g := baseGoal()
+		g.Rescuers = []entity.Rescuer{{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0.02}}
+		err := firewall.ValidateGoal(g, cfg)
+		if err == nil || !strings.Contains(err.Error(), "neutral_band_frac") {
+			t.Fatalf("expected neutral_band_frac error, got %v", err)
+		}
+	})
+
+	t.Run("rescuer pointing at objective rejected", func(t *testing.T) {
+		g := baseGoal()
+		g.NeutralBandFrac = 0.02
+		g.Rescuers = []entity.Rescuer{{Instrument: "ns_per_eval", Direction: "decrease", MinEffect: 0.02}}
+		err := firewall.ValidateGoal(g, cfg)
+		if err == nil || !strings.Contains(err.Error(), "equals the goal objective") {
+			t.Fatalf("expected self-rescue error, got %v", err)
+		}
+	})
+
+	t.Run("unregistered rescuer instrument rejected", func(t *testing.T) {
+		g := baseGoal()
+		g.NeutralBandFrac = 0.02
+		g.Rescuers = []entity.Rescuer{{Instrument: "unregistered", Direction: "decrease", MinEffect: 0.02}}
+		err := firewall.ValidateGoal(g, cfg)
+		if err == nil || !strings.Contains(err.Error(), "not registered") {
+			t.Fatalf("expected not-registered error, got %v", err)
+		}
+	})
+
+	t.Run("well-formed rescuer passes", func(t *testing.T) {
+		g := baseGoal()
+		g.NeutralBandFrac = 0.02
+		g.Rescuers = []entity.Rescuer{{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0.02}}
+		if err := firewall.ValidateGoal(g, cfg); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
 func TestCheckInspiredByLessonsReviewed(t *testing.T) {
 	t.Run("allows active reviewed hypothesis chain", func(t *testing.T) {
 		reader := fakeInspiredByReader{

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -147,10 +147,10 @@ When proposing, each hypothesis MUST be:
 
 - **Falsifiable** — a specific numerical threshold, not "I think X helps."
 - **Instrument-backed** — `predicts.instrument` must exist in the registry and
-  must be the active goal's objective instrument or one of its explicit
-  constraint instruments. Supporting instruments may still be measured on the
-  experiment; they are not standalone optimization targets unless the goal
-  names them.
+  must be the active goal's objective instrument, one of its explicit
+  constraint instruments, or one of its declared rescuer instruments.
+  Supporting instruments may still be measured on the experiment; they are
+  not standalone optimization targets unless the goal names them.
 - **Well-scoped** — one mechanism per hypothesis. "Unroll the loop AND use
   SIMD" is two hypotheses, not one.
 - **Non-duplicative** — check the tree for similar open or previously
@@ -327,6 +327,25 @@ absolute baseline.
 
 If the firewall downgrades your verdict, **the downgrade is
 authoritative**. Report it in the yield summary.
+
+**Goal-level rescuers** (optional; set by the human at goal time). If
+the goal declares `rescuers:` and a `neutral_band_frac`, the firewall
+can rescue a failing `supported` request when:
+
+1. `|delta_frac|` on the primary is within `neutral_band_frac` — i.e.
+   primary "didn't lose" in the user's declared sense, and
+2. a rescuer instrument passes its own strict check (CI cleanly on the
+   predicted side AND `|delta_frac|` meets the rescuer's `min_effect`)
+   on the same candidate/baseline pair.
+
+Rescued conclusions are still `supported`, but `strict.rescued_by`
+names the rescuer that carried the verdict and `secondary_checks[]`
+records the full audit trail. Record a lesson that names *which metric
+actually won* — a future hypothesis needs to know the real mechanism,
+not just that "something improved." Rescue does NOT fire when the
+primary structurally regresses (i.e. `|delta_frac|` outside the
+neutral band); rescue only saves neutrals, not losses. Agents do not
+configure rescuers — the goal does.
 
 **Interpretation rules:**
 

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -383,6 +383,14 @@ fix the input instead.
   Every downgrade is recorded in the conclusion's ` + "`strict_check`" + ` block and
   in ` + "`events.jsonl`" + ` as a ` + "`conclusion.downgrade`" + ` event. The conclusion still
   persists; the hypothesis moves to ` + "`inconclusive`" + `.
+  If the active goal declares ` + "`rescuers`" + ` and a ` + "`neutral_band_frac`" + `, a
+  failing primary check can instead be **rescued**: when
+  ` + "`|delta_frac|`" + ` on the primary is within ` + "`neutral_band_frac`" + ` (primary
+  "didn't lose") and a rescuer instrument passes its own strict check on
+  the same candidate/baseline pair, the verdict is kept as ` + "`supported`" + `
+  with ` + "`strict.rescued_by`" + ` naming the rescuer. ` + "`secondary_checks[]`" + `
+  on the conclusion records every rescuer considered. Rescue never fires
+  when the primary structurally regresses (outside the band).
 
 ## The notebook layer
 


### PR DESCRIPTION
## Summary

- Adds `rescuers: []` and `neutral_band_frac` on Goal (schema v3 → v4, pure additive). When the primary strict check fails AND `|delta_frac|` on primary is within `neutral_band_frac`, each rescuer runs its own strict check on the same candidate/baseline pair; the first passing rescuer keeps the verdict `supported` and records `strict.rescued_by`.
- Frontier now tie-breaks within-neutral-band rows by rescuer values (a limited Pareto move) so rescued candidates actually displace the prior best instead of becoming invisible winners.
- Renderers (list, show, dashboard, TUI hypothesis + conclusion views, markdown report) surface `supported (rescued by <instrument>)` distinctly — the `supported` string alone must never hide the rescue.
- New `--rescuer "instrument:direction:min_effect"` and `--neutral-band-frac` flags on `goal set`/`goal new`. Validation rejects rescuers without a band, bands without rescuers, rescuers pointing at the objective, duplicates, unregistered instruments.
- Agent docs (research-orchestrator, claude_doc / codex_doc) teach when rescue fires and what lessons to record.
- Hypothesis schema UNCHANGED — `Predicts` stays single-objective. Per-hypothesis rescuer override is out of scope.

Closes #27.

## Test plan

- [x] `make test` — all existing tests pass; new coverage:
  - [x] Firewall rescue fork: primary clean win does not consult rescuers; primary neutral + rescuer wins rescues; primary neutral + no rescuer passes still downgrades; primary regresses outside the band → rescue refuses to fire even if a rescuer would pass; rescuer missing data → clause check records reason
  - [x] `ValidateGoalRescuers`: rejects band-less rescuers, self-rescue, unregistered instruments
  - [x] Goal round-trip: rescuers + neutral_band_frac persist through marshal/parse
  - [x] Legacy v3 goal parses cleanly and upgrades silently
  - [x] `buildGoalFromFlags`: rescuer without band rejected, band without rescuer rejected, well-formed pair accepted
  - [x] Frontier tiebreak: within-band ties broken by rescuer direction; outside-band primary always wins
- [x] `make vet` clean
- [x] Manual: `./autoresearch goal set --help` shows the new flags; `./autoresearch conclude --help` unchanged (no agent-facing CLI surface added).
- [ ] Manual end-to-end on `examples/cortex-m4-synth/`: set up a goal with `--rescuer sim_total_bytes:decrease:0.02 --neutral-band-frac 0.02`, run a wall-time-neutral / size-positive experiment, confirm `conclude` yields `supported (rescued by sim_total_bytes)` and `frontier` picks it as the new tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)