### PR TITLE
readmodel: decouple read-side projections from CLI surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,11 @@ get a new file plus an entry in the `groups` slice in `Root()`.
   store and return `ErrPaused` (exit 3) when paused. Read-only verbs
   (`status`, `log`, `tree`, `frontier`, `report`, `artifact <read>`,
   `conclusion show`, `dashboard`, `*-list`, `*-show`) work even when paused.
+- **Read models live in `internal/readmodel/`.** `experiment list/show`,
+  `frontier`, `status`, `dashboard`, and the TUI consume shared read-side
+  projections from there. Don't re-encode "live/dead", frontier, or
+  actionability rules per CLI surface. Read-time `dead` means "not
+  loop-actionable now", not "historically irrelevant".
 - **Output.** Every verb supports `--json`. Use the `output` package; don't
   hand-roll JSON. Text output is for humans; JSON is the agent contract and
   must stay stable across patches.
@@ -285,6 +290,12 @@ poll loop. Views exclusively handle `storeChangedMsg`.
 - **New entity field.** Update `internal/entity/`, the markdown
   serialization in `internal/store/`, any validators in `internal/firewall/`,
   and the report renderer.
+- **Changing read-side semantics.** If you change `experiment list`,
+  `frontier`, `status`, `dashboard`, or TUI behavior, update the shared
+  projection in `internal/readmodel/` and add at least one scenario-style CLI
+  test that drives a real lifecycle end to end and asserts multiple read
+  surfaces together. Narrow unit tests are still useful, but they are not
+  sufficient on their own for these contracts.
 - **Touching statistics.** Keep the seeded PRNG. Reproducibility of CIs
   across runs is part of the contract — agents diff `analyze` output.
 

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -227,6 +227,22 @@ unmodified code and serve as comparators for hypothesis-bound experiments.
 lost, the retry history is auditable. A baseline experiment follows the
 same status progression but carries `IsBaseline=true`.
 
+### Read-side experiment classification
+
+Read surfaces derive a second, non-persisted experiment label from the parent
+hypothesis status. This does not replace `Experiment.Status`; it is a
+read-time projection used by `experiment list`, `experiment show`,
+`frontier`, `status`, `dashboard`, and the TUI.
+
+| Classification | Derived when | Meaning |
+| --- | --- | --- |
+| `live` | The experiment has no parent hypothesis, or the parent hypothesis is still loop-actionable. | The loop may still steer from this work. |
+| `dead` | The parent hypothesis is `unreviewed`, `supported`, `refuted`, or `killed`. | The work remains historically real, but it is no longer actionable for further steering. |
+
+This label is intentionally about actionability, not historical relevance. A
+baseline or an accepted winning experiment may still be important to derived
+views even when later rendered as `dead`.
+
 ---
 
 ## Observation
@@ -349,6 +365,24 @@ a clean primary win. The frontier's sort uses rescuers as a bounded
 tiebreak when primary values are within `NeutralBandFrac`: a rescued
 candidate whose rescuer wins displaces the prior best at the same
 primary tier.
+
+### Derived frontier snapshot
+
+`frontier` is not a stored entity. It is a read projection over supported
+conclusions, observations, goal policy, and the read-side experiment
+classification above.
+
+- Frontier rows may still point at experiments classified `dead`. That label
+  controls current loop actionability and rendering; it does not invalidate a
+  historically best result.
+- `goal_assessment.met` is about the best accepted supported conclusion that
+  still satisfies the goal's constraints and threshold. A reviewed win still
+  counts after acceptance moves its hypothesis to `supported` and the
+  experiment becomes read-classified `dead`.
+- `stalled_for` counts conclusions written since the last conclusion that
+  actually improved the frontier. Once a frontier exists, every later
+  non-improving conclusion increments the counter, even if that conclusion is
+  inconclusive or otherwise non-actionable.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The core nouns are:
 | **Observation** | The recorded result of running one instrument on one experiment: value, samples, CI, pass/fail, command, artifacts, and metadata. | This is the evidence layer. Conclusions may cite observations, not anecdotes. |
 | **Conclusion** | A verdict over a hypothesis, derived from observations and compared against the goal baseline. | Records whether the evidence actually supports, refutes, or fails to decide the claim. |
 | **Lesson** | A reusable takeaway extracted from prior work, either tied to a hypothesis chain or scoped to the system as a whole. | Prevents later cycles from rediscovering the same dead ends or overestimating future gains. |
-| **Frontier** | A derived view of the best supported conclusions for the current goal. | Shows whether the search is still improving or has stalled. |
+| **Frontier** | A derived view of the best supported conclusions for the current goal, annotated for current loop actionability. | Shows whether the search is still improving or has stalled without hiding historically important wins. |
 | **Instrument** | A command plus parser that turns program behavior into a number or pass/fail result. | Makes optimization targets measurable and repeatable. |
 | **Artifact** | Content-addressed captured output attached to an observation. | Preserves the exact evidence a reviewer or human needs to audit a measurement. |
 
@@ -419,6 +419,14 @@ When `stale_experiment_minutes` is configured (via `budget set`), both
 `status` and `dashboard` flag experiments idle beyond the threshold — a
 signal that a coder helper may have crashed or the orchestrator got
 distracted.
+
+Read surfaces such as `experiment list`, `frontier`, `dashboard`, and
+`dashboard tui` also derive a `live` / `dead` label for experiments and
+frontier rows. `dead` means "not actionable for steering right now"; it does
+not mean the result stopped mattering. A historically best accepted win can
+still appear on the frontier as `dead`, can still satisfy the goal threshold,
+and later non-improving conclusions still advance the reported stall count
+until a new frontier improvement appears.
 
 ### `dashboard tui`
 

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/stats"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
@@ -138,7 +139,7 @@ downgraded since there is no comparator).`,
 			goal, goalErr := s.ActiveGoal()
 			if goalErr == nil {
 				concls, _ := s.ListConclusions()
-				frontierRows, _ := computeFrontier(s, goal, concls)
+				frontierRows, _ := readmodel.ComputeFrontier(s, goal, concls)
 				if len(frontierRows) > 0 {
 					best := frontierRows[0].Candidate
 					// Only compute incremental if it differs from the absolute baseline.

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -221,12 +221,6 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		return nil, err
 	}
 
-	if snap.Goal != nil {
-		rows, stalled := readmodel.ComputeFrontier(s, snap.Goal, concls)
-		snap.Frontier = rows
-		snap.StalledFor = stalled
-	}
-
 	// Load events once — used for both in-flight timestamps and the
 	// recent-events panel (avoids N+1 full reads of events.jsonl).
 	allEvents, err := s.Events(0)
@@ -246,10 +240,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	if err != nil {
 		return nil, err
 	}
-	expClassByID, err := readmodel.ClassifyExperimentsForRead(s, exps)
-	if err != nil {
-		return nil, err
-	}
+	expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(exps, hyps)
 	staleThreshold := time.Duration(0)
 	if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
 		staleThreshold = time.Duration(staleMinutes) * time.Minute
@@ -263,6 +254,12 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	allObs, err = resolver.filterObservations(allObs)
 	if err != nil {
 		return nil, err
+	}
+
+	if snap.Goal != nil {
+		frontier := readmodel.BuildFrontierSnapshot(snap.Goal, concls, readmodel.GroupObservationsByExperiment(allObs), expClassByID)
+		snap.Frontier = frontier.Rows
+		snap.StalledFor = frontier.StalledFor
 	}
 
 	var lessonCount int
@@ -304,10 +301,8 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		}
 	}
 
-	// Derive counts from already-loaded data instead of calling Counts()
-	// which re-scans every entity directory. Only observations need a
-	// targeted ReadDir because they're loaded inside computeFrontier, not
-	// directly available here.
+	// Derive counts from already-loaded scoped slices instead of calling
+	// Counts(), which would re-scan every entity directory.
 	snap.Counts = readmodel.BuildCountsWithLessons(len(hyps), len(exps), len(allObs), len(concls), lessonCount)
 
 	snap.RecentEvents, _ = readDashboardRecentEvents(allEvents, 0, dashboardRecentEventsSummaryLimit)

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -100,23 +100,23 @@ output (recommended under ` + "`watch -c autoresearch dashboard`" + `).`,
 // ---- snapshot capture ----
 
 type dashboardSnapshot struct {
-	Project                string              `json:"project"`
-	ScopeGoalID            string              `json:"scope_goal_id,omitempty"`
-	ScopeAll               bool                `json:"scope_all"`
-	Paused                 bool                `json:"paused"`
-	PauseReason            string              `json:"pause_reason,omitempty"`
-	Mode                   string              `json:"mode"`
-	MainCheckoutDirty      bool                `json:"main_checkout_dirty"`
-	MainCheckoutDirtyPaths []string            `json:"main_checkout_dirty_paths"`
-	Goal                   *entity.Goal        `json:"goal,omitempty"`
-	Budgets                dashboardBudgets    `json:"budgets"`
-	Counts                 map[string]int      `json:"counts"`
-	Tree                   []*treeNode         `json:"tree"`
-	Frontier               []frontierRow       `json:"frontier"`
-	StalledFor             int                 `json:"stalled_for"`
-	InFlight               []dashboardInFlight `json:"in_flight"`
-	StaleExperiments       []dashboardStaleExp `json:"stale_experiments,omitempty"`
-	RecentLessons          []*entity.Lesson    `json:"recent_lessons,omitempty"`
+	Project                string                `json:"project"`
+	ScopeGoalID            string                `json:"scope_goal_id,omitempty"`
+	ScopeAll               bool                  `json:"scope_all"`
+	Paused                 bool                  `json:"paused"`
+	PauseReason            string                `json:"pause_reason,omitempty"`
+	Mode                   string                `json:"mode"`
+	MainCheckoutDirty      bool                  `json:"main_checkout_dirty"`
+	MainCheckoutDirtyPaths []string              `json:"main_checkout_dirty_paths"`
+	Goal                   *entity.Goal          `json:"goal,omitempty"`
+	Budgets                dashboardBudgets      `json:"budgets"`
+	Counts                 map[string]int        `json:"counts"`
+	Tree                   []*treeNode           `json:"tree"`
+	Frontier               []frontierRow         `json:"frontier"`
+	StalledFor             int                   `json:"stalled_for"`
+	InFlight               []dashboardInFlight   `json:"in_flight"`
+	StaleExperiments       []staleExperimentView `json:"stale_experiments,omitempty"`
+	RecentLessons          []*entity.Lesson      `json:"recent_lessons,omitempty"`
 	recentLessonAccuracy   map[string]lessonAccuracySummary
 	RecentEvents           []store.Event `json:"recent_events"`
 	CapturedAt             time.Time     `json:"captured_at"`
@@ -141,14 +141,6 @@ type dashboardInFlight struct {
 	Instruments   []string   `json:"instruments"`
 	ImplementedAt *time.Time `json:"implemented_at,omitempty"`
 	ElapsedS      float64    `json:"elapsed_s"`
-}
-
-type dashboardStaleExp struct {
-	ID            string  `json:"id"`
-	Hypothesis    string  `json:"hypothesis"`
-	Status        string  `json:"status"`
-	LastEventKind string  `json:"last_event_kind"`
-	StaleMinutes  float64 `json:"stale_minutes"`
 }
 
 const dashboardRecentEventsSummaryLimit = 10
@@ -287,7 +279,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		if len(e.ReferencedAsBaselineBy) > 0 {
 			continue
 		}
-		if expClassByID[e.ID].Classification == experimentClassificationDead {
+		if !experimentReadClassForID(expClassByID, e.ID).loopActionable() {
 			continue
 		}
 		row := dashboardInFlight{
@@ -316,35 +308,11 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		return a.After(*b)
 	})
 
-	// Stale experiment detection: flag non-terminal, non-baseline experiments
-	// whose last event is older than the configured threshold.
+	// Stale experiment detection: flag loop-actionable, non-baseline
+	// experiments whose last event is older than the configured threshold.
 	if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
 		threshold := time.Duration(staleMinutes) * time.Minute
-		now := time.Now().UTC()
-		for _, e := range exps {
-			switch e.Status {
-			case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
-			default:
-				continue
-			}
-			if e.IsBaseline {
-				continue
-			}
-			ts, kind := findLastEventForExperiment(allEvents, e.ID)
-			if ts == nil {
-				continue
-			}
-			age := now.Sub(*ts)
-			if age >= threshold {
-				snap.StaleExperiments = append(snap.StaleExperiments, dashboardStaleExp{
-					ID:            e.ID,
-					Hypothesis:    e.Hypothesis,
-					Status:        e.Status,
-					LastEventKind: kind,
-					StaleMinutes:  age.Minutes(),
-				})
-			}
-		}
+		snap.StaleExperiments = findStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
 	}
 
 	allObs, err := s.ListObservations()

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -123,17 +123,7 @@ type dashboardSnapshot struct {
 	CapturedAt             time.Time     `json:"captured_at"`
 }
 
-type dashboardBudgets struct {
-	Limits struct {
-		MaxExperiments int `json:"max_experiments"`
-		MaxWallTimeH   int `json:"max_wall_time_h"`
-		FrontierStallK int `json:"frontier_stall_k"`
-	} `json:"limits"`
-	Usage struct {
-		Experiments int     `json:"experiments"`
-		ElapsedH    float64 `json:"elapsed_h"`
-	} `json:"usage"`
-}
+type dashboardBudgets = readmodel.BudgetSnapshot
 
 type dashboardInFlight = readmodel.InFlightExperimentView
 
@@ -209,13 +199,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		}
 	}
 
-	snap.Budgets.Limits.MaxExperiments = cfg.Budgets.MaxExperiments
-	snap.Budgets.Limits.MaxWallTimeH = cfg.Budgets.MaxWallTimeH
-	snap.Budgets.Limits.FrontierStallK = cfg.Budgets.FrontierStallK
-	snap.Budgets.Usage.Experiments = st.Counters["E"]
-	if st.ResearchStartedAt != nil {
-		snap.Budgets.Usage.ElapsedH = time.Since(*st.ResearchStartedAt).Hours()
-	}
+	snap.Budgets = readmodel.BuildBudgetSnapshot(cfg, st, snap.CapturedAt)
 
 	resolver := newGoalScopeResolver(s, scope)
 
@@ -324,13 +308,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	// which re-scans every entity directory. Only observations need a
 	// targeted ReadDir because they're loaded inside computeFrontier, not
 	// directly available here.
-	snap.Counts = map[string]int{
-		"hypotheses":   len(hyps),
-		"experiments":  len(exps),
-		"observations": len(allObs),
-		"conclusions":  len(concls),
-		"lessons":      lessonCount,
-	}
+	snap.Counts = readmodel.BuildCountsWithLessons(len(hyps), len(exps), len(allObs), len(concls), lessonCount)
 
 	snap.RecentEvents, _ = readDashboardRecentEvents(allEvents, 0, dashboardRecentEventsSummaryLimit)
 

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -245,7 +245,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	}
 
 	if snap.Goal != nil {
-		rows, stalled := computeFrontier(s, snap.Goal, concls)
+		rows, stalled := readmodel.ComputeFrontier(s, snap.Goal, concls)
 		snap.Frontier = rows
 		snap.StalledFor = stalled
 	}
@@ -269,7 +269,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	if err != nil {
 		return nil, err
 	}
-	expClassByID, err := classifyExperimentsForRead(s, exps)
+	expClassByID, err := readmodel.ClassifyExperimentsForRead(s, exps)
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +280,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		if len(e.ReferencedAsBaselineBy) > 0 {
 			continue
 		}
-		if !experimentReadClassForID(expClassByID, e.ID).LoopActionable() {
+		if !readmodel.ExperimentReadClassForID(expClassByID, e.ID).LoopActionable() {
 			continue
 		}
 		row := dashboardInFlight{
@@ -289,7 +289,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 			Status:      e.Status,
 			Instruments: append([]string{}, e.Instruments...),
 		}
-		if ts, kind := findLastEventForExperiment(allEvents, e.ID); ts != nil && kind == "experiment.implement" {
+		if ts, kind := readmodel.FindLastEventForExperiment(allEvents, e.ID); ts != nil && kind == "experiment.implement" {
 			row.ImplementedAt = ts
 			row.ElapsedS = time.Since(*ts).Seconds()
 		}
@@ -313,7 +313,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	// experiments whose last event is older than the configured threshold.
 	if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
 		threshold := time.Duration(staleMinutes) * time.Minute
-		snap.StaleExperiments = findStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
+		snap.StaleExperiments = readmodel.FindStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
 	}
 
 	allObs, err := s.ListObservations()
@@ -379,12 +379,6 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	snap.RecentEvents, _ = readDashboardRecentEvents(allEvents, 0, dashboardRecentEventsSummaryLimit)
 
 	return snap, nil
-}
-
-// findLastEventForExperiment scans a pre-loaded event list backward for the
-// most recent event referencing expID and returns its timestamp and kind.
-func findLastEventForExperiment(events []store.Event, expID string) (ts *time.Time, kind string) {
-	return readmodel.FindLastEventForExperiment(events, expID)
 }
 
 // ---- one-shot + refresh loop ----

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -135,14 +135,7 @@ type dashboardBudgets struct {
 	} `json:"usage"`
 }
 
-type dashboardInFlight struct {
-	ID            string     `json:"id"`
-	Hypothesis    string     `json:"hypothesis"`
-	Status        string     `json:"status"`
-	Instruments   []string   `json:"instruments"`
-	ImplementedAt *time.Time `json:"implemented_at,omitempty"`
-	ElapsedS      float64    `json:"elapsed_s"`
-}
+type dashboardInFlight = readmodel.InFlightExperimentView
 
 const dashboardRecentEventsSummaryLimit = 10
 
@@ -273,48 +266,11 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	if err != nil {
 		return nil, err
 	}
