### PR TITLE
Directional hypotheses: allow min_effect=0 (#29)

### DIFF
--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -210,9 +210,10 @@ downgraded since there is no comparator).`,
 			effect := buildEffect(hyp.Predicts.Instrument, cSamples, bSamples, cmp)
 
 			strictRec := entity.Strict{
-				Passed:    decision.Passed,
-				RescuedBy: decision.RescuedBy,
-				Reasons:   decision.Reasons,
+				Passed:      decision.Passed,
+				RescuedBy:   decision.RescuedBy,
+				Directional: hyp.Predicts.MinEffect == 0,
+				Reasons:     decision.Reasons,
 			}
 			if decision.Downgraded {
 				strictRec.RequestedFrom = verdict
@@ -308,6 +309,9 @@ downgraded since there is no comparator).`,
 			}
 			if decision.RescuedBy != "" {
 				eventData["rescued_by"] = decision.RescuedBy
+			}
+			if strictRec.Directional {
+				eventData["directional"] = true
 			}
 			kind := "conclusion.write"
 			if decision.Downgraded {

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -65,6 +65,8 @@ func conclusionListCmd() *cobra.Command {
 					dg = fmt.Sprintf("  [downgraded from %s]", c.Strict.RequestedFrom)
 				} else if c.Strict.RescuedBy != "" {
 					dg = fmt.Sprintf("  [rescued by %s]", c.Strict.RescuedBy)
+				} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+					dg = "  [directional]"
 				}
 				w.Textf("  %-8s  %-12s  hyp=%-8s  delta_frac=%+.4f  p=%.4g%s\n",
 					c.ID, c.Verdict, c.Hypothesis, c.Effect.DeltaFrac, c.Effect.PValue, dg)