-	for _, e := range exps {
-		if e.Status != entity.ExpImplemented && e.Status != entity.ExpMeasured {
-			continue
-		}
-		if len(e.ReferencedAsBaselineBy) > 0 {
-			continue
-		}
-		if !readmodel.ExperimentReadClassForID(expClassByID, e.ID).LoopActionable() {
-			continue
-		}
-		row := dashboardInFlight{
-			ID:          e.ID,
-			Hypothesis:  e.Hypothesis,
-			Status:      e.Status,
-			Instruments: append([]string{}, e.Instruments...),
-		}
-		if ts, kind := readmodel.FindLastEventForExperiment(allEvents, e.ID); ts != nil && kind == "experiment.implement" {
-			row.ImplementedAt = ts
-			row.ElapsedS = time.Since(*ts).Seconds()
-		}
-		snap.InFlight = append(snap.InFlight, row)
-	}
-	sort.SliceStable(snap.InFlight, func(i, j int) bool {
-		a, b := snap.InFlight[i].ImplementedAt, snap.InFlight[j].ImplementedAt
-		if a == nil && b == nil {
-			return snap.InFlight[i].ID < snap.InFlight[j].ID
-		}
-		if a == nil {
-			return false
-		}
-		if b == nil {
-			return true
-		}
-		return a.After(*b)
-	})
-
-	// Stale experiment detection: flag loop-actionable, non-baseline
-	// experiments whose last event is older than the configured threshold.
+	staleThreshold := time.Duration(0)
 	if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
-		threshold := time.Duration(staleMinutes) * time.Minute
-		snap.StaleExperiments = readmodel.FindStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
+		staleThreshold = time.Duration(staleMinutes) * time.Minute
 	}
+	snap.InFlight, snap.StaleExperiments = readmodel.BuildExperimentActivity(exps, expClassByID, allEvents, staleThreshold, snap.CapturedAt)
 
 	allObs, err := s.ListObservations()
 	if err != nil {

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -279,7 +280,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 		if len(e.ReferencedAsBaselineBy) > 0 {
 			continue
 		}
-		if !experimentReadClassForID(expClassByID, e.ID).loopActionable() {
+		if !experimentReadClassForID(expClassByID, e.ID).LoopActionable() {
 			continue
 		}
 		row := dashboardInFlight{
@@ -383,14 +384,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 // findLastEventForExperiment scans a pre-loaded event list backward for the
 // most recent event referencing expID and returns its timestamp and kind.
 func findLastEventForExperiment(events []store.Event, expID string) (ts *time.Time, kind string) {
-	for i := len(events) - 1; i >= 0; i-- {
-		e := events[i]
-		if e.Subject == expID {
-			t := e.Ts
-			return &t, e.Kind
-		}
-	}
-	return nil, ""
+	return readmodel.FindLastEventForExperiment(events, expID)
 }
 
 // ---- one-shot + refresh loop ----

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -132,10 +132,110 @@ func TestCaptureDashboard_InFlightExcludesDeadExperiments(t *testing.T) {
 		ids[r.ID] = true
 	}
 	if ids["E-0001"] {
-		t.Error("E-0001 belongs to a terminal hypothesis and should not appear in-flight")
+		t.Error("E-0001 belongs to a non-actionable hypothesis and should not appear in-flight")
 	}
 	if !ids["E-0002"] {
 		t.Error("E-0002 belongs to an open hypothesis and should appear in-flight")
+	}
+}
+
+func TestCaptureDashboard_StaleExperimentsExcludeNonActionableWork(t *testing.T) {
+	s := newStoreWithBuiltins(t)
+	now := time.Now().UTC()
+
+	if err := s.UpdateConfig(func(cfg *store.Config) error {
+		cfg.Budgets.StaleExperimentMinutes = 5
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, h := range []*entity.Hypothesis{
+		{
+			ID: "H-0001", GoalID: "G-0001", Claim: "supported and done",
+			Predicts: entity.Predicts{Instrument: "host_timing", Target: "fir", Direction: "decrease"},
+			KillIf:   []string{"tests fail"}, Status: entity.StatusSupported, Author: "human", CreatedAt: now,
+		},
+		{
+			ID: "H-0002", GoalID: "G-0001", Claim: "awaiting review",
+			Predicts: entity.Predicts{Instrument: "host_timing", Target: "fir", Direction: "decrease"},
+			KillIf:   []string{"tests fail"}, Status: entity.StatusUnreviewed, Author: "human", CreatedAt: now,
+		},
+		{
+			ID: "H-0003", GoalID: "G-0001", Claim: "still live",
+			Predicts: entity.Predicts{Instrument: "host_timing", Target: "fir", Direction: "decrease"},
+			KillIf:   []string{"tests fail"}, Status: entity.StatusOpen, Author: "human", CreatedAt: now,
+		},
+	} {
+		if err := s.WriteHypothesis(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, e := range []*entity.Experiment{
+		{
+			ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured,
+			Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"host_timing"},
+			Author: "agent:designer", CreatedAt: now,
+		},
+		{
+			ID: "E-0002", Hypothesis: "H-0002", Status: entity.ExpMeasured,
+			Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"host_timing"},
+			Author: "agent:designer", CreatedAt: now,
+		},
+		{
+			ID: "E-0003", Hypothesis: "H-0003", Status: entity.ExpMeasured,
+			Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"host_timing"},
+			Author: "agent:designer", CreatedAt: now,
+		},
+	} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	staleAt := now.Add(-10 * time.Minute)
+	for _, expID := range []string{"E-0001", "E-0002", "E-0003"} {
+		if err := s.AppendEvent(store.Event{
+			Ts:      staleAt,
+			Kind:    "experiment.measure",
+			Subject: expID,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	snap, err := captureDashboard(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inFlightIDs := make(map[string]bool, len(snap.InFlight))
+	for _, row := range snap.InFlight {
+		inFlightIDs[row.ID] = true
+	}
+	if inFlightIDs["E-0001"] {
+		t.Error("E-0001 should not appear in-flight once its hypothesis is supported")
+	}
+	if inFlightIDs["E-0002"] {
+		t.Error("E-0002 should not appear in-flight while its decisive conclusion is awaiting review")
+	}
+	if !inFlightIDs["E-0003"] {
+		t.Error("E-0003 should remain in-flight while its hypothesis is open")
+	}
+
+	staleIDs := make(map[string]bool, len(snap.StaleExperiments))
+	for _, row := range snap.StaleExperiments {
+		staleIDs[row.ID] = true
+	}
+	if staleIDs["E-0001"] {
+		t.Error("E-0001 should not appear as stale once its hypothesis is supported")
+	}
+	if staleIDs["E-0002"] {
+		t.Error("E-0002 should not appear as stale while its decisive conclusion is awaiting review")
+	}
+	if !staleIDs["E-0003"] {
+		t.Error("E-0003 should appear as stale while its hypothesis is still actionable")
 	}
 }
 

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/bytter/autoresearch/internal/worktree"
 	"github.com/spf13/cobra"
@@ -540,7 +541,7 @@ func experimentShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			view, err := readExperimentForRead(s, args[0])
+			view, err := readmodel.ReadExperimentForRead(s, args[0])
 			if err != nil {
 				return err
 			}

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -1,11 +1,9 @@
 package cli
 
 import (
-	"math"
-	"sort"
-
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
 )
@@ -223,373 +221,31 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 	w.Textln("")
 }
 
-type frontierRow struct {
-	Conclusion string  `json:"conclusion"`
-	Hypothesis string  `json:"hypothesis"`
-	Candidate  string  `json:"candidate_experiment"`
-	Value      float64 `json:"value"`
-	DeltaFrac  float64 `json:"delta_frac"`
-	// Classification is a read-time label for the candidate experiment.
-	// "dead" means the experiment's parent hypothesis is no longer
-	// loop-actionable for steering (terminal or decisive-but-unreviewed), so
-	// the row is still historically valid but no longer actionable work.
-	Classification string `json:"classification"`
-	// HypothesisStatus records the hypothesis status that caused
-	// Classification=dead. Kept separate from Hypothesis, which is the ID.
-	HypothesisStatus string `json:"hypothesis_status,omitempty"`
-	// RescuedBy is non-empty when the backing conclusion was supported via
-	// a goal rescuer rather than a clean primary win. Renderers display a
-	// "rescued by <instrument>" annotation so the reader cannot mistake a
-	// rescued row for a clean primary-metric improvement.
-	RescuedBy string `json:"rescued_by,omitempty"`
-	// TiebreakValues holds one candidate value per goal.Rescuers clause, in
-	// declared order. Used when two rows are within goal.NeutralBandFrac on
-	// primary — the sort then picks the row that wins on the first rescuer
-	// whose value differs. Absent rescuer data is represented as NaN so the
-	// tiebreak skips cleanly over it.
-	TiebreakValues []float64 `json:"-"`
-}
-
-type frontierGoalAssessment struct {
-	Mode              string  `json:"mode"`
-	Threshold         float64 `json:"threshold,omitempty"`
-	OnThreshold       string  `json:"on_threshold,omitempty"`
-	Met               bool    `json:"met"`
-	MetByConclusion   string  `json:"met_by_conclusion,omitempty"`
-	RecommendedAction string  `json:"recommended_action"`
-}
-
-type frontierCandidate struct {
-	Conclusion *entity.Conclusion
-	Value      float64
-}
+type frontierRow = readmodel.FrontierRow
+type frontierGoalAssessment = readmodel.FrontierGoalAssessment
 
 // computeFrontier returns rows in best-first order for the objective and the
 // count of conclusions written since the last frontier improvement.
 func computeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) (rows []frontierRow, stalledFor int) {
-	return computeFrontierFromObservations(goal, concls, loadObservationsByExperiment(s), loadExperimentReadClasses(s))
+	return readmodel.ComputeFrontier(s, goal, concls)
 }
 
 func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]experimentReadClass) (rows []frontierRow, stalledFor int) {
-	rows = []frontierRow{} // always non-nil so --json emits [] not null
-	requireByInst := frontierRequireConstraints(goal)
-
-	for _, c := range concls {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
-		if !ok {
-			continue
-		}
-		class := experimentReadClassForID(expClassByID, c.CandidateExp)
-		rows = append(rows, frontierRow{
-			Conclusion:       c.ID,
-			Hypothesis:       c.Hypothesis,
-			Candidate:        c.CandidateExp,
-			Value:            val,
-			DeltaFrac:        c.Effect.DeltaFrac,
-			Classification:   class.Classification,
-			HypothesisStatus: class.HypothesisStatus,
-			RescuedBy:        c.Strict.RescuedBy,
-			TiebreakValues:   rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
-		})
-	}
-	sort.Slice(rows, func(i, j int) bool {
-		return frontierRowBetter(goal, rows[i], rows[j])
-	})
-
-	sortedByTime := make([]*entity.Conclusion, len(concls))
-	copy(sortedByTime, concls)
-	sort.Slice(sortedByTime, func(i, j int) bool { return sortedByTime[i].CreatedAt.Before(sortedByTime[j].CreatedAt) })
-
-	hasBest := false
-	var bestRow frontierRow
-	for _, c := range sortedByTime {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
-		if !ok {
-			continue
-		}
-		if !experimentReadClassForID(expClassByID, c.CandidateExp).loopActionable() {
-			continue
-		}
-		cur := frontierRow{
-			Value:          val,
-			TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
-		}
-		if !hasBest {
-			hasBest = true
-			bestRow = cur
-			stalledFor = 0
-			continue
-		}
-		if frontierRowBetter(goal, cur, bestRow) {
-			bestRow = cur
-			stalledFor = 0
-		} else {
-			stalledFor++
-		}
-	}
-	return rows, stalledFor
+	return readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
 }
 
-// rescuerTiebreakValues extracts one candidate value per goal rescuer, in
-// declared order. Missing observations (the candidate wasn't measured on a
-// rescuer instrument) are represented as NaN so the tiebreak comparator can
-// skip them cleanly.
-func rescuerTiebreakValues(goal *entity.Goal, obs []*entity.Observation) []float64 {
-	if goal == nil || len(goal.Rescuers) == 0 {
-		return nil
-	}
-	out := make([]float64, len(goal.Rescuers))
-	for i, r := range goal.Rescuers {
-		v, ok := candidateObjectiveValue(obs, r.Instrument)
-		if !ok {
-			out[i] = math.NaN()
-			continue
-		}
-		out[i] = v
-	}
-	return out
-}
-
-// frontierRowBetter reports whether a is strictly better than b on the goal.
-// When the primary values are within goal.NeutralBandFrac of each other, the
-// comparison falls through to rescuers in goal-declared order; the first
-// rescuer whose value differs decides. This is a limited Pareto-tiebreak,
-// not a full multi-objective frontier.
 func frontierRowBetter(goal *entity.Goal, a, b frontierRow) bool {
-	if goal == nil {
-		return false
-	}
-	if !withinPrimaryNeutralBand(goal, a.Value, b.Value) {
-		return betterFrontierValue(goal.Objective.Direction, a.Value, b.Value)
-	}
-	for i, r := range goal.Rescuers {
-		if i >= len(a.TiebreakValues) || i >= len(b.TiebreakValues) {
-			continue
-		}
-		av, bv := a.TiebreakValues[i], b.TiebreakValues[i]
-		if math.IsNaN(av) || math.IsNaN(bv) {
-			continue
-		}
-		if av == bv {
-			continue
-		}
-		return betterFrontierValue(r.Direction, av, bv)
-	}
-	return false
-}
-
-// withinPrimaryNeutralBand reports whether two primary values are close
-// enough (relative to the larger magnitude) that the goal considers them
-// "tied" on the primary metric. Returns false whenever the goal doesn't
-// declare a neutral band, preserving v3-goal behaviour exactly.
-func withinPrimaryNeutralBand(goal *entity.Goal, a, b float64) bool {
-	if goal == nil || goal.NeutralBandFrac <= 0 {
-		return false
-	}
-	denom := math.Max(math.Max(math.Abs(a), math.Abs(b)), 1e-9)
-	return math.Abs(a-b)/denom <= goal.NeutralBandFrac
-}
-
-func frontierRequireConstraints(goal *entity.Goal) map[string]string {
-	requireByInst := map[string]string{}
-	if goal == nil {
-		return requireByInst
-	}
-	for _, c := range goal.Constraints {
-		if c.Require != "" {
-			requireByInst[c.Instrument] = c.Require
-		}
-	}
-	return requireByInst
-}
-
-func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string) (float64, bool) {
-	if goal == nil || c == nil {
-		return 0, false
-	}
-	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
-		return 0, false
-	}
-	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
-		return 0, false
-	}
-	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
-}
-
-func betterFrontierValue(direction string, candidate, incumbent float64) bool {
-	if direction == "decrease" {
-		return candidate < incumbent
-	}
-	return candidate > incumbent
+	return readmodel.FrontierRowBetter(goal, a, b)
 }
 
 func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]experimentReadClass) frontierGoalAssessment {
-	if goal == nil || goal.IsOpenEnded() {
-		return frontierGoalAssessment{
-			Mode:              "open_ended",
-			Met:               false,
-			RecommendedAction: "continue",
-		}
-	}
-
-	assessment := frontierGoalAssessment{
-		Mode:              "threshold",
-		Threshold:         goal.Completion.Threshold,
-		OnThreshold:       goal.EffectiveOnThreshold(),
-		Met:               false,
-		RecommendedAction: "continue",
-	}
-
-	var bestReviewed frontierCandidate
-	hasReviewed := false
-	for _, c := range concls {
-		if c == nil || c.ReviewedBy == "" {
-			continue
-		}
-		if !experimentReadClassForID(expClassByID, c.CandidateExp).loopActionable() {
-			continue
-		}
-		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
-			continue
-		}
-		obs := obsByExp[c.CandidateExp]
-		if !goalConstraintsSatisfied(obs, goal.Constraints) {
-			continue
-		}
-		val, ok := candidateObjectiveValue(obs, goal.Objective.Instrument)
-		if !ok {
-			continue
-		}
-		if !hasReviewed || betterFrontierValue(goal.Objective.Direction, val, bestReviewed.Value) {
-			bestReviewed = frontierCandidate{Conclusion: c, Value: val}
-			hasReviewed = true
-		}
-	}
-	if !hasReviewed {
-		return assessment
-	}
-	if meetsGoalThreshold(goal.Objective.Direction, bestReviewed.Conclusion.Effect.DeltaFrac, goal.Completion.Threshold) {
-		assessment.Met = true
-		assessment.MetByConclusion = bestReviewed.Conclusion.ID
-		switch assessment.OnThreshold {
-		case entity.GoalOnThresholdAskHuman:
-			assessment.RecommendedAction = "ask_human"
-		case entity.GoalOnThresholdStop:
-			assessment.RecommendedAction = "stop"
-		default:
-			assessment.RecommendedAction = "continue"
-		}
-	}
-	return assessment
+	return readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
 }
 
 func loadExperimentReadClasses(s *store.Store) map[string]experimentReadClass {
-	classByID, err := classifyAllExperimentsForRead(s)
-	if err != nil {
-		return nil
-	}
-	return classByID
+	return readmodel.LoadExperimentReadClasses(s)
 }
 
-func meetsGoalThreshold(direction string, deltaFrac, threshold float64) bool {
-	if threshold <= 0 {
-		return false
-	}
-	if direction == "decrease" {
-		return deltaFrac <= -threshold
-	}
-	return deltaFrac >= threshold
-}
-
-// loadObservationsByExperiment reads all observations once and returns them
-// indexed by experiment ID. A nil map (on read error) is safe — callers get
-// empty slices from the nil map.
 func loadObservationsByExperiment(s *store.Store) map[string][]*entity.Observation {
-	all, err := s.ListObservations()
-	if err != nil {
-		return nil
-	}
-	m := make(map[string][]*entity.Observation, len(all))
-	for _, o := range all {
-		m[o.Experiment] = append(m[o.Experiment], o)
-	}
-	return m
-}
-
-func requireSatisfied(obs []*entity.Observation, req map[string]string) bool {
-	if len(req) == 0 {
-		return true
-	}
-	for inst, wanted := range req {
-		ok := false
-		for _, o := range obs {
-			if o.Instrument != inst {
-				continue
-			}
-			switch wanted {
-			case "pass":
-				if o.Pass != nil && *o.Pass {
-					ok = true
-				}
-			default:
-				// For v1, any non-"pass" require is treated as pass-through;
-				// we document that require-clauses other than "pass" are
-				// not evaluated yet.
-				ok = true
-			}
-			if ok {
-				break
-			}
-		}
-		if !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func goalConstraintsSatisfied(obs []*entity.Observation, constraints []entity.Constraint) bool {
-	for _, c := range constraints {
-		if !goalConstraintSatisfied(obs, c) {
-			return false
-		}
-	}
-	return true
-}
-
-func goalConstraintSatisfied(obs []*entity.Observation, c entity.Constraint) bool {
-	for _, o := range obs {
-		if o.Instrument != c.Instrument {
-			continue
-		}
-		switch {
-		case c.Max != nil:
-			if o.Value <= *c.Max {
-				return true
-			}
-		case c.Min != nil:
-			if o.Value >= *c.Min {
-				return true
-			}
-		case c.Require != "":
-			switch c.Require {
-			case "pass":
-				if o.Pass != nil && *o.Pass {
-					return true
-				}
-			default:
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func candidateObjectiveValue(obs []*entity.Observation, instrument string) (float64, bool) {
-	for _, o := range obs {
-		if o.Instrument == instrument {
-			return o.Value, true
-		}
-	}
-	return 0, false
+	return readmodel.LoadObservationsByExperiment(s)
 }

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -130,8 +130,8 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 	if err != nil {
 		return nil, err
 	}
-	obsByExp := loadObservationsByExperiment(s)
-	expClassByID, err := classifyAllExperimentsForRead(s)
+	obsByExp := readmodel.LoadObservationsByExperiment(s)
+	expClassByID, err := readmodel.ClassifyAllExperimentsForRead(s)
 	if err != nil {
 		return nil, err
 	}
@@ -146,11 +146,11 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 			if err != nil {
 				return nil, err
 			}
-			rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+			rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
 			out = append(out, goalFrontier{
 				Goal:       goal,
 				Rows:       rows,
-				Assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
+				Assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
 				StalledFor: stalled,
 			})
 		}
@@ -164,11 +164,11 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 	if err != nil {
 		return nil, err
 	}
-	rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
 	return []goalFrontier{{
 		Goal:       goal,
 		Rows:       rows,
-		Assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
+		Assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
 		StalledFor: stalled,
 	}}, nil
 }
@@ -223,29 +223,3 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 
 type frontierRow = readmodel.FrontierRow
 type frontierGoalAssessment = readmodel.FrontierGoalAssessment
-
-// computeFrontier returns rows in best-first order for the objective and the
-// count of conclusions written since the last frontier improvement.
-func computeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) (rows []frontierRow, stalledFor int) {
-	return readmodel.ComputeFrontier(s, goal, concls)
-}
-
-func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]experimentReadClass) (rows []frontierRow, stalledFor int) {
-	return readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
-}
-
-func frontierRowBetter(goal *entity.Goal, a, b frontierRow) bool {
-	return readmodel.FrontierRowBetter(goal, a, b)
-}
-
-func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]experimentReadClass) frontierGoalAssessment {
-	return readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
-}
-
-func loadExperimentReadClasses(s *store.Store) map[string]experimentReadClass {
-	return readmodel.LoadExperimentReadClasses(s)
-}
-
-func loadObservationsByExperiment(s *store.Store) map[string][]*entity.Observation {
-	return readmodel.LoadObservationsByExperiment(s)
-}

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -146,12 +146,12 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 			if err != nil {
 				return nil, err
 			}
-			rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+			frontier := readmodel.BuildFrontierSnapshot(goal, concls, obsByExp, expClassByID)
 			out = append(out, goalFrontier{
 				Goal:       goal,
-				Rows:       rows,
-				Assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
-				StalledFor: stalled,
+				Rows:       frontier.Rows,
+				Assessment: frontier.Assessment,
+				StalledFor: frontier.StalledFor,
 			})
 		}
 		return out, nil
@@ -164,12 +164,12 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 	if err != nil {
 		return nil, err
 	}
-	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+	frontier := readmodel.BuildFrontierSnapshot(goal, concls, obsByExp, expClassByID)
 	return []goalFrontier{{
 		Goal:       goal,
-		Rows:       rows,
-		Assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
-		StalledFor: stalled,
+		Rows:       frontier.Rows,
+		Assessment: frontier.Assessment,
+		StalledFor: frontier.StalledFor,
 	}}, nil
 }
 

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -152,7 +152,7 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 			out = append(out, goalFrontier{
 				Goal:       goal,
 				Rows:       rows,
-				Assessment: assessGoalCompletion(goal, concls, obsByExp),
+				Assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
 				StalledFor: stalled,
 			})
 		}
@@ -170,7 +170,7 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 	return []goalFrontier{{
 		Goal:       goal,
 		Rows:       rows,
-		Assessment: assessGoalCompletion(goal, concls, obsByExp),
+		Assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
 		StalledFor: stalled,
 	}}, nil
 }