@@ -109,6 +111,8 @@ func conclusionShowCmd() *cobra.Command {
 				for _, r := range c.Strict.Reasons {
 					w.Textf("  - %s\n", r)
 				}
+			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+				w.Textln("directional: yes  (hypothesis predicted direction only; no magnitude commitment)")
 			}
 			if len(c.SecondaryChecks) > 0 {
 				w.Textln("secondary_checks:")

--- a/internal/cli/goal.go
+++ b/internal/cli/goal.go
@@ -519,8 +519,8 @@ func parseRescuerSpec(spec string) (entity.Rescuer, error) {
 	if err != nil {
 		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: min_effect %q is not a float: %w", spec, minStr, err)
 	}
-	if min <= 0 {
-		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: min_effect must be > 0", spec)
+	if min < 0 {
+		return entity.Rescuer{}, fmt.Errorf("--rescuer %q: min_effect must be >= 0 (0 means directional — any clean-CI effect in the predicted direction passes)", spec)
 	}
 	return entity.Rescuer{Instrument: inst, Direction: dir, MinEffect: min}, nil
 }

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -157,7 +157,7 @@ func hypothesisAddCmd() *cobra.Command {
 	c.Flags().StringVar(&predInstrument, "predicts-instrument", "", "instrument that will measure the predicted effect (required; must be the active goal objective or a goal-constraint instrument)")
 	c.Flags().StringVar(&predTarget, "predicts-target", "", "target measured by the instrument (required)")
 	c.Flags().StringVar(&predDirection, "predicts-direction", "", "predicted direction: increase | decrease (required)")
-	c.Flags().Float64Var(&predMinEffect, "predicts-min-effect", 0, "minimum fractional effect required to call it supported (required)")
+	c.Flags().Float64Var(&predMinEffect, "predicts-min-effect", 0, "minimum |delta_frac| required to call it supported; pass 0 for a directional hypothesis (direction only, no magnitude commitment — prefer this when no prior evidence grounds a specific number)")
 	c.Flags().StringArrayVar(&killIf, "kill-if", nil, "kill criterion; may be repeated (at least one required)")
 	c.Flags().StringSliceVar(&inspiredBy, "inspired-by", nil, "lesson IDs this hypothesis draws on (L-NNNN; reviewed lessons only; comma-separated or repeated)")
 	addAuthorFlag(c, &author, "")

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -249,6 +249,8 @@ func renderReportMarkdown(r *reportData) string {
 			heading := c.Verdict
 			if c.Strict.RescuedBy != "" {
 				heading = fmt.Sprintf("%s (rescued by `%s`)", c.Verdict, c.Strict.RescuedBy)
+			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+				heading = fmt.Sprintf("%s (directional)", c.Verdict)
 			}
 			fmt.Fprintf(&sb, "### %s — %s\n\n", c.ID, heading)
 			if c.Strict.RequestedFrom != "" {
@@ -263,6 +265,8 @@ func renderReportMarkdown(r *reportData) string {
 					fmt.Fprintf(&sb, "> - %s\n", r)
 				}
 				sb.WriteString("\n")
+			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+				sb.WriteString("> **Directional** — the hypothesis predicted direction only (`min_effect: 0`); any clean-CI effect in the predicted direction counts as supported. Follow-up hypotheses should refine this into a quantitative claim once the magnitude is known.\n\n")
 			}
 			fmt.Fprintf(&sb, "- **Candidate experiment**: %s\n", c.CandidateExp)
 			if c.BaselineExp != "" {

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -102,6 +102,8 @@ func (v *conclusionListView) view(width, height int) string {
 			extras = tuiDim.Render("  ↓from " + c.Strict.RequestedFrom)
 		} else if c.Strict.RescuedBy != "" {
 			extras = tuiYellow.Render("  ⚕rescued:" + c.Strict.RescuedBy)
+		} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+			extras = tuiDim.Render("  ↕directional")
 		}
 		review := " "
 		if c.ReviewedBy != "" {
@@ -187,6 +189,9 @@ func (v *conclusionDetailView) view(width, height int) string {
 		for _, r := range c.Strict.Reasons {
 			lines = append(lines, "  · "+r)
 		}
+	} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+		lines = append(lines, "")
+		lines = append(lines, tuiDim.Render("↕ directional — hypothesis predicted direction only; no magnitude commitment"))
 	}
 	if len(c.SecondaryChecks) > 0 {
 		lines = append(lines, "")

--- a/internal/cli/tui_view_hypothesis.go
+++ b/internal/cli/tui_view_hypothesis.go
@@ -324,6 +324,8 @@ func (v *hypothesisDetailView) renderLines(width int) ([]string, []hypDetailLink
 				extras = tuiDim.Render("  (downgraded from " + c.Strict.RequestedFrom + ")")
 			} else if c.Strict.RescuedBy != "" {
 				extras = tuiYellow.Render("  (rescued by " + c.Strict.RescuedBy + ")")
+			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
+				extras = tuiDim.Render("  (directional)")
 			}
 			lines = append(lines, fmt.Sprintf("  %s  %s  delta_frac=%.4f  p=%.4g%s",
 				c.ID, tuiVerdictBadge(c.Verdict), c.Effect.DeltaFrac, c.Effect.PValue, extras))

--- a/internal/entity/conclusion.go
+++ b/internal/entity/conclusion.go
@@ -71,7 +71,12 @@ type Strict struct {
 	Passed        bool     `yaml:"passed"                    json:"passed"`
 	RequestedFrom string   `yaml:"downgraded_from,omitempty" json:"downgraded_from,omitempty"`
 	RescuedBy     string   `yaml:"rescued_by,omitempty"      json:"rescued_by,omitempty"`
-	Reasons       []string `yaml:"reasons,omitempty"         json:"reasons,omitempty"`
+	// Directional is true when the hypothesis predicted a direction
+	// with MinEffect == 0 (no magnitude commitment). A directional
+	// "supported" verdict must be rendered distinctly so readers don't
+	// mistake a tiny clean win for a quantitative result.
+	Directional bool     `yaml:"directional,omitempty"     json:"directional,omitempty"`
+	Reasons     []string `yaml:"reasons,omitempty"         json:"reasons,omitempty"`
 }
 
 func ParseConclusion(data []byte) (*Conclusion, error) {

--- a/internal/entity/hypothesis.go
+++ b/internal/entity/hypothesis.go
@@ -32,6 +32,17 @@ type Hypothesis struct {
 	Body       string    `yaml:"-"                     json:"body,omitempty"`
 }
 
+// Predicts is what a hypothesis claims will happen to one instrument.
+// A positive MinEffect commits to a magnitude: "supported" requires the
+// 95% CI to be clean on the predicted side AND |delta_frac| >= MinEffect.
+// A zero MinEffect marks the hypothesis as *directional*: the agent
+// claims only that the instrument will move in Direction, with no
+// magnitude commitment. The CI-clean-side check still runs — a neutral
+// result still downgrades — but any clean-CI effect in the predicted
+// direction is "supported." Use directional when no prior evidence
+// (lesson, literature, back-of-envelope calc) grounds a specific
+// threshold; follow up with a quantitative hypothesis once the first
+// measurement gives you one.
 type Predicts struct {
 	Instrument string  `yaml:"instrument" json:"instrument"`
 	Target     string  `yaml:"target"     json:"target"`

--- a/internal/firewall/validators.go
+++ b/internal/firewall/validators.go
@@ -127,8 +127,8 @@ func validateGoalRescuers(g *entity.Goal, cfg *store.Config) error {
 		default:
 			return fmt.Errorf("rescuer[%d] direction must be 'increase' or 'decrease', got %q", i, r.Direction)
 		}
-		if r.MinEffect <= 0 {
-			return fmt.Errorf("rescuer[%d] min_effect must be > 0 (rescue is still a scientific claim and needs a quantitative threshold)", i)
+		if r.MinEffect < 0 {
+			return fmt.Errorf("rescuer[%d] min_effect must be >= 0 (use 0 for a directional rescuer — any clean-CI effect in the predicted direction rescues; use a positive value when you have prior evidence for a quantitative threshold)", i)
 		}
 	}
 	return nil
@@ -904,8 +904,8 @@ func ValidateHypothesis(h *entity.Hypothesis, cfg *store.Config) error {
 	default:
 		return fmt.Errorf("predicts direction must be 'increase' or 'decrease', got %q", h.Predicts.Direction)
 	}
-	if h.Predicts.MinEffect <= 0 {
-		return errors.New("predicts min_effect must be > 0 (a falsifiable hypothesis needs a quantitative threshold)")
+	if h.Predicts.MinEffect < 0 {
+		return errors.New("predicts min_effect must be >= 0 (use 0 for a directional hypothesis — predicts direction only, with no minimum magnitude; use a positive value when you have prior evidence to ground a quantitative threshold)")
 	}
 	for i, lid := range h.InspiredBy {
 		if !strings.HasPrefix(lid, "L-") {

--- a/internal/firewall/validators_test.go
+++ b/internal/firewall/validators_test.go
@@ -230,6 +230,62 @@ func TestValidateHypothesis_Happy(t *testing.T) {
 	}
 }
 
+func TestValidateHypothesis_DirectionalAccepted(t *testing.T) {
+	// min_effect=0 is the directional opt-in; no magnitude commitment.
+	h := &entity.Hypothesis{
+		Claim: "unrolling the hot loop will reduce cycles",
+		Predicts: entity.Predicts{
+			Instrument: "qemu_cycles", Target: "dsp_fir_bench", Direction: "decrease", MinEffect: 0,
+		},
+		KillIf: []string{"ci upper bound >= 0"},
+	}
+	if err := firewall.ValidateHypothesis(h, cfgWith("qemu_cycles")); err != nil {
+		t.Errorf("directional hypothesis (min_effect=0) should validate, got %v", err)
+	}
+}
+
+func TestValidateHypothesis_NegativeMinEffectRejected(t *testing.T) {
+	h := &entity.Hypothesis{
+		Claim: "x",
+		Predicts: entity.Predicts{
+			Instrument: "qemu_cycles", Target: "y", Direction: "decrease", MinEffect: -0.01,
+		},
+		KillIf: []string{"..."},
+	}
+	err := firewall.ValidateHypothesis(h, cfgWith("qemu_cycles"))
+	if err == nil || !strings.Contains(err.Error(), ">= 0") {
+		t.Errorf("negative min_effect should be rejected, got %v", err)
+	}
+}
+
+func TestCheckStrictVerdict_Directional(t *testing.T) {
+	// min_effect=0: only the CI-clean-side gate applies. A tiny but
+	// cleanly-signed effect that would fail the magnitude gate with a
+	// positive min_effect should pass cleanly here.
+	h := &entity.Hypothesis{Predicts: entity.Predicts{
+		Direction: "decrease", MinEffect: 0,
+	}}
+	tiny := &stats.Comparison{
+		NBaseline: 10, NCandidate: 10,
+		DeltaFrac: -0.003, CILowFrac: -0.005, CIHighFrac: -0.001,
+	}
+	d := firewall.CheckStrictVerdict(entity.VerdictSupported, h, tiny)
+	if !d.Passed || d.Downgraded {
+		t.Fatalf("directional hypothesis with clean CI should pass, got %+v", d)
+	}
+
+	// CI still must be clean: a directional hypothesis with CI straddling
+	// zero still downgrades. The scientific discipline survives.
+	neutral := &stats.Comparison{
+		NBaseline: 10, NCandidate: 10,
+		DeltaFrac: -0.003, CILowFrac: -0.010, CIHighFrac: 0.005,
+	}
+	d = firewall.CheckStrictVerdict(entity.VerdictSupported, h, neutral)
+	if d.Passed || !d.Downgraded {
+		t.Fatalf("directional with CI straddling zero should still downgrade, got %+v", d)
+	}
+}
+
 func TestCheckHypothesisInstrumentWithinGoal(t *testing.T) {
 	max := 65536.0
 	goal := &entity.Goal{
@@ -831,6 +887,25 @@ func TestValidateGoalRescuers(t *testing.T) {
 		g.Rescuers = []entity.Rescuer{{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0.02}}
 		if err := firewall.ValidateGoal(g, cfg); err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("directional rescuer (min_effect=0) is accepted", func(t *testing.T) {
+		g := baseGoal()
+		g.NeutralBandFrac = 0.02
+		g.Rescuers = []entity.Rescuer{{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: 0}}
+		if err := firewall.ValidateGoal(g, cfg); err != nil {
+			t.Fatalf("directional rescuer should validate, got %v", err)
+		}
+	})
+
+	t.Run("negative rescuer min_effect rejected", func(t *testing.T) {
+		g := baseGoal()
+		g.NeutralBandFrac = 0.02
+		g.Rescuers = []entity.Rescuer{{Instrument: "sim_total_bytes", Direction: "decrease", MinEffect: -0.01}}
+		err := firewall.ValidateGoal(g, cfg)
+		if err == nil || !strings.Contains(err.Error(), ">= 0") {
+			t.Fatalf("negative rescuer min_effect should be rejected, got %v", err)
 		}
 	})
 }

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -145,7 +145,16 @@ Choose whether to:
 
 When proposing, each hypothesis MUST be:
 
-- **Falsifiable** — a specific numerical threshold, not "I think X helps."
+- **Falsifiable** — a clean CI on the predicted side is the minimum bar.
+  You can predict either a **magnitude** (`--predicts-min-effect 0.05` —
+  "decreases by at least 5%") or a **direction only**
+  (`--predicts-min-effect 0` — "decreases, by some amount").  Do NOT
+  fabricate a magnitude when you have no evidence for it: if you don't
+  have a lesson, a literature number, or a back-of-envelope calculation,
+  propose a directional hypothesis. A directional supported is weaker
+  evidence than a quantitative one, and downstream hypotheses should
+  refine it into a quantitative claim once the first measurement gives
+  you a grounded magnitude.
 - **Instrument-backed** — `predicts.instrument` must exist in the registry and
   must be the active goal's objective instrument, one of its explicit
   constraint instruments, or one of its declared rescuer instruments.
@@ -305,8 +314,10 @@ Read the `comparison` object: `delta_frac`, `ci_low_frac`,
 `ci_high_frac`, `p_value`. Then decide:
 
 - **supported** — CI sits entirely on the predicted side AND
-  `|delta_frac| >= min_effect`. If either is missing, don't request
-  supported — the firewall will downgrade you.
+  `|delta_frac| >= min_effect`. For a directional hypothesis
+  (`min_effect == 0`), any clean-CI effect in the predicted direction
+  counts — the magnitude gate is skipped. If either bar is missed,
+  don't request supported — the firewall will downgrade you.
 - **refuted** — a `kill_if` clause is clearly satisfied, or the CI is
   cleanly on the wrong side.
 - **inconclusive** — everything else.

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -380,6 +380,15 @@ fix the input instead.
   ` + "`inconclusive`" + ` if:
     - the 95% CI on the fractional effect crosses zero in the wrong direction, OR
     - ` + "`|delta_frac| < hypothesis.predicts.min_effect`" + `.
+  A hypothesis with ` + "`predicts.min_effect == 0`" + ` is **directional**: the
+  magnitude gate is skipped and any clean-CI effect in the predicted
+  direction counts as supported. Directional is the right choice when
+  no prior evidence (lesson, literature, back-of-envelope) grounds a
+  quantitative threshold; a directional supported is weaker evidence
+  than a quantitative one and a follow-up hypothesis should refine it
+  into a quantitative claim once the magnitude is known. Directional
+  conclusions carry ` + "`strict.directional: true`" + ` and render as
+  ` + "`supported (directional)`" + ` in list / show / TUI / report.
   Every downgrade is recorded in the conclusion's ` + "`strict_check`" + ` block and
   in ` + "`events.jsonl`" + ` as a ` + "`conclusion.downgrade`" + ` event. The conclusion still
   persists; the hypothesis moves to ` + "`inconclusive`" + `.


### PR DESCRIPTION
## Summary

A hypothesis with `predicts.min_effect: 0` is now **directional** — predicts direction only, with no magnitude commitment. The CI-clean-side gate still runs (a neutral result still downgrades), but the magnitude check is skipped. Same relaxation on goal rescuer clauses.

Directional conclusions carry `strict.directional: true` and render as `supported (directional)` in list / show / TUI / report so a tiny clean win cannot be mistaken for a quantitative result.

### Why

Agents were fabricating `min_effect` numbers when they had no prior evidence (lessons, literature, back-of-envelope) to ground a threshold. *"Unroll the loop will reduce cycles by at least 5%"* isn't a stronger claim than *"unroll the loop will reduce cycles"* when the 5% is invented — it just gates real-but-smaller effects out of existence. Directional is the right shape for first-cycle exploratory claims; follow-up hypotheses refine into quantitative claims once a real magnitude is measured.

### Design choice (from #29 options)

Option 1: **`min_effect: 0` is the directional opt-in.** Minimal surface-area change, no new schema fields, no migration. Overloading the zero value is acknowledged; the renderer annotation (`strict.directional: true`) makes the intent explicit in the audit trail.

### Stacked on #28

This PR targets `issue-27-goal-rescuers` because it relaxes rescuer-clause validation in the same pass (`rescuer.min_effect >= 0`) and shares the strict-verdict plumbing. Once #28 merges, retarget to master.

### Not in scope (see #29 for the full list)

- `lesson accuracy` handling of directional predictions (the lesson entity has its own `PredictedEffect` with min/max; classification for `min_effect: 0` can be a small follow-up).
- Changing the default from quantitative to directional (philosophical, separate conversation).
- Required rationale when dropping `min_effect` (option 4 in the issue).

## Test plan

- [x] `make test` — all existing tests pass
- [x] `make vet` clean
- [x] New firewall coverage:
  - `ValidateHypothesis` accepts `min_effect: 0`
  - `ValidateHypothesis` rejects negative `min_effect` with `>= 0` message
  - `CheckStrictVerdict` passes a tiny clean-CI effect when `min_effect: 0`
  - `CheckStrictVerdict` still downgrades when CI straddles zero even with `min_effect: 0`
  - `ValidateGoal` accepts a rescuer with `min_effect: 0`
  - `ValidateGoal` rejects a rescuer with negative `min_effect`
- [x] Manual: `autoresearch hypothesis add --help` shows the updated `--predicts-min-effect` copy explaining directional

🤖 Generated with [Claude Code](https://claude.com/claude-code)