@@ -230,10 +230,11 @@ type frontierRow struct {
 	Value      float64 `json:"value"`
 	DeltaFrac  float64 `json:"delta_frac"`
 	// Classification is a read-time label for the candidate experiment.
-	// "dead" means the experiment's parent hypothesis is already terminal,
-	// so the row is still historically valid but no longer actionable work.
+	// "dead" means the experiment's parent hypothesis is no longer
+	// loop-actionable for steering (terminal or decisive-but-unreviewed), so
+	// the row is still historically valid but no longer actionable work.
 	Classification string `json:"classification"`
-	// HypothesisStatus records the terminal hypothesis status that caused
+	// HypothesisStatus records the hypothesis status that caused
 	// Classification=dead. Kept separate from Hypothesis, which is the ID.
 	HypothesisStatus string `json:"hypothesis_status,omitempty"`
 	// RescuedBy is non-empty when the backing conclusion was supported via
@@ -278,10 +279,7 @@ func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 		if !ok {
 			continue
 		}
-		class := expClassByID[c.CandidateExp]
-		if class.Classification == "" {
-			class.Classification = experimentClassificationLive
-		}
+		class := experimentReadClassForID(expClassByID, c.CandidateExp)
 		rows = append(rows, frontierRow{
 			Conclusion:       c.ID,
 			Hypothesis:       c.Hypothesis,
@@ -307,9 +305,9 @@ func computeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	for _, c := range sortedByTime {
 		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
 		if !ok {
-			if hasBest {
-				stalledFor++
-			}
+			continue
+		}
+		if !experimentReadClassForID(expClassByID, c.CandidateExp).loopActionable() {
 			continue
 		}
 		cur := frontierRow{
@@ -425,7 +423,7 @@ func betterFrontierValue(direction string, candidate, incumbent float64) bool {
 	return candidate > incumbent
 }
 
-func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation) frontierGoalAssessment {
+func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]experimentReadClass) frontierGoalAssessment {
 	if goal == nil || goal.IsOpenEnded() {
 		return frontierGoalAssessment{
 			Mode:              "open_ended",
@@ -446,6 +444,9 @@ func assessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 	hasReviewed := false
 	for _, c := range concls {
 		if c == nil || c.ReviewedBy == "" {
+			continue
+		}
+		if !experimentReadClassForID(expClassByID, c.CandidateExp).loopActionable() {
 			continue
 		}
 		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -349,7 +349,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		}
 	})
 
-	t.Run("dead reviewed candidates do not satisfy threshold", func(t *testing.T) {
+	t.Run("accepted supported candidates still satisfy threshold after promotion", func(t *testing.T) {
 		goal := &entity.Goal{
 			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 			Completion: &entity.Completion{
@@ -373,11 +373,11 @@ func TestAssessGoalCompletion(t *testing.T) {
 		expClassByID := map[string]experimentReadClass{
 			"E-3000": {
 				Classification:   experimentClassificationDead,
-				HypothesisStatus: entity.StatusKilled,
+				HypothesisStatus: entity.StatusSupported,
 			},
 		}
 		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
-		if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
+		if !got.Met || got.MetByConclusion != "C-3000" || got.RecommendedAction != "stop" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
 	})
@@ -416,7 +416,7 @@ func TestComputeFrontierFromObservations_CarriesExperimentClassification(t *test
 	}
 }
 
-func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T) {
+func TestComputeFrontierFromObservations_StalledForCountsLaterConclusionsAfterAcceptedWin(t *testing.T) {
 	goal := &entity.Goal{
 		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 	}
@@ -433,7 +433,7 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		{
 			ID:           "C-0002",
 			Hypothesis:   "H-0002",
-			Verdict:      entity.VerdictSupported,
+			Verdict:      entity.VerdictInconclusive,
 			CandidateExp: "E-0002",
 			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.09},
 			CreatedAt:    base.Add(1 * time.Minute),
@@ -441,39 +441,30 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		{
 			ID:           "C-0003",
 			Hypothesis:   "H-0003",
-			Verdict:      entity.VerdictSupported,
+			Verdict:      entity.VerdictRefuted,
 			CandidateExp: "E-0003",
 			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
 			CreatedAt:    base.Add(2 * time.Minute),
-		},
-		{
-			ID:           "C-0004",
-			Hypothesis:   "H-0004",
-			Verdict:      entity.VerdictSupported,
-			CandidateExp: "E-0004",
-			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.08},
-			CreatedAt:    base.Add(3 * time.Minute),
 		},
 	}
 	obsByExp := map[string][]*entity.Observation{
 		"E-0001": {{Instrument: "host_timing", Value: 100}},
 		"E-0002": {{Instrument: "host_timing", Value: 101}},
 		"E-0003": {{Instrument: "host_timing", Value: 90}},
-		"E-0004": {{Instrument: "host_timing", Value: 102}},
 	}
 	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
-		"E-0003": {
+		"E-0001": {
 			Classification:   experimentClassificationDead,
-			HypothesisStatus: entity.StatusRefuted,
+			HypothesisStatus: entity.StatusSupported,
 		},
 	})
 	if got, want := stalled, 2; got != want {
 		t.Fatalf("stalled_for = %d, want %d", got, want)
 	}
-	if got, want := len(rows), 4; got != want {
+	if got, want := len(rows), 1; got != want {
 		t.Fatalf("rows len = %d, want %d", got, want)
 	}
-	if got, want := rows[0].Candidate, "E-0003"; got != want {
+	if got, want := rows[0].Candidate, "E-0001"; got != want {
 		t.Fatalf("best row candidate = %q, want %q", got, want)
 	}
 	if got, want := rows[0].Classification, experimentClassificationDead; got != want {

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 )
 
 func TestBuildGoalFromFlags_DefaultsThresholdPolicy(t *testing.T) {
@@ -129,16 +130,16 @@ func TestFrontierRowBetter_RescuerTiebreak(t *testing.T) {
 	// Same primary value, but a has smaller size → a should win.
 	a := frontierRow{Value: 100.0, TiebreakValues: []float64{512}}
 	b := frontierRow{Value: 100.5, TiebreakValues: []float64{600}} // within 1% band
-	if !frontierRowBetter(goal, a, b) {
+	if !readmodel.FrontierRowBetter(goal, a, b) {
 		t.Errorf("a should beat b via rescuer tiebreak")
 	}
-	if frontierRowBetter(goal, b, a) {
+	if readmodel.FrontierRowBetter(goal, b, a) {
 		t.Errorf("b should not beat a")
 	}
 	// If primary gap exceeds neutral band, primary wins regardless of size.
 	c := frontierRow{Value: 80.0, TiebreakValues: []float64{9999}}
 	d := frontierRow{Value: 100.0, TiebreakValues: []float64{10}}
-	if !frontierRowBetter(goal, c, d) {
+	if !readmodel.FrontierRowBetter(goal, c, d) {
 		t.Errorf("primary-dominant candidate should win over size-dominant one when outside the neutral band")
 	}
 }
@@ -148,7 +149,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		goal := &entity.Goal{
 			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 		}
-		got := assessGoalCompletion(goal, nil, nil, nil)
+		got := readmodel.AssessGoalCompletion(goal, nil, nil, nil)
 		if got.Mode != "open_ended" || got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -175,7 +176,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-0001": {{Instrument: "host_timing", Value: 0.75}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0001" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -211,7 +212,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-0001": {{Instrument: "host_timing", Value: 0.70}},
 			"E-0002": {{Instrument: "host_timing", Value: 0.82}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -279,7 +280,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 				{Instrument: "host_test", Pass: &pass},
 			},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0102" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -306,7 +307,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-1000": {{Instrument: "throughput", Value: 112}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -342,7 +343,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-2000": {{Instrument: "host_timing", Value: 0.70}},
 			"E-2001": {{Instrument: "host_timing", Value: 0.70}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
 		if got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -375,7 +376,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 				HypothesisStatus: entity.StatusKilled,
 			},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp, expClassByID)
+		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
 		if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -398,7 +399,7 @@ func TestComputeFrontierFromObservations_CarriesExperimentClassification(t *test
 	obsByExp := map[string][]*entity.Observation{
 		"E-0001": {{Instrument: "host_timing", Value: 0.75}},
 	}
-	rows, _ := computeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
+	rows, _ := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
 		"E-0001": {
 			Classification:   experimentClassificationDead,
 			HypothesisStatus: entity.StatusSupported,
@@ -460,7 +461,7 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		"E-0003": {{Instrument: "host_timing", Value: 90}},
 		"E-0004": {{Instrument: "host_timing", Value: 102}},
 	}
-	rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
+	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
 		"E-0003": {
 			Classification:   experimentClassificationDead,
 			HypothesisStatus: entity.StatusRefuted,

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"testing"
+	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
 )
@@ -147,7 +148,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		goal := &entity.Goal{
 			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 		}
-		got := assessGoalCompletion(goal, nil, nil)
+		got := assessGoalCompletion(goal, nil, nil, nil)
 		if got.Mode != "open_ended" || got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -174,7 +175,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-0001": {{Instrument: "host_timing", Value: 0.75}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp)
+		got := assessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0001" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -210,7 +211,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-0001": {{Instrument: "host_timing", Value: 0.70}},
 			"E-0002": {{Instrument: "host_timing", Value: 0.82}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp)
+		got := assessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -278,7 +279,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 				{Instrument: "host_test", Pass: &pass},
 			},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp)
+		got := assessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.MetByConclusion != "C-0102" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -305,7 +306,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-1000": {{Instrument: "throughput", Value: 112}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp)
+		got := assessGoalCompletion(goal, concls, obsByExp, nil)
 		if !got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -341,8 +342,41 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-2000": {{Instrument: "host_timing", Value: 0.70}},
 			"E-2001": {{Instrument: "host_timing", Value: 0.70}},
 		}
-		got := assessGoalCompletion(goal, concls, obsByExp)
+		got := assessGoalCompletion(goal, concls, obsByExp, nil)
 		if got.Met || got.RecommendedAction != "continue" {
+			t.Fatalf("unexpected assessment: %+v", got)
+		}
+	})
+
+	t.Run("dead reviewed candidates do not satisfy threshold", func(t *testing.T) {
+		goal := &entity.Goal{
+			Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+			Completion: &entity.Completion{
+				Threshold:   0.2,
+				OnThreshold: entity.GoalOnThresholdStop,
+			},
+		}
+		concls := []*entity.Conclusion{
+			{
+				ID:           "C-3000",
+				Hypothesis:   "H-3000",
+				Verdict:      entity.VerdictSupported,
+				ReviewedBy:   "agent:gate",
+				CandidateExp: "E-3000",
+				Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.3},
+			},
+		}
+		obsByExp := map[string][]*entity.Observation{
+			"E-3000": {{Instrument: "host_timing", Value: 0.70}},
+		}
+		expClassByID := map[string]experimentReadClass{
+			"E-3000": {
+				Classification:   experimentClassificationDead,
+				HypothesisStatus: entity.StatusKilled,
+			},
+		}
+		got := assessGoalCompletion(goal, concls, obsByExp, expClassByID)
+		if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
 	})
@@ -378,5 +412,70 @@ func TestComputeFrontierFromObservations_CarriesExperimentClassification(t *test
 	}
 	if got, want := rows[0].HypothesisStatus, entity.StatusSupported; got != want {
 		t.Fatalf("row hypothesis_status = %q, want %q", got, want)
+	}
+}
+
+func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	base := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0001",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.10},
+			CreatedAt:    base,
+		},
+		{
+			ID:           "C-0002",
+			Hypothesis:   "H-0002",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0002",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.09},
+			CreatedAt:    base.Add(1 * time.Minute),
+		},
+		{
+			ID:           "C-0003",
+			Hypothesis:   "H-0003",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0003",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
+			CreatedAt:    base.Add(2 * time.Minute),
+		},
+		{
+			ID:           "C-0004",
+			Hypothesis:   "H-0004",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0004",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.08},
+			CreatedAt:    base.Add(3 * time.Minute),
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-0001": {{Instrument: "host_timing", Value: 100}},
+		"E-0002": {{Instrument: "host_timing", Value: 101}},
+		"E-0003": {{Instrument: "host_timing", Value: 90}},
+		"E-0004": {{Instrument: "host_timing", Value: 102}},
+	}
+	rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
+		"E-0003": {
+			Classification:   experimentClassificationDead,
+			HypothesisStatus: entity.StatusRefuted,
+		},
+	})
+	if got, want := stalled, 2; got != want {
+		t.Fatalf("stalled_for = %d, want %d", got, want)
+	}
+	if got, want := len(rows), 4; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := rows[0].Candidate, "E-0003"; got != want {
+		t.Fatalf("best row candidate = %q, want %q", got, want)
+	}
+	if got, want := rows[0].Classification, experimentClassificationDead; got != want {
+		t.Fatalf("best row classification = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -470,46 +470,21 @@ func statusCmd() *cobra.Command {
 				"main_checkout_dirty_paths": mainCheckout.Paths,
 			}, scope)
 
-			// Stale experiment detection.
-			type staleExp struct {
-				ID            string  `json:"id"`
-				Hypothesis    string  `json:"hypothesis"`
-				Status        string  `json:"status"`
-				LastEventKind string  `json:"last_event_kind"`
-				StaleMinutes  float64 `json:"stale_minutes"`
-			}
-			var stale []staleExp
+			// Stale experiment detection: reuse the same read-side
+			// actionability policy as dashboard/frontier instead of open-coding
+			// another "live enough to steer from" definition here.
+			var stale []staleExperimentView
 			if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
 				allEvents, err := s.Events(0)
 				if err != nil {
 					return err
 				}
-				threshold := time.Duration(staleMinutes) * time.Minute
-				now := time.Now().UTC()
-				for _, e := range exps {
-					switch e.Status {
-					case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
-					default:
-						continue
-					}
-					if e.IsBaseline {
-						continue
-					}
-					ts, kind := findLastEventForExperiment(allEvents, e.ID)
-					if ts == nil {
-						continue
-					}
-					age := now.Sub(*ts)
-					if age >= threshold {
-						stale = append(stale, staleExp{
-							ID:            e.ID,
-							Hypothesis:    e.Hypothesis,
-							Status:        e.Status,
-							LastEventKind: kind,
-							StaleMinutes:  age.Minutes(),
-						})
-					}
+				expClassByID, err := classifyExperimentsForRead(s, exps)
+				if err != nil {
+					return err
 				}
+				threshold := time.Duration(staleMinutes) * time.Minute
+				stale = findStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
 			}
 			if len(stale) > 0 {
 				payload["stale_experiments"] = stale

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -484,8 +484,9 @@ func statusCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
+				now := time.Now().UTC()
 				threshold := time.Duration(staleMinutes) * time.Minute
-				stale = readmodel.FindStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
+				_, stale = readmodel.BuildExperimentActivity(exps, expClassByID, allEvents, threshold, now)
 			}
 			if len(stale) > 0 {
 				payload["stale_experiments"] = stale

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -474,10 +474,7 @@ func statusCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				expClassByID, err := readmodel.ClassifyExperimentsForRead(s, exps)
-				if err != nil {
-					return err
-				}
+				expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(exps, hyps)
 				now := time.Now().UTC()
 				threshold := time.Duration(staleMinutes) * time.Minute
 				_, stale = readmodel.BuildExperimentActivity(exps, expClassByID, allEvents, threshold, now)

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"sort"
 	"strings"
 	"time"
 
@@ -451,12 +450,7 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			counts := map[string]int{
-				"hypotheses":   len(hyps),
-				"experiments":  len(exps),
-				"observations": len(obs),
-				"conclusions":  len(concls),
-			}
+			counts := readmodel.BuildCounts(len(hyps), len(exps), len(obs), len(concls))
 
 			payload := mergeGoalScopePayload(map[string]any{
 				"root":                      s.Root(),
@@ -499,17 +493,7 @@ func statusCmd() *cobra.Command {
 			var unobservedInstruments []string
 			if !scope.All && scope.GoalID != "" {
 				if goal, err := s.ReadGoal(scope.GoalID); err == nil {
-					needed := map[string]bool{goal.Objective.Instrument: true}
-					for _, c := range goal.Constraints {
-						needed[c.Instrument] = true
-					}
-					for _, o := range obs {
-						delete(needed, o.Instrument)
-					}
-					for inst := range needed {
-						unobservedInstruments = append(unobservedInstruments, inst)
-					}
-					sort.Strings(unobservedInstruments)
+					unobservedInstruments = readmodel.FindUnobservedGoalInstruments(goal, obs)
 				}
 			}
 			if len(unobservedInstruments) > 0 {

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/integration"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/bytter/autoresearch/internal/worktree"
 	"github.com/spf13/cobra"
@@ -479,12 +480,12 @@ func statusCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				expClassByID, err := classifyExperimentsForRead(s, exps)
+				expClassByID, err := readmodel.ClassifyExperimentsForRead(s, exps)
 				if err != nil {
 					return err
 				}
 				threshold := time.Duration(staleMinutes) * time.Minute
-				stale = findStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
+				stale = readmodel.FindStaleExperimentsForRead(exps, expClassByID, allEvents, threshold, time.Now().UTC())
 			}
 			if len(stale) > 0 {
 				payload["stale_experiments"] = stale

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -1,0 +1,401 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type cliIDResponse struct {
+	ID string `json:"id"`
+}
+
+type cliImplementResponse struct {
+	ID       string `json:"id"`
+	Worktree string `json:"worktree"`
+	Branch   string `json:"branch"`
+}
+
+type cliObserveAllResponse struct {
+	Results []struct {
+		ID   string `json:"id"`
+		Inst string `json:"instrument"`
+	} `json:"results"`
+}
+
+type cliAnalyzeResponse struct {
+	Rows []struct {
+		Instrument string `json:"instrument"`
+		Comparison *struct {
+			DeltaFrac float64 `json:"delta_frac"`
+		} `json:"comparison,omitempty"`
+	} `json:"rows"`
+}
+
+type cliExperimentListRow struct {
+	ID               string `json:"id"`
+	Classification   string `json:"classification"`
+	HypothesisStatus string `json:"hypothesis_status,omitempty"`
+}
+
+type cliFrontierResponse struct {
+	ScopeGoalID    string `json:"scope_goal_id,omitempty"`
+	GoalID         string `json:"goal_id"`
+	StalledFor     int    `json:"stalled_for"`
+	GoalAssessment struct {
+		Met             bool   `json:"met"`
+		MetByConclusion string `json:"met_by_conclusion,omitempty"`
+	} `json:"goal_assessment"`
+	Frontier []struct {
+		Conclusion       string `json:"conclusion"`
+		Candidate        string `json:"candidate_experiment"`
+		Classification   string `json:"classification"`
+		HypothesisStatus string `json:"hypothesis_status,omitempty"`
+	} `json:"frontier"`
+}
+
+type cliDashboardResponse struct {
+	ScopeGoalID string         `json:"scope_goal_id,omitempty"`
+	StalledFor  int            `json:"stalled_for"`
+	Counts      map[string]int `json:"counts"`
+	Frontier    []struct {
+		Conclusion       string `json:"conclusion"`
+		Candidate        string `json:"candidate_experiment"`
+		Classification   string `json:"classification"`
+		HypothesisStatus string `json:"hypothesis_status,omitempty"`
+	} `json:"frontier"`
+}
+
+type cliStatusResponse struct {
+	ScopeGoalID       string         `json:"scope_goal_id,omitempty"`
+	MainCheckoutDirty bool           `json:"main_checkout_dirty"`
+	Counts            map[string]int `json:"counts"`
+}
+
+func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterStall(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	goal := runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--success-threshold", "0.1",
+		"--on-success", "stop",
+		"--constraint-max", "binary_size=1000",
+		"--constraint-require", "host_test=pass",
+	)
+	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+
+	hyp1 := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp1 := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp1.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl1 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp1.ID)
+	writeScenarioMetrics(t, impl1.Worktree, "80\n", "900\n")
+	gitCommitAll(t, impl1.Worktree, "improve timing")
+
+	obs1 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp1.ID, "--all")
+	analyze1 := runCLIJSON[cliAnalyzeResponse](t, dir, "analyze", exp1.ID, "--baseline", baseline.ID)
+	if got, want := len(analyze1.Rows), 3; got != want {
+		t.Fatalf("analyze rows len = %d, want %d", got, want)
+	}
+	if got := analyzeComparisonDeltaFrac(t, analyze1, "timing"); got >= 0 {
+		t.Fatalf("timing delta_frac = %v, want negative improvement", got)
+	}
+	concl1 := runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp1.ID,
+		"--verdict", "supported",
+		"--baseline-experiment", baseline.ID,
+		"--observations", observeResultID(t, obs1, "timing"),
+	)
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclusion", "accept", concl1.ID,
+		"--reviewed-by", "human:gate",
+		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
+	)
+
+	hyp2 := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "a smaller tweak might still help",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.05",
+		"--kill-if", "tests fail",
+	)
+	exp2 := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp2.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp2.ID)
+	writeScenarioMetrics(t, impl2.Worktree, "95\n", "900\n")
+	gitCommitAll(t, impl2.Worktree, "small tweak")
+
+	obs2 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp2.ID, "--all")
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp2.ID,
+		"--verdict", "inconclusive",
+		"--baseline-experiment", baseline.ID,
+		"--observations", observeResultID(t, obs2, "timing"),
+	)
+
+	dead := runCLIJSON[[]cliExperimentListRow](t, dir, "experiment", "list", "--goal", goal.ID, "--classification", experimentClassificationDead)
+	if got, want := len(dead), 1; got != want {
+		t.Fatalf("dead experiment list len = %d, want %d", got, want)
+	}
+	if dead[0].ID != exp1.ID || dead[0].HypothesisStatus != "supported" {
+		t.Fatalf("unexpected dead experiment row: %+v", dead[0])
+	}
+
+	frontier := runCLIJSON[cliFrontierResponse](t, dir, "frontier", "--goal", goal.ID)
+	if frontier.ScopeGoalID != goal.ID || frontier.GoalID != goal.ID {
+		t.Fatalf("frontier goal scope mismatch: %+v", frontier)
+	}
+	if !frontier.GoalAssessment.Met || frontier.GoalAssessment.MetByConclusion != concl1.ID {
+		t.Fatalf("unexpected frontier goal_assessment: %+v", frontier.GoalAssessment)
+	}
+	if got, want := frontier.StalledFor, 1; got != want {
+		t.Fatalf("frontier stalled_for = %d, want %d", got, want)
+	}
+	if got, want := len(frontier.Frontier), 1; got != want {
+		t.Fatalf("frontier rows len = %d, want %d", got, want)
+	}
+	if frontier.Frontier[0].Candidate != exp1.ID ||
+		frontier.Frontier[0].Conclusion != concl1.ID ||
+		frontier.Frontier[0].Classification != experimentClassificationDead ||
+		frontier.Frontier[0].HypothesisStatus != "supported" {
+		t.Fatalf("unexpected frontier row: %+v", frontier.Frontier[0])
+	}
+
+	dashboard := runCLIJSON[cliDashboardResponse](t, dir, "dashboard", "--goal", goal.ID)
+	if dashboard.ScopeGoalID != goal.ID {
+		t.Fatalf("dashboard scope_goal_id = %q, want %q", dashboard.ScopeGoalID, goal.ID)
+	}
+	if got, want := dashboard.StalledFor, frontier.StalledFor; got != want {
+		t.Fatalf("dashboard stalled_for = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["hypotheses"], 2; got != want {
+		t.Fatalf("dashboard counts[hypotheses] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["experiments"], 3; got != want {
+		t.Fatalf("dashboard counts[experiments] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["observations"], 9; got != want {
+		t.Fatalf("dashboard counts[observations] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["conclusions"], 2; got != want {
+		t.Fatalf("dashboard counts[conclusions] = %d, want %d", got, want)
+	}
+	if got, want := len(dashboard.Frontier), 1; got != want {
+		t.Fatalf("dashboard frontier len = %d, want %d", got, want)
+	}
+	if dashboard.Frontier[0].Candidate != exp1.ID ||
+		dashboard.Frontier[0].Conclusion != concl1.ID ||
+		dashboard.Frontier[0].Classification != experimentClassificationDead {
+		t.Fatalf("unexpected dashboard frontier row: %+v", dashboard.Frontier[0])
+	}
+
+	status := runCLIJSON[cliStatusResponse](t, dir, "status", "--goal", goal.ID)
+	if status.ScopeGoalID != goal.ID {
+		t.Fatalf("status scope_goal_id = %q, want %q", status.ScopeGoalID, goal.ID)
+	}
+	if status.MainCheckoutDirty {
+		t.Fatalf("status reported dirty main checkout for clean scenario")
+	}
+	if got, want := status.Counts["hypotheses"], 2; got != want {
+		t.Fatalf("status counts[hypotheses] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["experiments"], 3; got != want {
+		t.Fatalf("status counts[experiments] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["observations"], 9; got != want {
+		t.Fatalf("status counts[observations] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["conclusions"], 2; got != want {
+		t.Fatalf("status counts[conclusions] = %d, want %d", got, want)
+	}
+}
+
+func registerScenarioInstruments(t *testing.T, dir string) {
+	t.Helper()
+	runCLI(t, dir,
+		"instrument", "register", "timing",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "cat timing.txt",
+		"--parser", "builtin:scalar",
+		"--pattern", "([0-9]+)",
+		"--unit", "ns",
+	)
+	runCLI(t, dir,
+		"instrument", "register", "binary_size",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "cat size.txt",
+		"--parser", "builtin:scalar",
+		"--pattern", "([0-9]+)",
+		"--unit", "bytes",
+	)
+	runCLI(t, dir,
+		"instrument", "register", "host_test",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "test -f PASS",
+		"--parser", "builtin:passfail",
+		"--unit", "bool",
+	)
+}
+
+func gitInitScenarioRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		gitRun(t, dir, args...)
+	}
+	writeScenarioMetrics(t, dir, "100\n", "900\n")
+	if err := os.WriteFile(filepath.Join(dir, "PASS"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("write PASS: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("baseline\n"), 0o644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	gitRun(t, dir, "add", "timing.txt", "size.txt", "PASS", "README.md")
+	gitRun(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func writeScenarioMetrics(t *testing.T, dir, timing, size string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "timing.txt"), []byte(timing), 0o644); err != nil {
+		t.Fatalf("write timing.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "size.txt"), []byte(size), 0o644); err != nil {
+		t.Fatalf("write size.txt: %v", err)
+	}
+}
+
+func gitCommitAll(t *testing.T, dir, msg string) {
+	t.Helper()
+	gitRun(t, dir, "add", "timing.txt", "size.txt")
+	gitRun(t, dir, "commit", "-m", msg)
+}
+
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func runCLI(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	outCh := make(chan string, 1)
+	errCh := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(rOut)
+		outCh <- string(data)
+	}()
+	go func() {
+		data, _ := io.ReadAll(rErr)
+		errCh <- string(data)
+	}()
+
+	os.Stdout = wOut
+	os.Stderr = wErr
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	root := Root()
+	root.SetArgs(append([]string{"-C", dir}, args...))
+	execErr := root.Execute()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	stdout := <-outCh
+	stderr := <-errCh
+	if execErr != nil {
+		t.Fatalf("autoresearch %s: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), execErr, stdout, stderr)
+	}
+	return stdout
+}
+
+func runCLIJSON[T any](t *testing.T, dir string, args ...string) T {
+	t.Helper()
+	out := runCLI(t, dir, append([]string{"--json"}, args...)...)
+	var got T
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("decode JSON for %q: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return got
+}
+
+func observeResultID(t *testing.T, resp cliObserveAllResponse, inst string) string {
+	t.Helper()
+	for _, r := range resp.Results {
+		if r.Inst == inst {
+			return r.ID
+		}
+	}
+	t.Fatalf("observe result for %q not found in %+v", inst, resp.Results)
+	return ""
+}
+
+func analyzeComparisonDeltaFrac(t *testing.T, resp cliAnalyzeResponse, inst string) float64 {
+	t.Helper()
+	for _, row := range resp.Rows {
+		if row.Instrument == inst {
+			if row.Comparison == nil {
+				t.Fatalf("analyze row %q missing comparison", inst)
+			}
+			return row.Comparison.DeltaFrac
+		}
+	}
+	t.Fatalf("analyze row %q not found", inst)
+	return 0
+}

--- a/internal/cli/read_classification.go
+++ b/internal/cli/read_classification.go
@@ -2,9 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 )
@@ -18,26 +16,6 @@ type experimentReadClass = readmodel.ExperimentReadClass
 type experimentReadView = readmodel.ExperimentReadView
 type staleExperimentView = readmodel.StaleExperimentView
 
-func experimentReadClassForID(classByID map[string]experimentReadClass, expID string) experimentReadClass {
-	return readmodel.ExperimentReadClassForID(classByID, expID)
-}
-
-func classifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]experimentReadClass, error) {
-	return readmodel.ClassifyExperimentsForRead(s, exps)
-}
-
-func annotateExperimentsForRead(s *store.Store, exps []*entity.Experiment) ([]*experimentReadView, error) {
-	return readmodel.AnnotateExperimentsForRead(s, exps)
-}
-
-func annotateExperimentForRead(s *store.Store, e *entity.Experiment) (*experimentReadView, error) {
-	return readmodel.AnnotateExperimentForRead(s, e)
-}
-
-func readExperimentForRead(s *store.Store, id string) (*experimentReadView, error) {
-	return readmodel.ReadExperimentForRead(s, id)
-}
-
 func listScopedExperimentsForRead(s *store.Store, scope goalScope) ([]*experimentReadView, error) {
 	list, err := s.ListExperiments()
 	if err == nil {
@@ -46,7 +24,7 @@ func listScopedExperimentsForRead(s *store.Store, scope goalScope) ([]*experimen
 	if err != nil {
 		return nil, err
 	}
-	return annotateExperimentsForRead(s, list)
+	return readmodel.AnnotateExperimentsForRead(s, list)
 }
 
 func listExperimentsForHypothesisForRead(s *store.Store, hypID string) ([]*experimentReadView, error) {
@@ -54,15 +32,7 @@ func listExperimentsForHypothesisForRead(s *store.Store, hypID string) ([]*exper
 	if err != nil {
 		return nil, err
 	}
-	return annotateExperimentsForRead(s, list)
-}
-
-func classifyAllExperimentsForRead(s *store.Store) (map[string]experimentReadClass, error) {
-	return readmodel.ClassifyAllExperimentsForRead(s)
-}
-
-func classifyHypothesisStatusForExperimentRead(status string) experimentReadClass {
-	return readmodel.ClassifyHypothesisStatusForExperimentRead(status)
+	return readmodel.AnnotateExperimentsForRead(s, list)
 }
 
 func validateExperimentClassificationFilter(classification string) error {
@@ -92,8 +62,4 @@ func experimentClassificationMarker(classification string) string {
 		return "[dead]"
 	}
 	return ""
-}
-
-func findStaleExperimentsForRead(exps []*entity.Experiment, classByID map[string]experimentReadClass, events []store.Event, threshold time.Duration, now time.Time) []staleExperimentView {
-	return readmodel.FindStaleExperimentsForRead(exps, classByID, events, threshold, now)
 }

--- a/internal/cli/read_classification.go
+++ b/internal/cli/read_classification.go
@@ -5,112 +5,37 @@ import (
 	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 )
 
 const (
-	experimentClassificationLive = "live"
-	experimentClassificationDead = "dead"
+	experimentClassificationLive = readmodel.ExperimentClassificationLive
+	experimentClassificationDead = readmodel.ExperimentClassificationDead
 )
 
-type experimentReadClass struct {
-	Classification   string `json:"classification"`
-	HypothesisStatus string `json:"hypothesis_status,omitempty"`
-}
-
-type experimentReadView struct {
-	*entity.Experiment
-	Classification   string `json:"classification"`
-	HypothesisStatus string `json:"hypothesis_status,omitempty"`
-}
-
-type staleExperimentView struct {
-	ID            string  `json:"id"`
-	Hypothesis    string  `json:"hypothesis"`
-	Status        string  `json:"status"`
-	LastEventKind string  `json:"last_event_kind"`
-	StaleMinutes  float64 `json:"stale_minutes"`
-}
-
-func normalizeExperimentReadClass(class experimentReadClass) experimentReadClass {
-	if class.Classification == "" {
-		class.Classification = experimentClassificationLive
-	}
-	return class
-}
-
-// loopActionable reports whether the research loop should still steer from
-// this experiment's current hypothesis state. This is intentionally broader
-// than gc's "terminal" notion: decisive-but-unreviewed hypotheses are also
-// non-actionable for further loop steering even though they are not yet safe
-// to reclaim.
-func (class experimentReadClass) loopActionable() bool {
-	return normalizeExperimentReadClass(class).Classification == experimentClassificationLive
-}
+type experimentReadClass = readmodel.ExperimentReadClass
+type experimentReadView = readmodel.ExperimentReadView
+type staleExperimentView = readmodel.StaleExperimentView
 
 func experimentReadClassForID(classByID map[string]experimentReadClass, expID string) experimentReadClass {
-	return normalizeExperimentReadClass(classByID[expID])
+	return readmodel.ExperimentReadClassForID(classByID, expID)
 }
 
 func classifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]experimentReadClass, error) {
-	hyps, err := s.ListHypotheses()
-	if err != nil {
-		return nil, err
-	}
-	hypStatus := make(map[string]string, len(hyps))
-	for _, h := range hyps {
-		if h == nil {
-			continue
-		}
-		hypStatus[h.ID] = h.Status
-	}
-	out := make(map[string]experimentReadClass, len(exps))
-	for _, e := range exps {
-		if e == nil {
-			continue
-		}
-		out[e.ID] = classifyExperimentForRead(e, hypStatus)
-	}
-	return out, nil
+	return readmodel.ClassifyExperimentsForRead(s, exps)
 }
 
 func annotateExperimentsForRead(s *store.Store, exps []*entity.Experiment) ([]*experimentReadView, error) {
-	classByID, err := classifyExperimentsForRead(s, exps)
-	if err != nil {
-		return nil, err
-	}
-	out := make([]*experimentReadView, 0, len(exps))
-	for _, e := range exps {
-		if e == nil {
-			continue
-		}
-		class := normalizeExperimentReadClass(classByID[e.ID])
-		out = append(out, &experimentReadView{
-			Experiment:       e,
-			Classification:   class.Classification,
-			HypothesisStatus: class.HypothesisStatus,
-		})
-	}
-	return out, nil
+	return readmodel.AnnotateExperimentsForRead(s, exps)
 }
 
 func annotateExperimentForRead(s *store.Store, e *entity.Experiment) (*experimentReadView, error) {
-	views, err := annotateExperimentsForRead(s, []*entity.Experiment{e})
-	if err != nil {
-		return nil, err
-	}
-	if len(views) == 0 {
-		return nil, nil
-	}
-	return views[0], nil
+	return readmodel.AnnotateExperimentForRead(s, e)
 }
 
 func readExperimentForRead(s *store.Store, id string) (*experimentReadView, error) {
-	e, err := s.ReadExperiment(id)
-	if err != nil {
-		return nil, err
-	}
-	return annotateExperimentForRead(s, e)
+	return readmodel.ReadExperimentForRead(s, id)
 }
 
 func listScopedExperimentsForRead(s *store.Store, scope goalScope) ([]*experimentReadView, error) {
@@ -133,30 +58,11 @@ func listExperimentsForHypothesisForRead(s *store.Store, hypID string) ([]*exper
 }
 
 func classifyAllExperimentsForRead(s *store.Store) (map[string]experimentReadClass, error) {
-	exps, err := s.ListExperiments()
-	if err != nil {
-		return nil, err
-	}
-	return classifyExperimentsForRead(s, exps)
-}
-
-func classifyExperimentForRead(e *entity.Experiment, hypStatus map[string]string) experimentReadClass {
-	if e == nil {
-		return normalizeExperimentReadClass(experimentReadClass{})
-	}
-	return classifyHypothesisStatusForExperimentRead(hypStatus[e.Hypothesis])
+	return readmodel.ClassifyAllExperimentsForRead(s)
 }
 
 func classifyHypothesisStatusForExperimentRead(status string) experimentReadClass {
-	switch status {
-	case entity.StatusUnreviewed, entity.StatusSupported, entity.StatusRefuted, entity.StatusKilled:
-		return normalizeExperimentReadClass(experimentReadClass{
-			Classification:   experimentClassificationDead,
-			HypothesisStatus: status,
-		})
-	default:
-		return normalizeExperimentReadClass(experimentReadClass{})
-	}
+	return readmodel.ClassifyHypothesisStatusForExperimentRead(status)
 }
 
 func validateExperimentClassificationFilter(classification string) error {
@@ -169,7 +75,9 @@ func validateExperimentClassificationFilter(classification string) error {
 }
 
 func experimentClassificationSummary(classification, hypothesisStatus string) string {
-	classification = normalizeExperimentReadClass(experimentReadClass{Classification: classification}).Classification
+	if classification == "" {
+		classification = experimentClassificationLive
+	}
 	if classification != experimentClassificationDead {
 		return classification
 	}
@@ -187,34 +95,5 @@ func experimentClassificationMarker(classification string) string {
 }
 
 func findStaleExperimentsForRead(exps []*entity.Experiment, classByID map[string]experimentReadClass, events []store.Event, threshold time.Duration, now time.Time) []staleExperimentView {
-	stale := []staleExperimentView{}
-	for _, e := range exps {
-		switch e.Status {
-		case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
-		default:
-			continue
-		}
-		if e.IsBaseline {
-			continue
-		}
-		if !experimentReadClassForID(classByID, e.ID).loopActionable() {
-			continue
-		}
-		ts, kind := findLastEventForExperiment(events, e.ID)
-		if ts == nil {
-			continue
-		}
-		age := now.Sub(*ts)
-		if age < threshold {
-			continue
-		}
-		stale = append(stale, staleExperimentView{
-			ID:            e.ID,
-			Hypothesis:    e.Hypothesis,
-			Status:        e.Status,
-			LastEventKind: kind,
-			StaleMinutes:  age.Minutes(),
-		})
-	}
-	return stale
+	return readmodel.FindStaleExperimentsForRead(exps, classByID, events, threshold, now)
 }

--- a/internal/cli/read_classification.go
+++ b/internal/cli/read_classification.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/store"
@@ -23,11 +24,32 @@ type experimentReadView struct {
 	HypothesisStatus string `json:"hypothesis_status,omitempty"`
 }
 
+type staleExperimentView struct {
+	ID            string  `json:"id"`
+	Hypothesis    string  `json:"hypothesis"`
+	Status        string  `json:"status"`
+	LastEventKind string  `json:"last_event_kind"`
+	StaleMinutes  float64 `json:"stale_minutes"`
+}
+
 func normalizeExperimentReadClass(class experimentReadClass) experimentReadClass {
 	if class.Classification == "" {
 		class.Classification = experimentClassificationLive
 	}
 	return class
+}
+
+// loopActionable reports whether the research loop should still steer from
+// this experiment's current hypothesis state. This is intentionally broader
+// than gc's "terminal" notion: decisive-but-unreviewed hypotheses are also
+// non-actionable for further loop steering even though they are not yet safe
+// to reclaim.
+func (class experimentReadClass) loopActionable() bool {
+	return normalizeExperimentReadClass(class).Classification == experimentClassificationLive
+}
+
+func experimentReadClassForID(classByID map[string]experimentReadClass, expID string) experimentReadClass {
+	return normalizeExperimentReadClass(classByID[expID])
 }
 
 func classifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]experimentReadClass, error) {
@@ -122,14 +144,19 @@ func classifyExperimentForRead(e *entity.Experiment, hypStatus map[string]string
 	if e == nil {
 		return normalizeExperimentReadClass(experimentReadClass{})
 	}
-	status, ok := hypStatus[e.Hypothesis]
-	if ok && isTerminal(status) {
+	return classifyHypothesisStatusForExperimentRead(hypStatus[e.Hypothesis])
+}
+
+func classifyHypothesisStatusForExperimentRead(status string) experimentReadClass {
+	switch status {
+	case entity.StatusUnreviewed, entity.StatusSupported, entity.StatusRefuted, entity.StatusKilled:
 		return normalizeExperimentReadClass(experimentReadClass{
 			Classification:   experimentClassificationDead,
 			HypothesisStatus: status,
 		})
+	default:
+		return normalizeExperimentReadClass(experimentReadClass{})
 	}
-	return normalizeExperimentReadClass(experimentReadClass{})
 }
 
 func validateExperimentClassificationFilter(classification string) error {
@@ -157,4 +184,37 @@ func experimentClassificationMarker(classification string) string {
 		return "[dead]"
 	}
 	return ""
+}
+
+func findStaleExperimentsForRead(exps []*entity.Experiment, classByID map[string]experimentReadClass, events []store.Event, threshold time.Duration, now time.Time) []staleExperimentView {
+	stale := []staleExperimentView{}
+	for _, e := range exps {
+		switch e.Status {
+		case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
+		default:
+			continue
+		}
+		if e.IsBaseline {
+			continue
+		}
+		if !experimentReadClassForID(classByID, e.ID).loopActionable() {
+			continue
+		}
+		ts, kind := findLastEventForExperiment(events, e.ID)
+		if ts == nil {
+			continue
+		}
+		age := now.Sub(*ts)
+		if age < threshold {
+			continue
+		}
+		stale = append(stale, staleExperimentView{
+			ID:            e.ID,
+			Hypothesis:    e.Hypothesis,
+			Status:        e.Status,
+			LastEventKind: kind,
+			StaleMinutes:  age.Minutes(),
+		})
+	}
+	return stale
 }

--- a/internal/cli/read_classification_test.go
+++ b/internal/cli/read_classification_test.go
@@ -53,3 +53,36 @@ func TestAnnotateExperimentsForRead_UsesParentHypothesisStatus(t *testing.T) {
 		t.Fatalf("E-0002 classification = %q, want %q", got, want)
 	}
 }
+
+func TestClassifyHypothesisStatusForExperimentRead(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		class      string
+		actionable bool
+		wantStatus string
+	}{
+		{name: "missing defaults live", status: "", class: experimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "open stays live", status: entity.StatusOpen, class: experimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "inconclusive stays live", status: entity.StatusInconclusive, class: experimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "unreviewed is dead", status: entity.StatusUnreviewed, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusUnreviewed},
+		{name: "supported is dead", status: entity.StatusSupported, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusSupported},
+		{name: "refuted is dead", status: entity.StatusRefuted, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusRefuted},
+		{name: "killed is dead", status: entity.StatusKilled, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusKilled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyHypothesisStatusForExperimentRead(tc.status)
+			if got.Classification != tc.class {
+				t.Fatalf("classification = %q, want %q", got.Classification, tc.class)
+			}
+			if got.HypothesisStatus != tc.wantStatus {
+				t.Fatalf("hypothesis_status = %q, want %q", got.HypothesisStatus, tc.wantStatus)
+			}
+			if got.loopActionable() != tc.actionable {
+				t.Fatalf("loopActionable = %v, want %v", got.loopActionable(), tc.actionable)
+			}
+		})
+	}
+}

--- a/internal/cli/read_classification_test.go
+++ b/internal/cli/read_classification_test.go
@@ -80,8 +80,8 @@ func TestClassifyHypothesisStatusForExperimentRead(t *testing.T) {
 			if got.HypothesisStatus != tc.wantStatus {
 				t.Fatalf("hypothesis_status = %q, want %q", got.HypothesisStatus, tc.wantStatus)
 			}
-			if got.loopActionable() != tc.actionable {
-				t.Fatalf("loopActionable = %v, want %v", got.loopActionable(), tc.actionable)
+			if got.LoopActionable() != tc.actionable {
+				t.Fatalf("loopActionable = %v, want %v", got.LoopActionable(), tc.actionable)
 			}
 		})
 	}

--- a/internal/cli/read_classification_test.go
+++ b/internal/cli/read_classification_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/bytter/autoresearch/internal/store"
 )
 
-func TestAnnotateExperimentsForRead_UsesParentHypothesisStatus(t *testing.T) {
+func TestListExperimentsForHypothesisForRead_AnnotatesResults(t *testing.T) {
 	dir := t.TempDir()
 	s, err := store.Create(dir, store.Config{
 		Build: store.CommandSpec{Command: "true"},
@@ -36,53 +36,57 @@ func TestAnnotateExperimentsForRead_UsesParentHypothesisStatus(t *testing.T) {
 		}
 	}
 
-	views, err := annotateExperimentsForRead(s, []*entity.Experiment{
-		{ID: "E-0001", Hypothesis: "H-0001"},
-		{ID: "E-0002", Hypothesis: "H-0002"},
-	})
+	for _, e := range []*entity.Experiment{
+		{ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured, CreatedAt: now},
+		{ID: "E-0002", Hypothesis: "H-0002", Status: entity.ExpMeasured, CreatedAt: now},
+	} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	views, err := listExperimentsForHypothesisForRead(s, "H-0001")
 	if err != nil {
 		t.Fatal(err)
 	}
+	if got, want := len(views), 1; got != want {
+		t.Fatalf("len(views) = %d, want %d", got, want)
+	}
+	if got, want := views[0].ID, "E-0001"; got != want {
+		t.Fatalf("views[0].ID = %q, want %q", got, want)
+	}
 	if got, want := views[0].Classification, experimentClassificationDead; got != want {
-		t.Fatalf("E-0001 classification = %q, want %q", got, want)
+		t.Fatalf("views[0].Classification = %q, want %q", got, want)
 	}
 	if got, want := views[0].HypothesisStatus, entity.StatusSupported; got != want {
-		t.Fatalf("E-0001 hypothesis_status = %q, want %q", got, want)
-	}
-	if got, want := views[1].Classification, experimentClassificationLive; got != want {
-		t.Fatalf("E-0002 classification = %q, want %q", got, want)
+		t.Fatalf("views[0].HypothesisStatus = %q, want %q", got, want)
 	}
 }
 
-func TestClassifyHypothesisStatusForExperimentRead(t *testing.T) {
-	cases := []struct {
-		name       string
-		status     string
-		class      string
-		actionable bool
-		wantStatus string
-	}{
-		{name: "missing defaults live", status: "", class: experimentClassificationLive, actionable: true, wantStatus: ""},
-		{name: "open stays live", status: entity.StatusOpen, class: experimentClassificationLive, actionable: true, wantStatus: ""},
-		{name: "inconclusive stays live", status: entity.StatusInconclusive, class: experimentClassificationLive, actionable: true, wantStatus: ""},
-		{name: "unreviewed is dead", status: entity.StatusUnreviewed, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusUnreviewed},
-		{name: "supported is dead", status: entity.StatusSupported, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusSupported},
-		{name: "refuted is dead", status: entity.StatusRefuted, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusRefuted},
-		{name: "killed is dead", status: entity.StatusKilled, class: experimentClassificationDead, actionable: false, wantStatus: entity.StatusKilled},
+func TestExperimentClassificationHelpers(t *testing.T) {
+	if err := validateExperimentClassificationFilter(""); err != nil {
+		t.Fatalf("validate empty: %v", err)
+	}
+	if err := validateExperimentClassificationFilter(experimentClassificationLive); err != nil {
+		t.Fatalf("validate live: %v", err)
+	}
+	if err := validateExperimentClassificationFilter(experimentClassificationDead); err != nil {
+		t.Fatalf("validate dead: %v", err)
+	}
+	if err := validateExperimentClassificationFilter("zombie"); err == nil {
+		t.Fatal("expected invalid classification to be rejected")
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := classifyHypothesisStatusForExperimentRead(tc.status)
-			if got.Classification != tc.class {
-				t.Fatalf("classification = %q, want %q", got.Classification, tc.class)
-			}
-			if got.HypothesisStatus != tc.wantStatus {
-				t.Fatalf("hypothesis_status = %q, want %q", got.HypothesisStatus, tc.wantStatus)
-			}
-			if got.LoopActionable() != tc.actionable {
-				t.Fatalf("loopActionable = %v, want %v", got.LoopActionable(), tc.actionable)
-			}
-		})
+	if got, want := experimentClassificationSummary("", ""), experimentClassificationLive; got != want {
+		t.Fatalf("summary(empty) = %q, want %q", got, want)
+	}
+	if got, want := experimentClassificationSummary(experimentClassificationDead, entity.StatusSupported), "dead (hypothesis=supported)"; got != want {
+		t.Fatalf("summary(dead) = %q, want %q", got, want)
+	}
+	if got, want := experimentClassificationMarker(experimentClassificationDead), "[dead]"; got != want {
+		t.Fatalf("marker(dead) = %q, want %q", got, want)
+	}
+	if got := experimentClassificationMarker(experimentClassificationLive); got != "" {
+		t.Fatalf("marker(live) = %q, want empty", got)
 	}
 }

--- a/internal/cli/tui_app.go
+++ b/internal/cli/tui_app.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -188,12 +189,12 @@ func fetchChrome(s *store.Store, scope goalScope) tea.Cmd {
 		// store cache lands it'll be cheap for both paths.
 		if scope.All || scope.GoalID == "" {
 			if counts, err := s.Counts(); err == nil {
-				msg.counts = map[string]int{
-					"hypotheses":   counts["hypotheses"],
-					"experiments":  counts["experiments"],
-					"observations": counts["observations"],
-					"conclusions":  counts["conclusions"],
-				}
+				msg.counts = readmodel.BuildCounts(
+					counts["hypotheses"],
+					counts["experiments"],
+					counts["observations"],
+					counts["conclusions"],
+				)
 			}
 			return msg
 		}
@@ -207,12 +208,7 @@ func fetchChrome(s *store.Store, scope goalScope) tea.Cmd {
 			obs, oerr = resolver.filterObservations(obs)
 			concls, cerr = resolver.filterConclusions(concls)
 			if eerr == nil && oerr == nil && cerr == nil {
-				msg.counts = map[string]int{
-					"hypotheses":   len(resolver.filterHypotheses(hyps)),
-					"experiments":  len(exps),
-					"observations": len(obs),
-					"conclusions":  len(concls),
-				}
+				msg.counts = readmodel.BuildCounts(len(resolver.filterHypotheses(hyps)), len(exps), len(obs), len(concls))
 			}
 		}
 		return msg

--- a/internal/cli/tui_view_experiment.go
+++ b/internal/cli/tui_view_experiment.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/stats"
 	"github.com/bytter/autoresearch/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
@@ -133,7 +134,7 @@ func (v *experimentDetailView) title() string { return "Experiment " + v.id }
 func (v *experimentDetailView) init(s *store.Store) tea.Cmd {
 	id := v.id
 	return func() tea.Msg {
-		view, err := readExperimentForRead(s, id)
+		view, err := readmodel.ReadExperimentForRead(s, id)
 		if err != nil {
 			return expDetailLoadedMsg{err: err}
 		}

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -227,12 +227,12 @@ func (v *frontierView) init(s *store.Store) tea.Cmd {
 		}
 		obsByExp := readmodel.LoadObservationsByExperiment(s)
 		expClassByID := readmodel.LoadExperimentReadClasses(s)
-		rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+		frontier := readmodel.BuildFrontierSnapshot(goal, concls, obsByExp, expClassByID)
 		return frontierLoadedMsg{
 			goal:       goal,
-			rows:       rows,
-			assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
-			stalled:    stalled,
+			rows:       frontier.Rows,
+			assessment: frontier.Assessment,
+			stalled:    frontier.StalledFor,
 		}
 	}
 }

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -224,13 +225,13 @@ func (v *frontierView) init(s *store.Store) tea.Cmd {
 		if err != nil {
 			return frontierLoadedMsg{err: err}
 		}
-		obsByExp := loadObservationsByExperiment(s)
-		expClassByID := loadExperimentReadClasses(s)
-		rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+		obsByExp := readmodel.LoadObservationsByExperiment(s)
+		expClassByID := readmodel.LoadExperimentReadClasses(s)
+		rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
 		return frontierLoadedMsg{
 			goal:       goal,
 			rows:       rows,
-			assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
+			assessment: readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
 			stalled:    stalled,
 		}
 	}

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -225,11 +225,12 @@ func (v *frontierView) init(s *store.Store) tea.Cmd {
 			return frontierLoadedMsg{err: err}
 		}
 		obsByExp := loadObservationsByExperiment(s)
-		rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, loadExperimentReadClasses(s))
+		expClassByID := loadExperimentReadClasses(s)
+		rows, stalled := computeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
 		return frontierLoadedMsg{
 			goal:       goal,
 			rows:       rows,
-			assessment: assessGoalCompletion(goal, concls, obsByExp),
+			assessment: assessGoalCompletion(goal, concls, obsByExp, expClassByID),
 			stalled:    stalled,
 		}
 	}

--- a/internal/readmodel/experiment.go
+++ b/internal/readmodel/experiment.go
@@ -1,6 +1,7 @@
 package readmodel
 
 import (
+	"sort"
 	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
@@ -33,6 +34,17 @@ type StaleExperimentView struct {
 	Status        string  `json:"status"`
 	LastEventKind string  `json:"last_event_kind"`
 	StaleMinutes  float64 `json:"stale_minutes"`
+}
+
+// InFlightExperimentView is the read model shared by dashboard/TUI for active
+// experiments that still need human or agent attention.
+type InFlightExperimentView struct {
+	ID            string     `json:"id"`
+	Hypothesis    string     `json:"hypothesis"`
+	Status        string     `json:"status"`
+	Instruments   []string   `json:"instruments"`
+	ImplementedAt *time.Time `json:"implemented_at,omitempty"`
+	ElapsedS      float64    `json:"elapsed_s"`
 }
 
 func normalizeExperimentReadClass(class ExperimentReadClass) ExperimentReadClass {
@@ -149,6 +161,54 @@ func classifyExperimentForRead(e *entity.Experiment, hypStatus map[string]string
 		return normalizeExperimentReadClass(ExperimentReadClass{})
 	}
 	return ClassifyHypothesisStatusForExperimentRead(hypStatus[e.Hypothesis])
+}
+
+func BuildExperimentActivity(exps []*entity.Experiment, classByID map[string]ExperimentReadClass, events []store.Event, staleThreshold time.Duration, now time.Time) (inFlight []InFlightExperimentView, stale []StaleExperimentView) {
+	inFlight = BuildInFlightExperiments(exps, classByID, events, now)
+	if staleThreshold > 0 {
+		stale = FindStaleExperimentsForRead(exps, classByID, events, staleThreshold, now)
+	}
+	return inFlight, stale
+}
+
+func BuildInFlightExperiments(exps []*entity.Experiment, classByID map[string]ExperimentReadClass, events []store.Event, now time.Time) []InFlightExperimentView {
+	inFlight := []InFlightExperimentView{}
+	for _, e := range exps {
+		if e.Status != entity.ExpImplemented && e.Status != entity.ExpMeasured {
+			continue
+		}
+		if len(e.ReferencedAsBaselineBy) > 0 {
+			continue
+		}
+		if !ExperimentReadClassForID(classByID, e.ID).LoopActionable() {
+			continue
+		}
+		row := InFlightExperimentView{
+			ID:          e.ID,
+			Hypothesis:  e.Hypothesis,
+			Status:      e.Status,
+			Instruments: append([]string{}, e.Instruments...),
+		}
+		if ts, kind := FindLastEventForExperiment(events, e.ID); ts != nil && kind == "experiment.implement" {
+			row.ImplementedAt = ts
+			row.ElapsedS = now.Sub(*ts).Seconds()
+		}
+		inFlight = append(inFlight, row)
+	}
+	sort.SliceStable(inFlight, func(i, j int) bool {
+		a, b := inFlight[i].ImplementedAt, inFlight[j].ImplementedAt
+		if a == nil && b == nil {
+			return inFlight[i].ID < inFlight[j].ID
+		}
+		if a == nil {
+			return false
+		}
+		if b == nil {
+			return true
+		}
+		return a.After(*b)
+	})
+	return inFlight
 }
 
 func FindStaleExperimentsForRead(exps []*entity.Experiment, classByID map[string]ExperimentReadClass, events []store.Event, threshold time.Duration, now time.Time) []StaleExperimentView {

--- a/internal/readmodel/experiment.go
+++ b/internal/readmodel/experiment.go
@@ -67,11 +67,9 @@ func ExperimentReadClassForID(classByID map[string]ExperimentReadClass, expID st
 	return normalizeExperimentReadClass(classByID[expID])
 }
 
-func ClassifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]ExperimentReadClass, error) {
-	hyps, err := s.ListHypotheses()
-	if err != nil {
-		return nil, err
-	}
+// BuildHypothesisStatusIndex indexes hypotheses by ID for read-side
+// experiment classification and other projections that only need status.
+func BuildHypothesisStatusIndex(hyps []*entity.Hypothesis) map[string]string {
 	hypStatus := make(map[string]string, len(hyps))
 	for _, h := range hyps {
 		if h == nil {
@@ -79,14 +77,21 @@ func ClassifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[
 		}
 		hypStatus[h.ID] = h.Status
 	}
-	out := make(map[string]ExperimentReadClass, len(exps))
-	for _, e := range exps {
-		if e == nil {
-			continue
-		}
-		out[e.ID] = classifyExperimentForRead(e, hypStatus)
+	return hypStatus
+}
+
+// ClassifyExperimentsForReadFromHypotheses derives read-time experiment
+// classification from already-loaded hypotheses, avoiding another store read.
+func ClassifyExperimentsForReadFromHypotheses(exps []*entity.Experiment, hyps []*entity.Hypothesis) map[string]ExperimentReadClass {
+	return classifyExperimentsForRead(exps, BuildHypothesisStatusIndex(hyps))
+}
+
+func ClassifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]ExperimentReadClass, error) {
+	hyps, err := s.ListHypotheses()
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return ClassifyExperimentsForReadFromHypotheses(exps, hyps), nil
 }
 
 func AnnotateExperimentsForRead(s *store.Store, exps []*entity.Experiment) ([]*ExperimentReadView, error) {
@@ -161,6 +166,17 @@ func classifyExperimentForRead(e *entity.Experiment, hypStatus map[string]string
 		return normalizeExperimentReadClass(ExperimentReadClass{})
 	}
 	return ClassifyHypothesisStatusForExperimentRead(hypStatus[e.Hypothesis])
+}
+
+func classifyExperimentsForRead(exps []*entity.Experiment, hypStatus map[string]string) map[string]ExperimentReadClass {
+	out := make(map[string]ExperimentReadClass, len(exps))
+	for _, e := range exps {
+		if e == nil {
+			continue
+		}
+		out[e.ID] = classifyExperimentForRead(e, hypStatus)
+	}
+	return out
 }
 
 func BuildExperimentActivity(exps []*entity.Experiment, classByID map[string]ExperimentReadClass, events []store.Event, staleThreshold time.Duration, now time.Time) (inFlight []InFlightExperimentView, stale []StaleExperimentView) {

--- a/internal/readmodel/experiment.go
+++ b/internal/readmodel/experiment.go
@@ -1,0 +1,198 @@
+package readmodel
+
+import (
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const (
+	ExperimentClassificationLive = "live"
+	ExperimentClassificationDead = "dead"
+)
+
+// ExperimentReadClass captures whether a persisted experiment should still be
+// treated as actionable work by read-only steering surfaces.
+type ExperimentReadClass struct {
+	Classification   string `json:"classification"`
+	HypothesisStatus string `json:"hypothesis_status,omitempty"`
+}
+
+// ExperimentReadView is the read-side projection used by list/show surfaces.
+type ExperimentReadView struct {
+	*entity.Experiment
+	Classification   string `json:"classification"`
+	HypothesisStatus string `json:"hypothesis_status,omitempty"`
+}
+
+// StaleExperimentView is the stale-work read model shared by status/dashboard.
+type StaleExperimentView struct {
+	ID            string  `json:"id"`
+	Hypothesis    string  `json:"hypothesis"`
+	Status        string  `json:"status"`
+	LastEventKind string  `json:"last_event_kind"`
+	StaleMinutes  float64 `json:"stale_minutes"`
+}
+
+func normalizeExperimentReadClass(class ExperimentReadClass) ExperimentReadClass {
+	if class.Classification == "" {
+		class.Classification = ExperimentClassificationLive
+	}
+	return class
+}
+
+// LoopActionable reports whether the research loop should still steer from
+// this experiment's current hypothesis state. This is intentionally broader
+// than gc's "terminal" notion: decisive-but-unreviewed hypotheses are also
+// non-actionable for further loop steering even though they are not yet safe
+// to reclaim.
+func (class ExperimentReadClass) LoopActionable() bool {
+	return normalizeExperimentReadClass(class).Classification == ExperimentClassificationLive
+}
+
+func ExperimentReadClassForID(classByID map[string]ExperimentReadClass, expID string) ExperimentReadClass {
+	return normalizeExperimentReadClass(classByID[expID])
+}
+
+func ClassifyExperimentsForRead(s *store.Store, exps []*entity.Experiment) (map[string]ExperimentReadClass, error) {
+	hyps, err := s.ListHypotheses()
+	if err != nil {
+		return nil, err
+	}
+	hypStatus := make(map[string]string, len(hyps))
+	for _, h := range hyps {
+		if h == nil {
+			continue
+		}
+		hypStatus[h.ID] = h.Status
+	}
+	out := make(map[string]ExperimentReadClass, len(exps))
+	for _, e := range exps {
+		if e == nil {
+			continue
+		}
+		out[e.ID] = classifyExperimentForRead(e, hypStatus)
+	}
+	return out, nil
+}
+
+func AnnotateExperimentsForRead(s *store.Store, exps []*entity.Experiment) ([]*ExperimentReadView, error) {
+	classByID, err := ClassifyExperimentsForRead(s, exps)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*ExperimentReadView, 0, len(exps))
+	for _, e := range exps {
+		if e == nil {
+			continue
+		}
+		class := normalizeExperimentReadClass(classByID[e.ID])
+		out = append(out, &ExperimentReadView{
+			Experiment:       e,
+			Classification:   class.Classification,
+			HypothesisStatus: class.HypothesisStatus,
+		})
+	}
+	return out, nil
+}
+
+func AnnotateExperimentForRead(s *store.Store, e *entity.Experiment) (*ExperimentReadView, error) {
+	views, err := AnnotateExperimentsForRead(s, []*entity.Experiment{e})
+	if err != nil {
+		return nil, err
+	}
+	if len(views) == 0 {
+		return nil, nil
+	}
+	return views[0], nil
+}
+
+func ReadExperimentForRead(s *store.Store, id string) (*ExperimentReadView, error) {
+	e, err := s.ReadExperiment(id)
+	if err != nil {
+		return nil, err
+	}
+	return AnnotateExperimentForRead(s, e)
+}
+
+func ClassifyAllExperimentsForRead(s *store.Store) (map[string]ExperimentReadClass, error) {
+	exps, err := s.ListExperiments()
+	if err != nil {
+		return nil, err
+	}
+	return ClassifyExperimentsForRead(s, exps)
+}
+
+func LoadExperimentReadClasses(s *store.Store) map[string]ExperimentReadClass {
+	classByID, err := ClassifyAllExperimentsForRead(s)
+	if err != nil {
+		return nil
+	}
+	return classByID
+}
+
+func ClassifyHypothesisStatusForExperimentRead(status string) ExperimentReadClass {
+	switch status {
+	case entity.StatusUnreviewed, entity.StatusSupported, entity.StatusRefuted, entity.StatusKilled:
+		return normalizeExperimentReadClass(ExperimentReadClass{
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: status,
+		})
+	default:
+		return normalizeExperimentReadClass(ExperimentReadClass{})
+	}
+}
+
+func classifyExperimentForRead(e *entity.Experiment, hypStatus map[string]string) ExperimentReadClass {
+	if e == nil {
+		return normalizeExperimentReadClass(ExperimentReadClass{})
+	}
+	return ClassifyHypothesisStatusForExperimentRead(hypStatus[e.Hypothesis])
+}
+
+func FindStaleExperimentsForRead(exps []*entity.Experiment, classByID map[string]ExperimentReadClass, events []store.Event, threshold time.Duration, now time.Time) []StaleExperimentView {
+	stale := []StaleExperimentView{}
+	for _, e := range exps {
+		switch e.Status {
+		case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
+		default:
+			continue
+		}
+		if e.IsBaseline {
+			continue
+		}
+		if !ExperimentReadClassForID(classByID, e.ID).LoopActionable() {
+			continue
+		}
+		ts, kind := FindLastEventForExperiment(events, e.ID)
+		if ts == nil {
+			continue
+		}
+		age := now.Sub(*ts)
+		if age < threshold {
+			continue
+		}
+		stale = append(stale, StaleExperimentView{
+			ID:            e.ID,
+			Hypothesis:    e.Hypothesis,
+			Status:        e.Status,
+			LastEventKind: kind,
+			StaleMinutes:  age.Minutes(),
+		})
+	}
+	return stale
+}
+
+// FindLastEventForExperiment scans a pre-loaded event list backward for the
+// most recent event referencing expID and returns its timestamp and kind.
+func FindLastEventForExperiment(events []store.Event, expID string) (ts *time.Time, kind string) {
+	for i := len(events) - 1; i >= 0; i-- {
+		e := events[i]
+		if e.Subject == expID {
+			t := e.Ts
+			return &t, e.Kind
+		}
+	}
+	return nil, ""
+}

--- a/internal/readmodel/experiment_test.go
+++ b/internal/readmodel/experiment_test.go
@@ -41,6 +41,32 @@ func TestClassifyHypothesisStatusForExperimentRead(t *testing.T) {
 	}
 }
 
+func TestClassifyExperimentsForReadFromHypotheses(t *testing.T) {
+	hyps := []*entity.Hypothesis{
+		{ID: "H-0001", Status: entity.StatusSupported},
+		{ID: "H-0002", Status: entity.StatusOpen},
+	}
+	exps := []*entity.Experiment{
+		{ID: "E-0001", Hypothesis: "H-0001"},
+		{ID: "E-0002", Hypothesis: "H-0002"},
+		{ID: "E-0003"},
+	}
+
+	got := ClassifyExperimentsForReadFromHypotheses(exps, hyps)
+	if got["E-0001"].Classification != ExperimentClassificationDead {
+		t.Fatalf("E-0001 classification = %q, want %q", got["E-0001"].Classification, ExperimentClassificationDead)
+	}
+	if got["E-0001"].HypothesisStatus != entity.StatusSupported {
+		t.Fatalf("E-0001 hypothesis_status = %q, want %q", got["E-0001"].HypothesisStatus, entity.StatusSupported)
+	}
+	if got["E-0002"].Classification != ExperimentClassificationLive {
+		t.Fatalf("E-0002 classification = %q, want %q", got["E-0002"].Classification, ExperimentClassificationLive)
+	}
+	if got["E-0003"].Classification != ExperimentClassificationLive {
+		t.Fatalf("baseline-like experiment classification = %q, want %q", got["E-0003"].Classification, ExperimentClassificationLive)
+	}
+}
+
 func TestFindStaleExperimentsForRead_ExcludesNonActionableWork(t *testing.T) {
 	now := time.Date(2026, 4, 18, 20, 0, 0, 0, time.UTC)
 	exps := []*entity.Experiment{

--- a/internal/readmodel/experiment_test.go
+++ b/internal/readmodel/experiment_test.go
@@ -67,3 +67,89 @@ func TestFindStaleExperimentsForRead_ExcludesNonActionableWork(t *testing.T) {
 		t.Fatalf("stale[0].ID = %q, want %q", got, want)
 	}
 }
+
+func TestBuildInFlightExperiments_FiltersAndSorts(t *testing.T) {
+	now := time.Date(2026, 4, 18, 20, 0, 0, 0, time.UTC)
+	exps := []*entity.Experiment{
+		{
+			ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured,
+			Instruments:            []string{"host_timing"},
+			ReferencedAsBaselineBy: []string{"C-0001"},
+		},
+		{
+			ID: "E-0002", Hypothesis: "H-0002", Status: entity.ExpMeasured,
+			Instruments: []string{"host_timing"},
+		},
+		{
+			ID: "E-0003", Hypothesis: "H-0003", Status: entity.ExpImplemented,
+			Instruments: []string{"host_timing"},
+		},
+		{
+			ID: "E-0004", Hypothesis: "H-0004", Status: entity.ExpMeasured,
+			Instruments: []string{"host_timing", "host_test"},
+		},
+		{
+			ID: "E-0005", Hypothesis: "H-0005", Status: entity.ExpMeasured,
+			Instruments: []string{"host_timing"},
+		},
+	}
+	classByID := map[string]ExperimentReadClass{
+		"E-0002": ClassifyHypothesisStatusForExperimentRead(entity.StatusSupported),
+	}
+	old := now.Add(-10 * time.Minute)
+	recent := now.Add(-2 * time.Minute)
+	events := []store.Event{
+		{Ts: old, Kind: "experiment.implement", Subject: "E-0003"},
+		{Ts: recent, Kind: "experiment.implement", Subject: "E-0004"},
+	}
+
+	inFlight := BuildInFlightExperiments(exps, classByID, events, now)
+	if got, want := len(inFlight), 3; got != want {
+		t.Fatalf("inFlight len = %d, want %d", got, want)
+	}
+	if got, want := inFlight[0].ID, "E-0004"; got != want {
+		t.Fatalf("inFlight[0].ID = %q, want %q", got, want)
+	}
+	if got, want := inFlight[1].ID, "E-0003"; got != want {
+		t.Fatalf("inFlight[1].ID = %q, want %q", got, want)
+	}
+	if got, want := inFlight[2].ID, "E-0005"; got != want {
+		t.Fatalf("inFlight[2].ID = %q, want %q", got, want)
+	}
+	if got, want := inFlight[0].ElapsedS, 120.0; got != want {
+		t.Fatalf("inFlight[0].ElapsedS = %v, want %v", got, want)
+	}
+	if got, want := inFlight[1].ElapsedS, 600.0; got != want {
+		t.Fatalf("inFlight[1].ElapsedS = %v, want %v", got, want)
+	}
+	if inFlight[2].ImplementedAt != nil {
+		t.Fatalf("inFlight[2].ImplementedAt = %v, want nil", inFlight[2].ImplementedAt)
+	}
+}
+
+func TestBuildExperimentActivity_UsesSharedThresholdAndNow(t *testing.T) {
+	now := time.Date(2026, 4, 18, 20, 0, 0, 0, time.UTC)
+	exps := []*entity.Experiment{
+		{ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured, Instruments: []string{"host_timing"}},
+	}
+	classByID := map[string]ExperimentReadClass{
+		"E-0001": ClassifyHypothesisStatusForExperimentRead(entity.StatusOpen),
+	}
+	events := []store.Event{
+		{Ts: now.Add(-10 * time.Minute), Kind: "experiment.implement", Subject: "E-0001"},
+	}
+
+	inFlight, stale := BuildExperimentActivity(exps, classByID, events, 5*time.Minute, now)
+	if got, want := len(inFlight), 1; got != want {
+		t.Fatalf("inFlight len = %d, want %d", got, want)
+	}
+	if got, want := len(stale), 1; got != want {
+		t.Fatalf("stale len = %d, want %d", got, want)
+	}
+	if got, want := inFlight[0].ElapsedS, 600.0; got != want {
+		t.Fatalf("inFlight[0].ElapsedS = %v, want %v", got, want)
+	}
+	if got, want := stale[0].StaleMinutes, 10.0; got != want {
+		t.Fatalf("stale[0].StaleMinutes = %v, want %v", got, want)
+	}
+}

--- a/internal/readmodel/experiment_test.go
+++ b/internal/readmodel/experiment_test.go
@@ -1,0 +1,69 @@
+package readmodel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func TestClassifyHypothesisStatusForExperimentRead(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		class      string
+		actionable bool
+		wantStatus string
+	}{
+		{name: "missing defaults live", status: "", class: ExperimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "open stays live", status: entity.StatusOpen, class: ExperimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "inconclusive stays live", status: entity.StatusInconclusive, class: ExperimentClassificationLive, actionable: true, wantStatus: ""},
+		{name: "unreviewed is dead", status: entity.StatusUnreviewed, class: ExperimentClassificationDead, actionable: false, wantStatus: entity.StatusUnreviewed},
+		{name: "supported is dead", status: entity.StatusSupported, class: ExperimentClassificationDead, actionable: false, wantStatus: entity.StatusSupported},
+		{name: "refuted is dead", status: entity.StatusRefuted, class: ExperimentClassificationDead, actionable: false, wantStatus: entity.StatusRefuted},
+		{name: "killed is dead", status: entity.StatusKilled, class: ExperimentClassificationDead, actionable: false, wantStatus: entity.StatusKilled},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClassifyHypothesisStatusForExperimentRead(tc.status)
+			if got.Classification != tc.class {
+				t.Fatalf("classification = %q, want %q", got.Classification, tc.class)
+			}
+			if got.HypothesisStatus != tc.wantStatus {
+				t.Fatalf("hypothesis_status = %q, want %q", got.HypothesisStatus, tc.wantStatus)
+			}
+			if got.LoopActionable() != tc.actionable {
+				t.Fatalf("LoopActionable = %v, want %v", got.LoopActionable(), tc.actionable)
+			}
+		})
+	}
+}
+
+func TestFindStaleExperimentsForRead_ExcludesNonActionableWork(t *testing.T) {
+	now := time.Date(2026, 4, 18, 20, 0, 0, 0, time.UTC)
+	exps := []*entity.Experiment{
+		{ID: "E-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured},
+		{ID: "E-0002", Hypothesis: "H-0002", Status: entity.ExpMeasured},
+		{ID: "E-0003", Hypothesis: "H-0003", Status: entity.ExpMeasured},
+	}
+	classByID := map[string]ExperimentReadClass{
+		"E-0001": ClassifyHypothesisStatusForExperimentRead(entity.StatusSupported),
+		"E-0002": ClassifyHypothesisStatusForExperimentRead(entity.StatusUnreviewed),
+		"E-0003": ClassifyHypothesisStatusForExperimentRead(entity.StatusOpen),
+	}
+	events := []store.Event{
+		{Ts: now.Add(-10 * time.Minute), Kind: "experiment.measure", Subject: "E-0001"},
+		{Ts: now.Add(-10 * time.Minute), Kind: "experiment.measure", Subject: "E-0002"},
+		{Ts: now.Add(-10 * time.Minute), Kind: "experiment.measure", Subject: "E-0003"},
+	}
+
+	stale := FindStaleExperimentsForRead(exps, classByID, events, 5*time.Minute, now)
+	if got, want := len(stale), 1; got != want {
+		t.Fatalf("stale len = %d, want %d", got, want)
+	}
+	if got, want := stale[0].ID, "E-0003"; got != want {
+		t.Fatalf("stale[0].ID = %q, want %q", got, want)
+	}
+}

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -1,0 +1,372 @@
+package readmodel
+
+import (
+	"math"
+	"sort"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type FrontierRow struct {
+	Conclusion string  `json:"conclusion"`
+	Hypothesis string  `json:"hypothesis"`
+	Candidate  string  `json:"candidate_experiment"`
+	Value      float64 `json:"value"`
+	DeltaFrac  float64 `json:"delta_frac"`
+	// Classification is a read-time label for the candidate experiment.
+	// "dead" means the experiment's parent hypothesis is no longer
+	// loop-actionable for steering (terminal or decisive-but-unreviewed), so
+	// the row is still historically valid but no longer actionable work.
+	Classification string `json:"classification"`
+	// HypothesisStatus records the hypothesis status that caused
+	// Classification=dead. Kept separate from Hypothesis, which is the ID.
+	HypothesisStatus string `json:"hypothesis_status,omitempty"`
+	// RescuedBy is non-empty when the backing conclusion was supported via
+	// a goal rescuer rather than a clean primary win. Renderers display a
+	// "rescued by <instrument>" annotation so the reader cannot mistake a
+	// rescued row for a clean primary-metric improvement.
+	RescuedBy string `json:"rescued_by,omitempty"`
+	// TiebreakValues holds one candidate value per goal.Rescuers clause, in
+	// declared order. Used when two rows are within goal.NeutralBandFrac on
+	// primary — the sort then picks the row that wins on the first rescuer
+	// whose value differs. Absent rescuer data is represented as NaN so the
+	// tiebreak skips cleanly over it.
+	TiebreakValues []float64 `json:"-"`
+}
+
+type FrontierGoalAssessment struct {
+	Mode              string  `json:"mode"`
+	Threshold         float64 `json:"threshold,omitempty"`
+	OnThreshold       string  `json:"on_threshold,omitempty"`
+	Met               bool    `json:"met"`
+	MetByConclusion   string  `json:"met_by_conclusion,omitempty"`
+	RecommendedAction string  `json:"recommended_action"`
+}
+
+type frontierCandidate struct {
+	Conclusion *entity.Conclusion
+	Value      float64
+}
+
+// ComputeFrontier returns rows in best-first order for the objective and the
+// count of conclusions written since the last frontier improvement.
+func ComputeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) (rows []FrontierRow, stalledFor int) {
+	return ComputeFrontierFromObservations(goal, concls, LoadObservationsByExperiment(s), LoadExperimentReadClasses(s))
+}
+
+func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) (rows []FrontierRow, stalledFor int) {
+	rows = []FrontierRow{} // always non-nil so --json emits [] not null
+	requireByInst := frontierRequireConstraints(goal)
+
+	for _, c := range concls {
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if !ok {
+			continue
+		}
+		class := ExperimentReadClassForID(expClassByID, c.CandidateExp)
+		rows = append(rows, FrontierRow{
+			Conclusion:       c.ID,
+			Hypothesis:       c.Hypothesis,
+			Candidate:        c.CandidateExp,
+			Value:            val,
+			DeltaFrac:        c.Effect.DeltaFrac,
+			Classification:   class.Classification,
+			HypothesisStatus: class.HypothesisStatus,
+			RescuedBy:        c.Strict.RescuedBy,
+			TiebreakValues:   rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		return FrontierRowBetter(goal, rows[i], rows[j])
+	})
+
+	sortedByTime := make([]*entity.Conclusion, len(concls))
+	copy(sortedByTime, concls)
+	sort.Slice(sortedByTime, func(i, j int) bool { return sortedByTime[i].CreatedAt.Before(sortedByTime[j].CreatedAt) })
+
+	hasBest := false
+	var bestRow FrontierRow
+	for _, c := range sortedByTime {
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		if !ok {
+			continue
+		}
+		if !ExperimentReadClassForID(expClassByID, c.CandidateExp).LoopActionable() {
+			continue
+		}
+		cur := FrontierRow{
+			Value:          val,
+			TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+		}
+		if !hasBest {
+			hasBest = true
+			bestRow = cur
+			stalledFor = 0
+			continue
+		}
+		if FrontierRowBetter(goal, cur, bestRow) {
+			bestRow = cur
+			stalledFor = 0
+		} else {
+			stalledFor++
+		}
+	}
+	return rows, stalledFor
+}
+
+// FrontierRowBetter reports whether a is strictly better than b on the goal.
+// When the primary values are within goal.NeutralBandFrac of each other, the
+// comparison falls through to rescuers in goal-declared order; the first
+// rescuer whose value differs decides. This is a limited Pareto-tiebreak,
+// not a full multi-objective frontier.
+func FrontierRowBetter(goal *entity.Goal, a, b FrontierRow) bool {
+	if goal == nil {
+		return false
+	}
+	if !withinPrimaryNeutralBand(goal, a.Value, b.Value) {
+		return betterFrontierValue(goal.Objective.Direction, a.Value, b.Value)
+	}
+	for i, r := range goal.Rescuers {
+		if i >= len(a.TiebreakValues) || i >= len(b.TiebreakValues) {
+			continue
+		}
+		av, bv := a.TiebreakValues[i], b.TiebreakValues[i]
+		if math.IsNaN(av) || math.IsNaN(bv) {
+			continue
+		}
+		if av == bv {
+			continue
+		}
+		return betterFrontierValue(r.Direction, av, bv)
+	}
+	return false
+}
+
+func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierGoalAssessment {
+	if goal == nil || goal.IsOpenEnded() {
+		return FrontierGoalAssessment{
+			Mode:              "open_ended",
+			Met:               false,
+			RecommendedAction: "continue",
+		}
+	}
+
+	assessment := FrontierGoalAssessment{
+		Mode:              "threshold",
+		Threshold:         goal.Completion.Threshold,
+		OnThreshold:       goal.EffectiveOnThreshold(),
+		Met:               false,
+		RecommendedAction: "continue",
+	}
+
+	var bestReviewed frontierCandidate
+	hasReviewed := false
+	for _, c := range concls {
+		if c == nil || c.ReviewedBy == "" {
+			continue
+		}
+		if !ExperimentReadClassForID(expClassByID, c.CandidateExp).LoopActionable() {
+			continue
+		}
+		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+			continue
+		}
+		obs := obsByExp[c.CandidateExp]
+		if !goalConstraintsSatisfied(obs, goal.Constraints) {
+			continue
+		}
+		val, ok := candidateObjectiveValue(obs, goal.Objective.Instrument)
+		if !ok {
+			continue
+		}
+		if !hasReviewed || betterFrontierValue(goal.Objective.Direction, val, bestReviewed.Value) {
+			bestReviewed = frontierCandidate{Conclusion: c, Value: val}
+			hasReviewed = true
+		}
+	}
+	if !hasReviewed {
+		return assessment
+	}
+	if meetsGoalThreshold(goal.Objective.Direction, bestReviewed.Conclusion.Effect.DeltaFrac, goal.Completion.Threshold) {
+		assessment.Met = true
+		assessment.MetByConclusion = bestReviewed.Conclusion.ID
+		switch assessment.OnThreshold {
+		case entity.GoalOnThresholdAskHuman:
+			assessment.RecommendedAction = "ask_human"
+		case entity.GoalOnThresholdStop:
+			assessment.RecommendedAction = "stop"
+		default:
+			assessment.RecommendedAction = "continue"
+		}
+	}
+	return assessment
+}
+
+// LoadObservationsByExperiment reads all observations once and returns them
+// indexed by experiment ID. A nil map (on read error) is safe — callers get
+// empty slices from the nil map.
+func LoadObservationsByExperiment(s *store.Store) map[string][]*entity.Observation {
+	all, err := s.ListObservations()
+	if err != nil {
+		return nil
+	}
+	m := make(map[string][]*entity.Observation, len(all))
+	for _, o := range all {
+		m[o.Experiment] = append(m[o.Experiment], o)
+	}
+	return m
+}
+
+// rescuerTiebreakValues extracts one candidate value per goal rescuer, in
+// declared order. Missing observations (the candidate wasn't measured on a
+// rescuer instrument) are represented as NaN so the tiebreak comparator can
+// skip them cleanly.
+func rescuerTiebreakValues(goal *entity.Goal, obs []*entity.Observation) []float64 {
+	if goal == nil || len(goal.Rescuers) == 0 {
+		return nil
+	}
+	out := make([]float64, len(goal.Rescuers))
+	for i, r := range goal.Rescuers {
+		v, ok := candidateObjectiveValue(obs, r.Instrument)
+		if !ok {
+			out[i] = math.NaN()
+			continue
+		}
+		out[i] = v
+	}
+	return out
+}
+
+// withinPrimaryNeutralBand reports whether two primary values are close
+// enough (relative to the larger magnitude) that the goal considers them
+// "tied" on the primary metric. Returns false whenever the goal doesn't
+// declare a neutral band, preserving v3-goal behaviour exactly.
+func withinPrimaryNeutralBand(goal *entity.Goal, a, b float64) bool {
+	if goal == nil || goal.NeutralBandFrac <= 0 {
+		return false
+	}
+	denom := math.Max(math.Max(math.Abs(a), math.Abs(b)), 1e-9)
+	return math.Abs(a-b)/denom <= goal.NeutralBandFrac
+}
+
+func frontierRequireConstraints(goal *entity.Goal) map[string]string {
+	requireByInst := map[string]string{}
+	if goal == nil {
+		return requireByInst
+	}
+	for _, c := range goal.Constraints {
+		if c.Require != "" {
+			requireByInst[c.Instrument] = c.Require
+		}
+	}
+	return requireByInst
+}
+
+func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string) (float64, bool) {
+	if goal == nil || c == nil {
+		return 0, false
+	}
+	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+		return 0, false
+	}
+	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
+		return 0, false
+	}
+	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
+}
+
+func betterFrontierValue(direction string, candidate, incumbent float64) bool {
+	if direction == "decrease" {
+		return candidate < incumbent
+	}
+	return candidate > incumbent
+}
+
+func meetsGoalThreshold(direction string, deltaFrac, threshold float64) bool {
+	if threshold <= 0 {
+		return false
+	}
+	if direction == "decrease" {
+		return deltaFrac <= -threshold
+	}
+	return deltaFrac >= threshold
+}
+
+func requireSatisfied(obs []*entity.Observation, req map[string]string) bool {
+	if len(req) == 0 {
+		return true
+	}
+	for inst, wanted := range req {
+		ok := false
+		for _, o := range obs {
+			if o.Instrument != inst {
+				continue
+			}
+			switch wanted {
+			case "pass":
+				if o.Pass != nil && *o.Pass {
+					ok = true
+				}
+			default:
+				// For v1, any non-"pass" require is treated as pass-through;
+				// we document that require-clauses other than "pass" are
+				// not evaluated yet.
+				ok = true
+			}
+			if ok {
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func goalConstraintsSatisfied(obs []*entity.Observation, constraints []entity.Constraint) bool {
+	for _, c := range constraints {
+		if !goalConstraintSatisfied(obs, c) {
+			return false
+		}
+	}
+	return true
+}
+
+func goalConstraintSatisfied(obs []*entity.Observation, c entity.Constraint) bool {
+	for _, o := range obs {
+		if o.Instrument != c.Instrument {
+			continue
+		}
+		switch {
+		case c.Max != nil:
+			if o.Value <= *c.Max {
+				return true
+			}
+		case c.Min != nil:
+			if o.Value >= *c.Min {
+				return true
+			}
+		case c.Require != "":
+			switch c.Require {
+			case "pass":
+				if o.Pass != nil && *o.Pass {
+					return true
+				}
+			default:
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func candidateObjectiveValue(obs []*entity.Observation, instrument string) (float64, bool) {
+	for _, o := range obs {
+		if o.Instrument == instrument {
+			return o.Value, true
+		}
+	}
+	return 0, false
+}

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -114,26 +114,27 @@ func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	var bestRow FrontierRow
 	for _, c := range sortedByTime {
 		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
-		if !ok {
-			continue
+		if ok {
+			cur := FrontierRow{
+				Value:          val,
+				TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+			}
+			if !hasBest {
+				hasBest = true
+				bestRow = cur
+				stalledFor = 0
+				continue
+			}
+			if FrontierRowBetter(goal, cur, bestRow) {
+				bestRow = cur
+				stalledFor = 0
+				continue
+			}
 		}
-		if !ExperimentReadClassForID(expClassByID, c.CandidateExp).LoopActionable() {
-			continue
-		}
-		cur := FrontierRow{
-			Value:          val,
-			TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
-		}
-		if !hasBest {
-			hasBest = true
-			bestRow = cur
-			stalledFor = 0
-			continue
-		}
-		if FrontierRowBetter(goal, cur, bestRow) {
-			bestRow = cur
-			stalledFor = 0
-		} else {
+		// stalled_for tracks conclusions written since the last frontier
+		// improvement, not just supported+feasible conclusions. Once the
+		// frontier exists, every later non-improving conclusion advances it.
+		if hasBest {
 			stalledFor++
 		}
 	}
@@ -169,6 +170,7 @@ func FrontierRowBetter(goal *entity.Goal, a, b FrontierRow) bool {
 }
 
 func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierGoalAssessment {
+	_ = expClassByID
 	if goal == nil || goal.IsOpenEnded() {
 		return FrontierGoalAssessment{
 			Mode:              "open_ended",
@@ -191,9 +193,10 @@ func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 		if c == nil || c.ReviewedBy == "" {
 			continue
 		}
-		if !ExperimentReadClassForID(expClassByID, c.CandidateExp).LoopActionable() {
-			continue
-		}
+		// goal_assessment is about accepted historical wins, not loop
+		// actionability. Once a supported conclusion is accepted, its parent
+		// hypothesis becomes supported and the experiment read class goes dead;
+		// the assessment must still be able to report the goal as met.
 		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
 			continue
 		}

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -44,6 +44,13 @@ type FrontierGoalAssessment struct {
 	RecommendedAction string  `json:"recommended_action"`
 }
 
+// FrontierSnapshot is the shared read projection for frontier surfaces.
+type FrontierSnapshot struct {
+	Rows       []FrontierRow          `json:"rows"`
+	Assessment FrontierGoalAssessment `json:"assessment"`
+	StalledFor int                    `json:"stalled_for"`
+}
+
 type frontierCandidate struct {
 	Conclusion *entity.Conclusion
 	Value      float64
@@ -52,7 +59,25 @@ type frontierCandidate struct {
 // ComputeFrontier returns rows in best-first order for the objective and the
 // count of conclusions written since the last frontier improvement.
 func ComputeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) (rows []FrontierRow, stalledFor int) {
-	return ComputeFrontierFromObservations(goal, concls, LoadObservationsByExperiment(s), LoadExperimentReadClasses(s))
+	snap := ComputeFrontierSnapshot(s, goal, concls)
+	return snap.Rows, snap.StalledFor
+}
+
+// ComputeFrontierSnapshot loads the read-side context needed to build a full
+// frontier projection from store-backed entities.
+func ComputeFrontierSnapshot(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) FrontierSnapshot {
+	return BuildFrontierSnapshot(goal, concls, LoadObservationsByExperiment(s), LoadExperimentReadClasses(s))
+}
+
+// BuildFrontierSnapshot composes the frontier rows, goal assessment, and
+// stalled-for counter from already-loaded read-side inputs.
+func BuildFrontierSnapshot(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierSnapshot {
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+	return FrontierSnapshot{
+		Rows:       rows,
+		Assessment: AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
+		StalledFor: stalled,
+	}
 }
 
 func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) (rows []FrontierRow, stalledFor int) {
@@ -211,8 +236,17 @@ func LoadObservationsByExperiment(s *store.Store) map[string][]*entity.Observati
 	if err != nil {
 		return nil
 	}
+	return GroupObservationsByExperiment(all)
+}
+
+// GroupObservationsByExperiment buckets already-loaded observations by their
+// experiment ID for frontier and status projections.
+func GroupObservationsByExperiment(all []*entity.Observation) map[string][]*entity.Observation {
 	m := make(map[string][]*entity.Observation, len(all))
 	for _, o := range all {
+		if o == nil {
+			continue
+		}
 		m[o.Experiment] = append(m[o.Experiment], o)
 	}
 	return m

--- a/internal/readmodel/frontier_test.go
+++ b/internal/readmodel/frontier_test.go
@@ -106,3 +106,40 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		t.Fatalf("best row classification = %q, want %q", got, want)
 	}
 }
+
+func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Completion: &entity.Completion{
+			Threshold:   0.1,
+			OnThreshold: entity.GoalOnThresholdStop,
+		},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			ReviewedBy:   "agent:gate",
+			CandidateExp: "E-0001",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.15},
+		},
+	}
+	obs := []*entity.Observation{
+		{Experiment: "E-0001", Instrument: "host_timing", Value: 85},
+	}
+
+	got := BuildFrontierSnapshot(goal, concls, GroupObservationsByExperiment(obs), nil)
+	if got.StalledFor != 0 {
+		t.Fatalf("stalled_for = %d, want 0", got.StalledFor)
+	}
+	if len(got.Rows) != 1 {
+		t.Fatalf("rows len = %d, want 1", len(got.Rows))
+	}
+	if got.Rows[0].Candidate != "E-0001" {
+		t.Fatalf("best row candidate = %q, want %q", got.Rows[0].Candidate, "E-0001")
+	}
+	if !got.Assessment.Met || got.Assessment.MetByConclusion != "C-0001" {
+		t.Fatalf("unexpected assessment: %+v", got.Assessment)
+	}
+}

--- a/internal/readmodel/frontier_test.go
+++ b/internal/readmodel/frontier_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 )
 
-func TestAssessGoalCompletion_IgnoresDeadReviewedCandidates(t *testing.T) {
+func TestAssessGoalCompletion_CountsReviewedSupportedCandidatesAfterAcceptance(t *testing.T) {
 	goal := &entity.Goal{
 		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 		Completion: &entity.Completion{
@@ -31,17 +31,17 @@ func TestAssessGoalCompletion_IgnoresDeadReviewedCandidates(t *testing.T) {
 	expClassByID := map[string]ExperimentReadClass{
 		"E-3000": {
 			Classification:   ExperimentClassificationDead,
-			HypothesisStatus: entity.StatusKilled,
+			HypothesisStatus: entity.StatusSupported,
 		},
 	}
 
 	got := AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
-	if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
+	if !got.Met || got.MetByConclusion != "C-3000" || got.RecommendedAction != "stop" {
 		t.Fatalf("unexpected assessment: %+v", got)
 	}
 }
 
-func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T) {
+func TestComputeFrontierFromObservations_StalledForCountsLaterConclusionsAfterAcceptedWin(t *testing.T) {
 	goal := &entity.Goal{
 		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
 	}
@@ -58,7 +58,7 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		{
 			ID:           "C-0002",
 			Hypothesis:   "H-0002",
-			Verdict:      entity.VerdictSupported,
+			Verdict:      entity.VerdictInconclusive,
 			CandidateExp: "E-0002",
 			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.09},
 			CreatedAt:    base.Add(1 * time.Minute),
@@ -66,40 +66,31 @@ func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T)
 		{
 			ID:           "C-0003",
 			Hypothesis:   "H-0003",
-			Verdict:      entity.VerdictSupported,
+			Verdict:      entity.VerdictRefuted,
 			CandidateExp: "E-0003",
 			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
 			CreatedAt:    base.Add(2 * time.Minute),
-		},
-		{
-			ID:           "C-0004",
-			Hypothesis:   "H-0004",
-			Verdict:      entity.VerdictSupported,
-			CandidateExp: "E-0004",
-			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.08},
-			CreatedAt:    base.Add(3 * time.Minute),
 		},
 	}
 	obsByExp := map[string][]*entity.Observation{
 		"E-0001": {{Instrument: "host_timing", Value: 100}},
 		"E-0002": {{Instrument: "host_timing", Value: 101}},
 		"E-0003": {{Instrument: "host_timing", Value: 90}},
-		"E-0004": {{Instrument: "host_timing", Value: 102}},
 	}
 
 	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]ExperimentReadClass{
-		"E-0003": {
+		"E-0001": {
 			Classification:   ExperimentClassificationDead,
-			HypothesisStatus: entity.StatusRefuted,
+			HypothesisStatus: entity.StatusSupported,
 		},
 	})
 	if got, want := stalled, 2; got != want {
 		t.Fatalf("stalled_for = %d, want %d", got, want)
 	}
-	if got, want := len(rows), 4; got != want {
+	if got, want := len(rows), 1; got != want {
 		t.Fatalf("rows len = %d, want %d", got, want)
 	}
-	if got, want := rows[0].Candidate, "E-0003"; got != want {
+	if got, want := rows[0].Candidate, "E-0001"; got != want {
 		t.Fatalf("best row candidate = %q, want %q", got, want)
 	}
 	if got, want := rows[0].Classification, ExperimentClassificationDead; got != want {
@@ -128,8 +119,14 @@ func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
 	obs := []*entity.Observation{
 		{Experiment: "E-0001", Instrument: "host_timing", Value: 85},
 	}
+	expClassByID := map[string]ExperimentReadClass{
+		"E-0001": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusSupported,
+		},
+	}
 
-	got := BuildFrontierSnapshot(goal, concls, GroupObservationsByExperiment(obs), nil)
+	got := BuildFrontierSnapshot(goal, concls, GroupObservationsByExperiment(obs), expClassByID)
 	if got.StalledFor != 0 {
 		t.Fatalf("stalled_for = %d, want 0", got.StalledFor)
 	}
@@ -141,5 +138,8 @@ func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
 	}
 	if !got.Assessment.Met || got.Assessment.MetByConclusion != "C-0001" {
 		t.Fatalf("unexpected assessment: %+v", got.Assessment)
+	}
+	if got.Rows[0].Classification != ExperimentClassificationDead {
+		t.Fatalf("row classification = %q, want %q", got.Rows[0].Classification, ExperimentClassificationDead)
 	}
 }

--- a/internal/readmodel/frontier_test.go
+++ b/internal/readmodel/frontier_test.go
@@ -1,0 +1,108 @@
+package readmodel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestAssessGoalCompletion_IgnoresDeadReviewedCandidates(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Completion: &entity.Completion{
+			Threshold:   0.2,
+			OnThreshold: entity.GoalOnThresholdStop,
+		},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-3000",
+			Hypothesis:   "H-3000",
+			Verdict:      entity.VerdictSupported,
+			ReviewedBy:   "agent:gate",
+			CandidateExp: "E-3000",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.3},
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-3000": {{Instrument: "host_timing", Value: 0.70}},
+	}
+	expClassByID := map[string]ExperimentReadClass{
+		"E-3000": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusKilled,
+		},
+	}
+
+	got := AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
+	if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
+		t.Fatalf("unexpected assessment: %+v", got)
+	}
+}
+
+func TestComputeFrontierFromObservations_StalledForIgnoresDeadRows(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	base := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0001",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.10},
+			CreatedAt:    base,
+		},
+		{
+			ID:           "C-0002",
+			Hypothesis:   "H-0002",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0002",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.09},
+			CreatedAt:    base.Add(1 * time.Minute),
+		},
+		{
+			ID:           "C-0003",
+			Hypothesis:   "H-0003",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0003",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
+			CreatedAt:    base.Add(2 * time.Minute),
+		},
+		{
+			ID:           "C-0004",
+			Hypothesis:   "H-0004",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0004",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.08},
+			CreatedAt:    base.Add(3 * time.Minute),
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-0001": {{Instrument: "host_timing", Value: 100}},
+		"E-0002": {{Instrument: "host_timing", Value: 101}},
+		"E-0003": {{Instrument: "host_timing", Value: 90}},
+		"E-0004": {{Instrument: "host_timing", Value: 102}},
+	}
+
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]ExperimentReadClass{
+		"E-0003": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusRefuted,
+		},
+	})
+	if got, want := stalled, 2; got != want {
+		t.Fatalf("stalled_for = %d, want %d", got, want)
+	}
+	if got, want := len(rows), 4; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := rows[0].Candidate, "E-0003"; got != want {
+		t.Fatalf("best row candidate = %q, want %q", got, want)
+	}
+	if got, want := rows[0].Classification, ExperimentClassificationDead; got != want {
+		t.Fatalf("best row classification = %q, want %q", got, want)
+	}
+}

--- a/internal/readmodel/status.go
+++ b/internal/readmodel/status.go
@@ -1,0 +1,84 @@
+package readmodel
+
+import (
+	"sort"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type BudgetSnapshot struct {
+	Limits BudgetLimits `json:"limits"`
+	Usage  BudgetUsage  `json:"usage"`
+}
+
+type BudgetLimits struct {
+	MaxExperiments int `json:"max_experiments"`
+	MaxWallTimeH   int `json:"max_wall_time_h"`
+	FrontierStallK int `json:"frontier_stall_k"`
+}
+
+type BudgetUsage struct {
+	Experiments int     `json:"experiments"`
+	ElapsedH    float64 `json:"elapsed_h"`
+}
+
+func BuildBudgetSnapshot(cfg *store.Config, st *store.State, now time.Time) BudgetSnapshot {
+	snap := BudgetSnapshot{}
+	if cfg != nil {
+		snap.Limits.MaxExperiments = cfg.Budgets.MaxExperiments
+		snap.Limits.MaxWallTimeH = cfg.Budgets.MaxWallTimeH
+		snap.Limits.FrontierStallK = cfg.Budgets.FrontierStallK
+	}
+	if st != nil {
+		snap.Usage.Experiments = st.Counters["E"]
+		if st.ResearchStartedAt != nil {
+			snap.Usage.ElapsedH = now.Sub(*st.ResearchStartedAt).Hours()
+		}
+	}
+	return snap
+}
+
+func BuildCounts(hypotheses, experiments, observations, conclusions int) map[string]int {
+	return buildCounts(hypotheses, experiments, observations, conclusions, -1)
+}
+
+func BuildCountsWithLessons(hypotheses, experiments, observations, conclusions, lessons int) map[string]int {
+	return buildCounts(hypotheses, experiments, observations, conclusions, lessons)
+}
+
+func buildCounts(hypotheses, experiments, observations, conclusions, lessons int) map[string]int {
+	counts := map[string]int{
+		"hypotheses":   hypotheses,
+		"experiments":  experiments,
+		"observations": observations,
+		"conclusions":  conclusions,
+	}
+	if lessons >= 0 {
+		counts["lessons"] = lessons
+	}
+	return counts
+}
+
+func FindUnobservedGoalInstruments(goal *entity.Goal, obs []*entity.Observation) []string {
+	if goal == nil {
+		return nil
+	}
+	needed := map[string]bool{goal.Objective.Instrument: true}
+	for _, c := range goal.Constraints {
+		needed[c.Instrument] = true
+	}
+	for _, o := range obs {
+		delete(needed, o.Instrument)
+	}
+	if len(needed) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(needed))
+	for inst := range needed {
+		out = append(out, inst)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/readmodel/status_test.go
+++ b/internal/readmodel/status_test.go
@@ -1,0 +1,80 @@
+package readmodel
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func TestBuildBudgetSnapshot(t *testing.T) {
+	started := time.Date(2026, 4, 18, 18, 30, 0, 0, time.UTC)
+	now := time.Date(2026, 4, 18, 20, 0, 0, 0, time.UTC)
+	cfg := &store.Config{
+		Budgets: store.Budgets{
+			MaxExperiments: 12,
+			MaxWallTimeH:   8,
+			FrontierStallK: 5,
+		},
+	}
+	st := &store.State{
+		Counters:          map[string]int{"E": 7},
+		ResearchStartedAt: &started,
+	}
+
+	got := BuildBudgetSnapshot(cfg, st, now)
+	if got.Limits.MaxExperiments != 12 || got.Limits.MaxWallTimeH != 8 || got.Limits.FrontierStallK != 5 {
+		t.Fatalf("unexpected limits: %+v", got.Limits)
+	}
+	if got.Usage.Experiments != 7 {
+		t.Fatalf("usage.experiments = %d, want 7", got.Usage.Experiments)
+	}
+	if got.Usage.ElapsedH != 1.5 {
+		t.Fatalf("usage.elapsed_h = %v, want 1.5", got.Usage.ElapsedH)
+	}
+}
+
+func TestBuildCounts(t *testing.T) {
+	got := BuildCounts(1, 2, 3, 4)
+	want := map[string]int{
+		"hypotheses":   1,
+		"experiments":  2,
+		"observations": 3,
+		"conclusions":  4,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(counts) = %d, want %d", len(got), len(want))
+	}
+	for key, wantVal := range want {
+		if got[key] != wantVal {
+			t.Fatalf("counts[%q] = %d, want %d", key, got[key], wantVal)
+		}
+	}
+}
+
+func TestBuildCountsWithLessons(t *testing.T) {
+	got := BuildCountsWithLessons(1, 2, 3, 4, 5)
+	if got["lessons"] != 5 {
+		t.Fatalf("counts[lessons] = %d, want 5", got["lessons"])
+	}
+}
+
+func TestFindUnobservedGoalInstruments(t *testing.T) {
+	flashMax := 100.0
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Constraints: []entity.Constraint{
+			{Instrument: "size_flash", Max: &flashMax},
+			{Instrument: "host_test", Require: "pass"},
+		},
+	}
+	obs := []*entity.Observation{
+		{Instrument: "host_test"},
+	}
+
+	got := FindUnobservedGoalInstruments(goal, obs)
+	if got[0] != "host_timing" || got[1] != "size_flash" || len(got) != 2 {
+		t.Fatalf("unexpected unobserved instruments: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- move read-side experiment, frontier, and status shaping further into `internal/readmodel`
- keep CLI, dashboard, and TUI focused on scope resolution, orchestration, and rendering
- reuse already-loaded scoped hypotheses and observations instead of re-reading store state to rebuild the same projections

## Why
This started as the follow-up to issue `#21`, but the branch pushes on the more fundamental seam behind it: read-only surfaces should consume shared read models instead of each embedding their own version of the business logic.

Although this PR is broader than issue `#21`, it also closes it.

Closes #21

## Testing
- `go test ./internal/readmodel`
- `go test ./internal/cli/...`
- `make test`
