### PR TITLE
lifecycle: harden conclusion reversal semantics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ This is the project's central design idea. Two enforcement points:
    forcibly downgraded from `supported` to `inconclusive` and the reason is
    recorded in `Conclusion.strict`. Critic agents can additionally call
    `conclusion downgrade` to flip a verdict to `inconclusive` with a reason.
+   Main-session authors/orchestrators use `conclusion withdraw` for
+   author-side retractions; don't fake that provenance with the critic verb.
 
 If you're tempted to weaken either path "to make a test pass" — stop and
 rethink. The whole point of the tool is that supported conclusions are hard

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -159,18 +159,21 @@ goal and names the instrument that will measure its predicted effect.
 | From                      | To                 | Trigger                                           |
 | ------------------------- | ------------------ | ------------------------------------------------- |
 | —                         | `open`             | `hypothesis add`                                  |
-| `open`                    | `unreviewed`       | `conclude` with decisive verdict (`supported`/`refuted`) |
-| `open`                    | `inconclusive`     | `conclude inconclusive` (no gate review needed)   |
+| `open` / `inconclusive`   | `unreviewed`       | `conclude` with decisive verdict (`supported`/`refuted`) |
+| `open` / `inconclusive`   | `inconclusive`     | `conclude inconclusive`                           |
 | `unreviewed`              | `supported` / `refuted` | `conclusion accept --reviewed-by`            |
-| `supported` / `refuted`   | `inconclusive`     | `conclusion downgrade --reason` (critic)          |
+| `unreviewed` / `supported` / `refuted` | `inconclusive` | `conclusion downgrade --reason` (critic) or `conclusion withdraw --reason` (author/orchestrator/human) |
 | `inconclusive`            | `unreviewed`       | `conclusion appeal --reason`                      |
-| `open`                    | `killed`           | `hypothesis kill --reason`                        |
+| `open` / `inconclusive`   | `killed`           | `hypothesis kill --reason`                        |
 | `killed`                  | `open`             | `hypothesis reopen --reason`                      |
 
 `unreviewed` is the post-conclude / pre-review holding state and exists to
 keep the two-agent firewall honest: the generator cannot derive a child
 hypothesis from, nor can `hypothesis apply` ship, a conclusion that hasn't
-been independently reviewed.
+been independently reviewed. `conclude` and `hypothesis kill` are only valid
+from `open` or `inconclusive`; if a decisive claim should no longer stand,
+the lifecycle first moves it back through `conclusion downgrade` or
+`conclusion withdraw`.
 
 ---
 
@@ -323,10 +326,10 @@ experiment, and the statistical comparison of their observations.
 | `Strict` field | Type | YAML key | Notes |
 | --- | --- | --- | --- |
 | `Passed` | `bool` | `passed` | Whether the firewall accepted the requested verdict. |
-| `RequestedFrom` | `string` | `downgraded_from` | Original verdict before a strict downgrade. |
+| `RequestedFrom` | `string` | `downgraded_from` | Original verdict before a firewall downgrade, critic downgrade, or author-side withdrawal. |
 | `RescuedBy` | `string` | `rescued_by` | Instrument name of the goal rescuer whose clause check saved the verdict. Empty when the primary passed directly or when the downgrade wasn't rescued. |
 | `Directional` | `bool` | `directional` | True when the hypothesis predicted with `MinEffect == 0` (direction-only). A rendering hint so a clean-CI but tiny effect is never mistaken for a quantitative win. |
-| `Reasons` | `[]string` | `reasons` | Why the firewall downgraded or (on rescue) what the primary looked like before rescue fired. |
+| `Reasons` | `[]string` | `reasons` | Why the verdict moved back to `inconclusive` or (on rescue) what the primary looked like before rescue fired. |
 
 | `ClauseCheck` field | Type | YAML key | Notes |
 | --- | --- | --- | --- |
@@ -346,8 +349,12 @@ crosses zero in the wrong direction, if sample counts are insufficient, or
 if `|delta_frac| < Hypothesis.Predicts.MinEffect`. A directional
 hypothesis (`MinEffect == 0`) skips the magnitude gate; the CI-clean-side
 check still applies. A critic can also call `conclusion downgrade` to flip
-a decisive verdict to `inconclusive` with a reason. `conclusion appeal`
-reverses a downgrade and moves the hypothesis back to `unreviewed`.
+a decisive verdict to `inconclusive` with a reason. The main
+session/author/human can instead call `conclusion withdraw` to retract a
+decisive claim explicitly; both paths preserve the original verdict in
+`Strict.RequestedFrom`, but the event log distinguishes critic downgrade
+from author-side withdrawal. `conclusion appeal` only reverses critic
+downgrades and moves the hypothesis back to `unreviewed`.
 
 **Rescue path**: when the goal declares `Rescuers` and a positive
 `NeutralBandFrac`, a failing `supported` check can be salvaged.
@@ -375,10 +382,18 @@ classification above.
 - Frontier rows may still point at experiments classified `dead`. That label
   controls current loop actionability and rendering; it does not invalidate a
   historically best result.
+- Current-truth surfaces treat the hypothesis's current accepted stance as
+  authoritative. Older supported conclusions from hypotheses now at
+  `refuted` or `inconclusive` no longer count toward the frontier or
+  `goal_assessment`.
 - `goal_assessment.met` is about the best accepted supported conclusion that
   still satisfies the goal's constraints and threshold. A reviewed win still
   counts after acceptance moves its hypothesis to `supported` and the
   experiment becomes read-classified `dead`.
+- Back-compat exception: legacy stores may still contain `supported` →
+  `killed` histories from before the lifecycle guard tightened. Read-only
+  frontier/goal views may still show those historical wins, but shipping and
+  default winner resolution do not treat `killed` as currently shippable.
 - `stalled_for` counts conclusions written since the last conclusion that
   actually improved the frontier. Once a frontier exists, every later
   non-improving conclusion increments the counter, even if that conclusion is

--- a/README.md
+++ b/README.md
@@ -125,9 +125,15 @@ The system is intentionally gated at a few hard boundaries:
 | **Experiment isolation** | Every experiment runs in its own git worktree from the recorded baseline. | Prevents cross-experiment leakage and makes resets cheap. |
 | **Observation dependency gate** | `observe` refuses an instrument whose declared prerequisites (for example `host_test=pass`) have not passed on the same experiment, unless `--force` is used. | Stops invalid preconditions from being mistaken for meaningful measurements. |
 | **Strict conclusion gate** | `conclude` may downgrade `supported` to `inconclusive` when the CI crosses zero in the wrong direction or the observed effect misses the hypothesis's `min_effect`. | Makes "supported" hard to earn. |
-| **Independent review gate** | Decisive conclusions can be independently accepted or downgraded by the gate reviewer or `conclusion downgrade`. | Adds a second pass over stats, artifacts, and diffs before a result is treated as settled. |
+| **Independent review gate** | Decisive conclusions stay provisional until the gate reviewer resolves them via `conclusion accept` or `conclusion downgrade`; later author-side retractions use `conclusion withdraw`. | Keeps the current scientific stance explicit and auditable. |
 | **Pause and budget gates** | Mutating verbs refuse to proceed when the project is paused or budgets are exhausted. | Gives humans and policies a hard stop on the loop. |
 | **Single-writer gate** | Only the CLI writes `.research/`. Agents and subagents must go through verbs, not file edits. | Keeps state atomic, auditable, and machine-readable. |
+
+Once a decisive claim is on the record, autoresearch treats the hypothesis
+status as the current accepted stance. If later evidence or review means the
+claim should no longer stand, move it back to `inconclusive` first via
+reviewer-side `conclusion downgrade` or author/orchestrator-side
+`conclusion withdraw`, then re-conclude from the new evidence.
 
 ## Install
 
@@ -245,7 +251,7 @@ is paused.
 | **observe** | `observe <exp> --instrument <name>`, `observe <exp> --all` |
 | **analyze** | `analyze <exp> [--baseline <exp>]` |
 | **conclude** | `conclude <hyp> --verdict ... --observations ...` |
-| **conclusion** | `list`, `show`, `accept`, `downgrade`, `appeal` |
+| **conclusion** | `list`, `show`, `accept`, `downgrade`, `withdraw`, `appeal` |
 | **tree / frontier** | `tree [--goal G-NNNN\|all]`, `frontier [--goal G-NNNN\|all]` |
 | **log** | `log [--goal G-NNNN\|all] [--tail --kind --since --follow]` |
 | **report** | `report <hyp>` |

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -128,10 +128,8 @@ to persist a verdict.`,
 				}
 				if r.Comparison != nil {
 					cmp := r.Comparison
-					w.Textf("  delta_abs:  %s  95%% CI %s\n",
-						fmtSignedNumber(cmp.DeltaAbs), fmtSignedRange(cmp.CILowAbs, cmp.CIHighAbs))
-					w.Textf("  delta_frac: %s  95%% CI %s\n",
-						fmtSignedNumber(cmp.DeltaFrac), fmtSignedRange(cmp.CILowFrac, cmp.CIHighFrac))
+					w.Textf("  delta_abs:  %s\n", formatSignedCI95(cmp.DeltaAbs, cmp.CILowAbs, cmp.CIHighAbs))
+					w.Textf("  delta_frac: %s\n", formatSignedCI95(cmp.DeltaFrac, cmp.CILowFrac, cmp.CIHighFrac))
 					w.Textf("  mann–whitney U=%.1f  p=%.4f\n", cmp.UStat, cmp.PValue)
 				}
 			}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -120,18 +120,18 @@ to persist a verdict.`,
 			for _, r := range rows {
 				w.Textln("")
 				w.Textf("instrument: %s\n", r.Instrument)
-				w.Textf("  candidate: n=%d  mean=%.6g  [%.6g, %.6g]  (stddev=%.4g)\n",
-					r.Candidate.N, r.Candidate.Mean, r.Candidate.CILow, r.Candidate.CIHigh, r.Candidate.StdDev)
+				w.Textf("  candidate: n=%d  mean=%s  %s  (stddev=%s)\n",
+					r.Candidate.N, fmtNumber(r.Candidate.Mean), fmtRange(r.Candidate.CILow, r.Candidate.CIHigh), fmtNumber(r.Candidate.StdDev))
 				if r.Baseline != nil {
-					w.Textf("  baseline:  n=%d  mean=%.6g  [%.6g, %.6g]  (stddev=%.4g)\n",
-						r.Baseline.N, r.Baseline.Mean, r.Baseline.CILow, r.Baseline.CIHigh, r.Baseline.StdDev)
+					w.Textf("  baseline:  n=%d  mean=%s  %s  (stddev=%s)\n",
+						r.Baseline.N, fmtNumber(r.Baseline.Mean), fmtRange(r.Baseline.CILow, r.Baseline.CIHigh), fmtNumber(r.Baseline.StdDev))
 				}
 				if r.Comparison != nil {
 					cmp := r.Comparison
-					w.Textf("  delta_abs:  %+.6g  95%% CI [%+.6g, %+.6g]\n",
-						cmp.DeltaAbs, cmp.CILowAbs, cmp.CIHighAbs)
-					w.Textf("  delta_frac: %+.4f  95%% CI [%+.4f, %+.4f]\n",
-						cmp.DeltaFrac, cmp.CILowFrac, cmp.CIHighFrac)
+					w.Textf("  delta_abs:  %s  95%% CI %s\n",
+						fmtSignedNumber(cmp.DeltaAbs), fmtSignedRange(cmp.CILowAbs, cmp.CIHighAbs))
+					w.Textf("  delta_frac: %s  95%% CI %s\n",
+						fmtSignedNumber(cmp.DeltaFrac), fmtSignedRange(cmp.CILowFrac, cmp.CIHighFrac))
 					w.Textf("  mann–whitney U=%.1f  p=%.4f\n", cmp.UStat, cmp.PValue)
 				}
 			}
@@ -173,4 +173,3 @@ func sortedKeys(m map[string][]*entity.Observation) []string {
 	sort.Strings(out)
 	return out
 }
-

--- a/internal/cli/appeal_render_test.go
+++ b/internal/cli/appeal_render_test.go
@@ -1,0 +1,180 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const appealedDowngradeReason = "benchmark setup was invalid"
+const appealedRebuttal = "benchmark setup was valid because warm-up and CPU pinning were already controlled"
+
+func setupAppealedConclusionScenario(t *testing.T) (string, *store.Store) {
+	t.Helper()
+	saveGlobals(t)
+
+	dir, s := setupGoalStore(t)
+	now := time.Now().UTC()
+
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "tighten loop",
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "fir", Direction: "decrease", MinEffect: 0.1},
+		KillIf:    []string{"tests fail"},
+		Status:    entity.StatusSupported,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+
+	e := &entity.Experiment{
+		ID:          "E-0001",
+		Hypothesis:  h.ID,
+		Status:      entity.ExpMeasured,
+		Baseline:    entity.Baseline{Ref: "HEAD"},
+		Instruments: []string{"timing"},
+		Author:      "agent:designer",
+		CreatedAt:   now,
+	}
+	if err := s.WriteExperiment(e); err != nil {
+		t.Fatal(err)
+	}
+
+	body := entity.AppendMarkdownSection("", "Interpretation", "The timing win matches the intended mechanism.")
+	c := &entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   h.ID,
+		Verdict:      entity.VerdictSupported,
+		CandidateExp: e.ID,
+		Effect: entity.Effect{
+			Instrument: "timing",
+			DeltaFrac:  -0.2,
+			CILowFrac:  -0.25,
+			CIHighFrac: -0.15,
+			PValue:     0.01,
+			CIMethod:   "bootstrap_bca_95",
+			NCandidate: 5,
+			NBaseline:  5,
+		},
+		StatTest:   "welch",
+		ReviewedBy: "human:gate",
+		Author:     "agent:analyst",
+		CreatedAt:  now,
+		Body:       body,
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+
+	runCLI(t, dir,
+		"conclusion", "downgrade", c.ID,
+		"--reason", appealedDowngradeReason,
+		"--reviewed-by", "human:alice",
+	)
+	runCLI(t, dir,
+		"conclusion", "appeal", c.ID,
+		"--rebuttal", appealedRebuttal,
+		"--author", "agent:orchestrator",
+	)
+
+	reopened, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return dir, reopened
+}
+
+func TestAppealedConclusionCLIReadSurfacesPreserveHistoricalDowngradeContext(t *testing.T) {
+	dir, _ := setupAppealedConclusionScenario(t)
+
+	listOut := runCLI(t, dir, "conclusion", "list", "--hypothesis", "H-0001")
+	for _, want := range []string{"C-0001", "supported", "downgraded from supported"} {
+		if !strings.Contains(listOut, want) {
+			t.Fatalf("conclusion list missing %q:\n%s", want, listOut)
+		}
+	}
+
+	showOut := runCLI(t, dir, "conclusion", "show", "C-0001")
+	for _, want := range []string{
+		"verdict:      supported",
+		"downgraded:   from \"supported\" with reasons:",
+		"critic downgrade: " + appealedDowngradeReason,
+		"# Appeal",
+		appealedRebuttal,
+	} {
+		if !strings.Contains(showOut, want) {
+			t.Fatalf("conclusion show missing %q:\n%s", want, showOut)
+		}
+	}
+	if strings.Contains(showOut, "reviewed_by:") {
+		t.Fatalf("conclusion show unexpectedly reports reviewed_by after appeal:\n%s", showOut)
+	}
+
+	reportOut := runCLI(t, dir, "report", "H-0001")
+	for _, want := range []string{
+		"### C-0001 — supported",
+		"> **Downgraded** from `supported`",
+		"critic downgrade: " + appealedDowngradeReason,
+		"# Appeal",
+		appealedRebuttal,
+	} {
+		if !strings.Contains(reportOut, want) {
+			t.Fatalf("report missing %q:\n%s", want, reportOut)
+		}
+	}
+}
+
+func TestAppealedConclusionTUIReadSurfacesPreserveHistoricalDowngradeContext(t *testing.T) {
+	_, s := setupAppealedConclusionScenario(t)
+
+	c, err := s.ReadConclusion("C-0001")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listView := newConclusionListView(goalScope{All: true})
+	nv, _ := listView.update(concListLoadedMsg{list: []*entity.Conclusion{c}}, nil)
+	listOut := stripANSI(nv.view(120, 20))
+	for _, want := range []string{"C-0001", "supported", "downgraded from supported"} {
+		if !strings.Contains(listOut, want) {
+			t.Fatalf("TUI conclusion list missing %q:\n%s", want, listOut)
+		}
+	}
+
+	detailView := newConclusionDetailView("C-0001")
+	nv, _ = detailView.update(concDetailLoadedMsg{c: c}, nil)
+	detailOut := stripANSI(nv.view(120, 30))
+	for _, want := range []string{"C-0001", "supported", "downgraded from supported", appealedDowngradeReason} {
+		if !strings.Contains(detailOut, want) {
+			t.Fatalf("TUI conclusion detail missing %q:\n%s", want, detailOut)
+		}
+	}
+	if strings.Contains(detailOut, "reviewed_by=") {
+		t.Fatalf("TUI conclusion detail unexpectedly reports reviewed_by after appeal:\n%s", detailOut)
+	}
+
+	h, err := s.ReadHypothesis("H-0001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rep, err := buildReport(s, h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportMD := renderReportMarkdown(rep)
+	view := newReportView("H-0001")
+	nv, _ = view.update(reportLoadedMsg{md: reportMD}, nil)
+	rv := nv.(*reportView)
+	reportOut := stripANSI(rv.ensureRendered(140))
+	for _, want := range []string{"C-0001", "supported", "Downgraded", "supported", appealedDowngradeReason, appealedRebuttal} {
+		if !strings.Contains(reportOut, want) {
+			t.Fatalf("TUI report missing %q:\n%s", want, reportOut)
+		}
+	}
+}

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -360,14 +360,13 @@ downgraded since there is no comparator).`,
 				w.Textf("  baseline:    %s  (n=%d)\n", baselineExp, effect.NBaseline)
 			}
 			if cmp != nil {
-				w.Textf("  delta_frac:  %s  95%% CI %s  (vs absolute baseline)\n",
-					fmtSignedNumber(effect.DeltaFrac), fmtSignedRange(effect.CILowFrac, effect.CIHighFrac))
+				w.Textf("  delta_frac:  %s  (vs absolute baseline)\n", formatSignedCI95(effect.DeltaFrac, effect.CILowFrac, effect.CIHighFrac))
 				w.Textf("  p-value:     %.4g  (%s)\n", effect.PValue, concl.StatTest)
 			}
 			if concl.IncrementalEffect != nil {
 				ie := concl.IncrementalEffect
-				w.Textf("  incremental: %s  delta_frac=%s  CI %s  (vs frontier best)\n",
-					incrementalExp, fmtSignedNumber(ie.DeltaFrac), fmtSignedRange(ie.CILowFrac, ie.CIHighFrac))
+				w.Textf("  incremental: %s  delta_frac=%s  (vs frontier best)\n",
+					incrementalExp, formatSignedCI(ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac))
 			}
 			if len(decision.Reasons) > 0 && !decision.Downgraded {
 				w.Textln("  notes:")

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -63,8 +63,17 @@ downgraded since there is no comparator).`,
 			if err != nil {
 				return err
 			}
-			if hyp.Status == entity.StatusKilled {
-				return fmt.Errorf("hypothesis %s is killed; reopen before concluding", hypID)
+			if !hypothesisStatusAllowsConclude(hyp.Status) {
+				switch hyp.Status {
+				case entity.StatusKilled:
+					return fmt.Errorf("hypothesis %s is killed; reopen before concluding", hypID)
+				case entity.StatusUnreviewed:
+					return fmt.Errorf("hypothesis %s is unreviewed — resolve the pending conclusion via `conclusion accept`, `conclusion downgrade`, or `conclusion withdraw` before concluding again", hypID)
+				case entity.StatusSupported, entity.StatusRefuted:
+					return fmt.Errorf("hypothesis %s is %s — use `conclusion withdraw` or `conclusion downgrade` before concluding again", hypID, hyp.Status)
+				default:
+					return fmt.Errorf("hypothesis %s has status %q; concluding is only valid for open or inconclusive hypotheses", hypID, hyp.Status)
+				}
 			}
 
 			// Load observations, enforce they target the hypothesis's predicted instrument

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -360,13 +360,14 @@ downgraded since there is no comparator).`,
 				w.Textf("  baseline:    %s  (n=%d)\n", baselineExp, effect.NBaseline)
 			}
 			if cmp != nil {
-				w.Textf("  delta_frac:  %+.4f  95%% CI [%+.4f, %+.4f]  (vs absolute baseline)\n", effect.DeltaFrac, effect.CILowFrac, effect.CIHighFrac)
+				w.Textf("  delta_frac:  %s  95%% CI %s  (vs absolute baseline)\n",
+					fmtSignedNumber(effect.DeltaFrac), fmtSignedRange(effect.CILowFrac, effect.CIHighFrac))
 				w.Textf("  p-value:     %.4g  (%s)\n", effect.PValue, concl.StatTest)
 			}
 			if concl.IncrementalEffect != nil {
 				ie := concl.IncrementalEffect
-				w.Textf("  incremental: %s  delta_frac=%+.4f  CI [%+.4f, %+.4f]  (vs frontier best)\n",
-					incrementalExp, ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac)
+				w.Textf("  incremental: %s  delta_frac=%s  CI %s  (vs frontier best)\n",
+					incrementalExp, fmtSignedNumber(ie.DeltaFrac), fmtSignedRange(ie.CILowFrac, ie.CIHighFrac))
 			}
 			if len(decision.Reasons) > 0 && !decision.Downgraded {
 				w.Textln("  notes:")

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -91,8 +91,8 @@ func conclusionListCmd() *cobra.Command {
 				} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
 					dg = "  [directional]"
 				}
-				w.Textf("  %-8s  %-12s  hyp=%-8s  delta_frac=%+.4f  p=%.4g%s\n",
-					c.ID, c.Verdict, c.Hypothesis, c.Effect.DeltaFrac, c.Effect.PValue, dg)
+				w.Textf("  %-8s  %-12s  hyp=%-8s  delta_frac=%s  p=%.4g%s\n",
+					c.ID, c.Verdict, c.Hypothesis, fmtSignedNumber(c.Effect.DeltaFrac), c.Effect.PValue, dg)
 			}
 			return nil
 		},
@@ -149,8 +149,8 @@ func conclusionShowCmd() *cobra.Command {
 						status = "pass"
 					}
 					if cc.Effect != nil {
-						w.Textf("  - %s (%s) %s: delta_frac=%+.4f  CI [%+.4f, %+.4f]\n",
-							cc.Instrument, cc.Role, status, cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac)
+						w.Textf("  - %s (%s) %s: delta_frac=%s  CI %s\n",
+							cc.Instrument, cc.Role, status, fmtSignedNumber(cc.Effect.DeltaFrac), fmtSignedRange(cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
 					} else {
 						w.Textf("  - %s (%s) %s\n", cc.Instrument, cc.Role, status)
 					}
@@ -164,14 +164,14 @@ func conclusionShowCmd() *cobra.Command {
 				w.Textf("baseline:     %s  (n=%d)\n", c.BaselineExp, c.Effect.NBaseline)
 			}
 			w.Textf("effect on %s:\n", c.Effect.Instrument)
-			w.Textf("  delta_frac: %+.4f  95%% CI [%+.4f, %+.4f]\n", c.Effect.DeltaFrac, c.Effect.CILowFrac, c.Effect.CIHighFrac)
-			w.Textf("  delta_abs:  %+.6g  95%% CI [%+.6g, %+.6g]\n", c.Effect.DeltaAbs, c.Effect.CILowAbs, c.Effect.CIHighAbs)
+			w.Textf("  delta_frac: %s  95%% CI %s\n", fmtSignedNumber(c.Effect.DeltaFrac), fmtSignedRange(c.Effect.CILowFrac, c.Effect.CIHighFrac))
+			w.Textf("  delta_abs:  %s  95%% CI %s\n", fmtSignedNumber(c.Effect.DeltaAbs), fmtSignedRange(c.Effect.CILowAbs, c.Effect.CIHighAbs))
 			w.Textf("  p-value:    %.4g  (%s)\n", c.Effect.PValue, c.StatTest)
 			if c.IncrementalExp != "" && c.IncrementalEffect != nil {
 				ie := c.IncrementalEffect
 				w.Textf("incremental:  %s  (vs frontier best)\n", c.IncrementalExp)
-				w.Textf("  delta_frac: %+.4f  95%% CI [%+.4f, %+.4f]\n", ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac)
-				w.Textf("  delta_abs:  %+.6g  95%% CI [%+.6g, %+.6g]\n", ie.DeltaAbs, ie.CILowAbs, ie.CIHighAbs)
+				w.Textf("  delta_frac: %s  95%% CI %s\n", fmtSignedNumber(ie.DeltaFrac), fmtSignedRange(ie.CILowFrac, ie.CIHighFrac))
+				w.Textf("  delta_abs:  %s  95%% CI %s\n", fmtSignedNumber(ie.DeltaAbs), fmtSignedRange(ie.CILowAbs, ie.CIHighAbs))
 				w.Textf("  p-value:    %.4g\n", ie.PValue)
 			}
 			w.Textf("author:       %s\n", c.Author)

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -149,8 +149,8 @@ func conclusionShowCmd() *cobra.Command {
 						status = "pass"
 					}
 					if cc.Effect != nil {
-						w.Textf("  - %s (%s) %s: delta_frac=%s  CI %s\n",
-							cc.Instrument, cc.Role, status, fmtSignedNumber(cc.Effect.DeltaFrac), fmtSignedRange(cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
+						w.Textf("  - %s (%s) %s: delta_frac=%s\n",
+							cc.Instrument, cc.Role, status, formatSignedCI(cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
 					} else {
 						w.Textf("  - %s (%s) %s\n", cc.Instrument, cc.Role, status)
 					}
@@ -164,14 +164,14 @@ func conclusionShowCmd() *cobra.Command {
 				w.Textf("baseline:     %s  (n=%d)\n", c.BaselineExp, c.Effect.NBaseline)
 			}
 			w.Textf("effect on %s:\n", c.Effect.Instrument)
-			w.Textf("  delta_frac: %s  95%% CI %s\n", fmtSignedNumber(c.Effect.DeltaFrac), fmtSignedRange(c.Effect.CILowFrac, c.Effect.CIHighFrac))
-			w.Textf("  delta_abs:  %s  95%% CI %s\n", fmtSignedNumber(c.Effect.DeltaAbs), fmtSignedRange(c.Effect.CILowAbs, c.Effect.CIHighAbs))
+			w.Textf("  delta_frac: %s\n", formatSignedCI95(c.Effect.DeltaFrac, c.Effect.CILowFrac, c.Effect.CIHighFrac))
+			w.Textf("  delta_abs:  %s\n", formatSignedCI95(c.Effect.DeltaAbs, c.Effect.CILowAbs, c.Effect.CIHighAbs))
 			w.Textf("  p-value:    %.4g  (%s)\n", c.Effect.PValue, c.StatTest)
 			if c.IncrementalExp != "" && c.IncrementalEffect != nil {
 				ie := c.IncrementalEffect
 				w.Textf("incremental:  %s  (vs frontier best)\n", c.IncrementalExp)
-				w.Textf("  delta_frac: %s  95%% CI %s\n", fmtSignedNumber(ie.DeltaFrac), fmtSignedRange(ie.CILowFrac, ie.CIHighFrac))
-				w.Textf("  delta_abs:  %s  95%% CI %s\n", fmtSignedNumber(ie.DeltaAbs), fmtSignedRange(ie.CILowAbs, ie.CIHighAbs))
+				w.Textf("  delta_frac: %s\n", formatSignedCI95(ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac))
+				w.Textf("  delta_abs:  %s\n", formatSignedCI95(ie.DeltaAbs, ie.CILowAbs, ie.CIHighAbs))
 				w.Textf("  p-value:    %.4g\n", ie.PValue)
 			}
 			w.Textf("author:       %s\n", c.Author)

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -7,8 +7,24 @@ import (
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/store"
 	"github.com/spf13/cobra"
 )
+
+type conclusionInconclusiveTransition struct {
+	Action       string
+	DryRunVerb   string
+	ResultVerb   string
+	EventKind    string
+	ReasonPrefix string
+	ReasonLabel  string
+	Actor        string
+	ReviewedBy   string
+	LessonMode   lessonSyncMode
+	BodySection  string
+	BodyTemplate string
+	EventExtra   map[string]any
+}
 
 func conclusionCommands() []*cobra.Command {
 	c := &cobra.Command{
@@ -203,70 +219,20 @@ marked inconclusive.`,
 			if err != nil {
 				return err
 			}
-			switch c.Verdict {
-			case entity.VerdictSupported, entity.VerdictRefuted:
-			case entity.VerdictInconclusive:
-				return fmt.Errorf("%s is already inconclusive; nothing to downgrade", c.ID)
-			default:
-				return fmt.Errorf("%s has unknown verdict %q", c.ID, c.Verdict)
-			}
-			prev := c.Verdict
-			c.Verdict = entity.VerdictInconclusive
-			if c.Strict.RequestedFrom == "" {
-				c.Strict.RequestedFrom = prev
-			}
-			c.Strict.Passed = false
-			c.Strict.Reasons = append(c.Strict.Reasons, "critic downgrade: "+reason)
-			if reviewedBy != "" {
-				c.ReviewedBy = reviewedBy
-			}
-			if err := dryRun(w, fmt.Sprintf("downgrade %s from %s to inconclusive (%s)", c.ID, prev, reason), map[string]any{"id": c.ID, "from": prev, "reason": reason}); err != nil {
-				return err
-			}
-			if err := s.WriteConclusion(c); err != nil {
-				return err
-			}
-			// Update hypothesis status to match.
-			hyp, err := s.ReadHypothesis(c.Hypothesis)
-			if err == nil {
-				hyp.Status = entity.VerdictInconclusive
-				_ = s.WriteHypothesis(hyp)
-			}
-			lessonChanges, err := syncHypothesisLessons(s, c.Hypothesis, lessonSyncOnDowngrade)
-			if err != nil {
-				return err
-			}
-			for _, change := range lessonChanges {
-				if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), or(reviewedBy, "agent:critic"), change.LessonID, map[string]any{
-					"from_status": change.FromStatus,
-					"to_status":   change.ToStatus,
-					"from_source": change.FromSource,
-					"to_source":   change.ToSource,
-					"hypothesis":  c.Hypothesis,
-					"conclusion":  c.ID,
-				}); err != nil {
-					return err
-				}
-			}
-			if err := emitEvent(s, "conclusion.critic_downgrade", "agent:critic", c.ID, map[string]any{
-				"from":        prev,
-				"reason":      reason,
-				"reviewed_by": reviewedBy,
-				"hypothesis":  c.Hypothesis,
-			}); err != nil {
-				return err
-			}
-			return w.Emit(
-				fmt.Sprintf("downgraded %s: %s → inconclusive (%s)", c.ID, prev, reason),
-				map[string]any{
-					"status":     "ok",
-					"id":         c.ID,
-					"from":       prev,
-					"to":         entity.VerdictInconclusive,
-					"reason":     reason,
-					"hypothesis": c.Hypothesis,
+			return transitionConclusionToInconclusive(w, s, c, reason, conclusionInconclusiveTransition{
+				Action:       "downgrade",
+				DryRunVerb:   "downgrade",
+				ResultVerb:   "downgraded",
+				EventKind:    "conclusion.critic_downgrade",
+				ReasonPrefix: conclusionReasonCriticDowngradePrefix,
+				ReasonLabel:  "downgrade",
+				Actor:        "agent:critic",
+				ReviewedBy:   reviewedBy,
+				LessonMode:   lessonSyncOnDowngrade,
+				EventExtra: map[string]any{
+					"reviewed_by": reviewedBy,
 				},
-			)
+			})
 		},
 	}
 	c.Flags().StringVar(&reason, "reason", "", "why the conclusion is being downgraded (required)")
@@ -305,71 +271,19 @@ before re-concluding the hypothesis from new evidence.`,
 			if err != nil {
 				return err
 			}
-			switch c.Verdict {
-			case entity.VerdictSupported, entity.VerdictRefuted:
-			case entity.VerdictInconclusive:
-				return fmt.Errorf("%s is already inconclusive; nothing to withdraw", c.ID)
-			default:
-				return fmt.Errorf("%s has unknown verdict %q", c.ID, c.Verdict)
-			}
-
-			prev := c.Verdict
 			withdrawer := or(author, "agent:orchestrator")
-			if err := dryRun(w, fmt.Sprintf("withdraw %s from %s (%s)", c.ID, prev, reason), map[string]any{"id": c.ID, "from": prev, "reason": reason}); err != nil {
-				return err
-			}
-
-			c.Verdict = entity.VerdictInconclusive
-			if c.Strict.RequestedFrom == "" {
-				c.Strict.RequestedFrom = prev
-			}
-			c.Strict.Passed = false
-			c.Strict.Reasons = append(c.Strict.Reasons, conclusionReasonWithdrawalPrefix+reason)
-			c.Body = entity.AppendMarkdownSection(c.Body, "Withdrawal", fmt.Sprintf("**Withdrawn by:** %s\n\n%s", withdrawer, reason))
-			if err := s.WriteConclusion(c); err != nil {
-				return err
-			}
-
-			hyp, err := s.ReadHypothesis(c.Hypothesis)
-			if err == nil {
-				hyp.Status = entity.StatusInconclusive
-				_ = s.WriteHypothesis(hyp)
-			}
-			lessonChanges, err := syncHypothesisLessons(s, c.Hypothesis, lessonSyncOnWithdraw)
-			if err != nil {
-				return err
-			}
-			for _, change := range lessonChanges {
-				if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), withdrawer, change.LessonID, map[string]any{
-					"from_status": change.FromStatus,
-					"to_status":   change.ToStatus,
-					"from_source": change.FromSource,
-					"to_source":   change.ToSource,
-					"hypothesis":  c.Hypothesis,
-					"conclusion":  c.ID,
-				}); err != nil {
-					return err
-				}
-			}
-			if err := emitEvent(s, "conclusion.withdraw", withdrawer, c.ID, map[string]any{
-				"from":       prev,
-				"to":         entity.VerdictInconclusive,
-				"reason":     reason,
-				"hypothesis": c.Hypothesis,
-			}); err != nil {
-				return err
-			}
-			return w.Emit(
-				fmt.Sprintf("withdrew %s: %s → inconclusive (%s)", c.ID, prev, reason),
-				map[string]any{
-					"status":     "ok",
-					"id":         c.ID,
-					"from":       prev,
-					"to":         entity.VerdictInconclusive,
-					"reason":     reason,
-					"hypothesis": c.Hypothesis,
-				},
-			)
+			return transitionConclusionToInconclusive(w, s, c, reason, conclusionInconclusiveTransition{
+				Action:       "withdraw",
+				DryRunVerb:   "withdraw",
+				ResultVerb:   "withdrew",
+				EventKind:    "conclusion.withdraw",
+				ReasonPrefix: conclusionReasonWithdrawalPrefix,
+				ReasonLabel:  "withdraw",
+				Actor:        withdrawer,
+				LessonMode:   lessonSyncOnWithdraw,
+				BodySection:  "Withdrawal",
+				BodyTemplate: "**Withdrawn by:** %s\n\n%s",
+			})
 		},
 	}
 	c.Flags().StringVar(&reason, "reason", "", "why the conclusion is being withdrawn (required)")
@@ -439,21 +353,8 @@ conclusion cannot be shipped until it has been reviewed.`,
 				hyp.Status = c.Verdict
 				_ = s.WriteHypothesis(hyp)
 			}
-			lessonChanges, err := syncHypothesisLessons(s, c.Hypothesis, lessonSyncOnAccept)
-			if err != nil {
+			if err := emitHypothesisLessonSyncEvents(s, c.Hypothesis, c.ID, lessonSyncOnAccept, reviewedBy); err != nil {
 				return err
-			}
-			for _, change := range lessonChanges {
-				if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), reviewedBy, change.LessonID, map[string]any{
-					"from_status": change.FromStatus,
-					"to_status":   change.ToStatus,
-					"from_source": change.FromSource,
-					"to_source":   change.ToSource,
-					"hypothesis":  c.Hypothesis,
-					"conclusion":  c.ID,
-				}); err != nil {
-					return err
-				}
 			}
 
 			if err := emitEvent(s, "conclusion.accept", reviewedBy, c.ID, map[string]any{
@@ -544,24 +445,12 @@ verdict should stand.`,
 				hyp.Status = entity.StatusUnreviewed
 				_ = s.WriteHypothesis(hyp)
 			}
-			lessonChanges, err := syncHypothesisLessons(s, c.Hypothesis, lessonSyncOnAppeal)
-			if err != nil {
+			appealer := or(author, "agent:orchestrator")
+			if err := emitHypothesisLessonSyncEvents(s, c.Hypothesis, c.ID, lessonSyncOnAppeal, appealer); err != nil {
 				return err
 			}
-			for _, change := range lessonChanges {
-				if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), or(author, "agent:orchestrator"), change.LessonID, map[string]any{
-					"from_status": change.FromStatus,
-					"to_status":   change.ToStatus,
-					"from_source": change.FromSource,
-					"to_source":   change.ToSource,
-					"hypothesis":  c.Hypothesis,
-					"conclusion":  c.ID,
-				}); err != nil {
-					return err
-				}
-			}
 
-			if err := emitEvent(s, "conclusion.appeal", or(author, "agent:orchestrator"), c.ID, map[string]any{
+			if err := emitEvent(s, "conclusion.appeal", appealer, c.ID, map[string]any{
 				"original_verdict": originalVerdict,
 				"hypothesis":       c.Hypothesis,
 				"rebuttal":         truncate(rebuttal, 200),
@@ -583,4 +472,102 @@ verdict should stand.`,
 	c.Flags().StringVar(&rebuttal, "rebuttal", "", "specific disagreement with the downgrade reason (required)")
 	addAuthorFlag(c, &author, "")
 	return c
+}
+
+func transitionConclusionToInconclusive(w *output.Writer, s *store.Store, c *entity.Conclusion, reason string, spec conclusionInconclusiveTransition) error {
+	prev, err := validateConclusionCanBecomeInconclusive(c, spec.Action)
+	if err != nil {
+		return err
+	}
+	if err := dryRun(w, fmt.Sprintf("%s %s from %s to inconclusive (%s)", spec.DryRunVerb, c.ID, prev, reason), map[string]any{"id": c.ID, "from": prev, "reason": reason}); err != nil {
+		return err
+	}
+
+	c.Verdict = entity.VerdictInconclusive
+	if c.Strict.RequestedFrom == "" {
+		c.Strict.RequestedFrom = prev
+	}
+	c.Strict.Passed = false
+	c.Strict.Reasons = append(c.Strict.Reasons, spec.ReasonPrefix+reason)
+	if spec.ReviewedBy != "" {
+		c.ReviewedBy = spec.ReviewedBy
+	}
+	if spec.BodySection != "" {
+		c.Body = entity.AppendMarkdownSection(c.Body, spec.BodySection, fmt.Sprintf(spec.BodyTemplate, spec.Actor, reason))
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		return err
+	}
+	if err := setHypothesisStatusIfPresent(s, c.Hypothesis, entity.StatusInconclusive); err != nil {
+		return err
+	}
+	if err := emitHypothesisLessonSyncEvents(s, c.Hypothesis, c.ID, spec.LessonMode, spec.Actor); err != nil {
+		return err
+	}
+	eventData := map[string]any{
+		"from":       prev,
+		"to":         entity.VerdictInconclusive,
+		"reason":     reason,
+		"hypothesis": c.Hypothesis,
+	}
+	for k, v := range spec.EventExtra {
+		eventData[k] = v
+	}
+	if err := emitEvent(s, spec.EventKind, spec.Actor, c.ID, eventData); err != nil {
+		return err
+	}
+	return w.Emit(
+		fmt.Sprintf("%s %s: %s → inconclusive (%s)", spec.ResultVerb, c.ID, prev, reason),
+		map[string]any{
+			"status":     "ok",
+			"id":         c.ID,
+			"from":       prev,
+			"to":         entity.VerdictInconclusive,
+			"reason":     reason,
+			"hypothesis": c.Hypothesis,
+		},
+	)
+}
+
+func validateConclusionCanBecomeInconclusive(c *entity.Conclusion, action string) (string, error) {
+	switch c.Verdict {
+	case entity.VerdictSupported, entity.VerdictRefuted:
+		return c.Verdict, nil
+	case entity.VerdictInconclusive:
+		return "", fmt.Errorf("%s is already inconclusive; nothing to %s", c.ID, action)
+	default:
+		return "", fmt.Errorf("%s has unknown verdict %q", c.ID, c.Verdict)
+	}
+}
+
+func setHypothesisStatusIfPresent(s *store.Store, hypID, status string) error {
+	hyp, err := s.ReadHypothesis(hypID)
+	if err != nil {
+		if errors.Is(err, store.ErrHypothesisNotFound) {
+			return nil
+		}
+		return err
+	}
+	hyp.Status = status
+	return s.WriteHypothesis(hyp)
+}
+
+func emitHypothesisLessonSyncEvents(s *store.Store, hypID, conclID string, mode lessonSyncMode, actor string) error {
+	lessonChanges, err := syncHypothesisLessons(s, hypID, mode)
+	if err != nil {
+		return err
+	}
+	for _, change := range lessonChanges {
+		if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), actor, change.LessonID, map[string]any{
+			"from_status": change.FromStatus,
+			"to_status":   change.ToStatus,
+			"from_source": change.FromSource,
+			"to_source":   change.ToSource,
+			"hypothesis":  hypID,
+			"conclusion":  conclID,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -19,6 +19,7 @@ type conclusionInconclusiveTransition struct {
 	ReasonPrefix string
 	ReasonLabel  string
 	Actor        string
+	LessonActor  string
 	ReviewedBy   string
 	LessonMode   lessonSyncMode
 	BodySection  string
@@ -227,6 +228,7 @@ marked inconclusive.`,
 				ReasonPrefix: conclusionReasonCriticDowngradePrefix,
 				ReasonLabel:  "downgrade",
 				Actor:        "agent:critic",
+				LessonActor:  or(reviewedBy, "agent:critic"),
 				ReviewedBy:   reviewedBy,
 				LessonMode:   lessonSyncOnDowngrade,
 				EventExtra: map[string]any{
@@ -501,7 +503,7 @@ func transitionConclusionToInconclusive(w *output.Writer, s *store.Store, c *ent
 	if err := setHypothesisStatusIfPresent(s, c.Hypothesis, entity.StatusInconclusive); err != nil {
 		return err
 	}
-	if err := emitHypothesisLessonSyncEvents(s, c.Hypothesis, c.ID, spec.LessonMode, spec.Actor); err != nil {
+	if err := emitHypothesisLessonSyncEvents(s, c.Hypothesis, c.ID, spec.LessonMode, or(spec.LessonActor, spec.Actor)); err != nil {
 		return err
 	}
 	eventData := map[string]any{

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -13,9 +13,16 @@ import (
 func conclusionCommands() []*cobra.Command {
 	c := &cobra.Command{
 		Use:   "conclusion",
-		Short: "Inspect and (for the critic) downgrade existing conclusions",
+		Short: "Inspect and revise existing conclusions",
 	}
-	c.AddCommand(conclusionListCmd(), conclusionShowCmd(), conclusionDowngradeCmd(), conclusionAcceptCmd(), conclusionAppealCmd())
+	c.AddCommand(
+		conclusionListCmd(),
+		conclusionShowCmd(),
+		conclusionDowngradeCmd(),
+		conclusionWithdrawCmd(),
+		conclusionAcceptCmd(),
+		conclusionAppealCmd(),
+	)
 	return []*cobra.Command{c}
 }
 
@@ -61,8 +68,8 @@ func conclusionListCmd() *cobra.Command {
 			}
 			for _, c := range filtered {
 				dg := ""
-				if c.Strict.RequestedFrom != "" {
-					dg = fmt.Sprintf("  [downgraded from %s]", c.Strict.RequestedFrom)
+				if summary := conclusionAdjustmentSummary(c); summary != "" {
+					dg = fmt.Sprintf("  [%s]", summary)
 				} else if c.Strict.RescuedBy != "" {
 					dg = fmt.Sprintf("  [rescued by %s]", c.Strict.RescuedBy)
 				} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
@@ -102,7 +109,11 @@ func conclusionShowCmd() *cobra.Command {
 			w.Textf("hypothesis:   %s\n", c.Hypothesis)
 			w.Textf("verdict:      %s\n", c.Verdict)
 			if c.Strict.RequestedFrom != "" {
-				w.Textf("downgraded:   from %q with reasons:\n", c.Strict.RequestedFrom)
+				label := "downgraded"
+				if conclusionAdjustmentKind(c) == conclusionAdjustmentWith {
+					label = "withdrawn"
+				}
+				w.Textf("%s:   from %q with reasons:\n", label, c.Strict.RequestedFrom)
 				for _, r := range c.Strict.Reasons {
 					w.Textf("  - %s\n", r)
 				}
@@ -263,6 +274,109 @@ marked inconclusive.`,
 	return c
 }
 
+func conclusionWithdrawCmd() *cobra.Command {
+	var (
+		reason string
+		author string
+	)
+	c := &cobra.Command{
+		Use:   "withdraw <id>",
+		Short: "Withdraw a decisive conclusion and return the hypothesis to inconclusive",
+		Long: `Withdraw a decisive conclusion when the main session, author, or human
+decides the accepted or pending claim should no longer stand. This flips
+the conclusion from supported/refuted to inconclusive, preserves the
+original verdict in strict_check.downgraded_from, records a withdrawal
+reason, and updates the hypothesis status to inconclusive.
+
+Unlike conclusion downgrade, withdrawal is not a critic-only review
+action. It is the author/orchestrator-side path for retracting a claim
+before re-concluding the hypothesis from new evidence.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := output.Default(globalJSON)
+			if strings.TrimSpace(reason) == "" {
+				return errors.New("--reason is required")
+			}
+			s, err := openStoreLive()
+			if err != nil {
+				return err
+			}
+			c, err := s.ReadConclusion(args[0])
+			if err != nil {
+				return err
+			}
+			switch c.Verdict {
+			case entity.VerdictSupported, entity.VerdictRefuted:
+			case entity.VerdictInconclusive:
+				return fmt.Errorf("%s is already inconclusive; nothing to withdraw", c.ID)
+			default:
+				return fmt.Errorf("%s has unknown verdict %q", c.ID, c.Verdict)
+			}
+
+			prev := c.Verdict
+			withdrawer := or(author, "agent:orchestrator")
+			if err := dryRun(w, fmt.Sprintf("withdraw %s from %s (%s)", c.ID, prev, reason), map[string]any{"id": c.ID, "from": prev, "reason": reason}); err != nil {
+				return err
+			}
+
+			c.Verdict = entity.VerdictInconclusive
+			if c.Strict.RequestedFrom == "" {
+				c.Strict.RequestedFrom = prev
+			}
+			c.Strict.Passed = false
+			c.Strict.Reasons = append(c.Strict.Reasons, conclusionReasonWithdrawalPrefix+reason)
+			c.Body = entity.AppendMarkdownSection(c.Body, "Withdrawal", fmt.Sprintf("**Withdrawn by:** %s\n\n%s", withdrawer, reason))
+			if err := s.WriteConclusion(c); err != nil {
+				return err
+			}
+
+			hyp, err := s.ReadHypothesis(c.Hypothesis)
+			if err == nil {
+				hyp.Status = entity.StatusInconclusive
+				_ = s.WriteHypothesis(hyp)
+			}
+			lessonChanges, err := syncHypothesisLessons(s, c.Hypothesis, lessonSyncOnWithdraw)
+			if err != nil {
+				return err
+			}
+			for _, change := range lessonChanges {
+				if err := emitEvent(s, lessonEventKindForStatus(change.ToStatus), withdrawer, change.LessonID, map[string]any{
+					"from_status": change.FromStatus,
+					"to_status":   change.ToStatus,
+					"from_source": change.FromSource,
+					"to_source":   change.ToSource,
+					"hypothesis":  c.Hypothesis,
+					"conclusion":  c.ID,
+				}); err != nil {
+					return err
+				}
+			}
+			if err := emitEvent(s, "conclusion.withdraw", withdrawer, c.ID, map[string]any{
+				"from":       prev,
+				"to":         entity.VerdictInconclusive,
+				"reason":     reason,
+				"hypothesis": c.Hypothesis,
+			}); err != nil {
+				return err
+			}
+			return w.Emit(
+				fmt.Sprintf("withdrew %s: %s → inconclusive (%s)", c.ID, prev, reason),
+				map[string]any{
+					"status":     "ok",
+					"id":         c.ID,
+					"from":       prev,
+					"to":         entity.VerdictInconclusive,
+					"reason":     reason,
+					"hypothesis": c.Hypothesis,
+				},
+			)
+		},
+	}
+	c.Flags().StringVar(&reason, "reason", "", "why the conclusion is being withdrawn (required)")
+	addAuthorFlag(c, &author, "")
+	return c
+}
+
 func conclusionAcceptCmd() *cobra.Command {
 	var (
 		reviewedBy string
@@ -404,15 +518,11 @@ verdict should stand.`,
 			if c.Strict.RequestedFrom == "" {
 				return fmt.Errorf("%s was not downgraded (no original verdict recorded) — nothing to appeal", c.ID)
 			}
-			// Only allow appeal of critic downgrades.
-			hasCriticDowngrade := false
-			for _, r := range c.Strict.Reasons {
-				if strings.HasPrefix(r, "critic downgrade:") {
-					hasCriticDowngrade = true
-					break
-				}
-			}
-			if !hasCriticDowngrade {
+			switch conclusionAdjustmentKind(c) {
+			case conclusionAdjustmentCrit:
+			case conclusionAdjustmentWith:
+				return fmt.Errorf("%s was withdrawn, not critic-downgraded — re-conclude the hypothesis once new evidence is ready", c.ID)
+			default:
 				return fmt.Errorf("%s was downgraded by the firewall, not a critic — you cannot appeal statistical evidence; collect better data instead", c.ID)
 			}
 

--- a/internal/cli/conclusion_adjustment.go
+++ b/internal/cli/conclusion_adjustment.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+const (
+	conclusionReasonCriticDowngradePrefix = "critic downgrade: "
+	conclusionReasonWithdrawalPrefix      = "withdrawal: "
+)
+
+const (
+	conclusionAdjustmentNone = ""
+	conclusionAdjustmentFire = "firewall_downgrade"
+	conclusionAdjustmentCrit = "critic_downgrade"
+	conclusionAdjustmentWith = "withdrawn"
+)
+
+func conclusionAdjustmentKind(c *entity.Conclusion) string {
+	if c == nil || c.Strict.RequestedFrom == "" {
+		return conclusionAdjustmentNone
+	}
+	switch {
+	case conclusionReasonHasPrefix(c.Strict.Reasons, conclusionReasonWithdrawalPrefix):
+		return conclusionAdjustmentWith
+	case conclusionReasonHasPrefix(c.Strict.Reasons, conclusionReasonCriticDowngradePrefix):
+		return conclusionAdjustmentCrit
+	default:
+		return conclusionAdjustmentFire
+	}
+}
+
+func conclusionAdjustmentSummary(c *entity.Conclusion) string {
+	if c == nil || c.Strict.RequestedFrom == "" {
+		return ""
+	}
+	switch conclusionAdjustmentKind(c) {
+	case conclusionAdjustmentWith:
+		return "withdrawn from " + c.Strict.RequestedFrom
+	default:
+		return "downgraded from " + c.Strict.RequestedFrom
+	}
+}
+
+func conclusionReasonHasPrefix(reasons []string, prefix string) bool {
+	for _, r := range reasons {
+		if strings.HasPrefix(r, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -538,8 +538,8 @@ func renderDashboardFrontier(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 			if r.Classification == experimentClassificationDead {
 				dead = "  " + a.dim(experimentClassificationMarker(r.Classification))
 			}
-			fmt.Fprintf(w, " %s %s  %s  %s=%.6g%s\n",
-				marker, a.cyan(r.Conclusion), a.cyan(r.Hypothesis), snap.Goal.Objective.Instrument, r.Value, dead)
+			fmt.Fprintf(w, " %s %s  %s  %s=%s%s\n",
+				marker, a.cyan(r.Conclusion), a.cyan(r.Hypothesis), snap.Goal.Objective.Instrument, fmtNumber(r.Value), dead)
 		}
 	}
 	if lim := snap.Budgets.Limits.FrontierStallK; lim > 0 {

--- a/internal/cli/display_format.go
+++ b/internal/cli/display_format.go
@@ -1,0 +1,120 @@
+package cli
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Human-facing CLI/TUI/report surfaces intentionally round more aggressively
+// than JSON. JSON stays the machine contract; these helpers are for readable
+// text where six significant digits on 0-100 scale values is usually noise.
+
+func fmtNumber(v float64) string {
+	switch {
+	case math.IsNaN(v):
+		return "NaN"
+	case math.IsInf(v, 1):
+		return "+Inf"
+	case math.IsInf(v, -1):
+		return "-Inf"
+	case v == 0:
+		return "0"
+	case v == math.Trunc(v) && math.Abs(v) < 1e15:
+		return strconv.FormatInt(int64(v), 10)
+	}
+
+	abs := math.Abs(v)
+	switch {
+	case abs < 0.01 || abs >= 1e6:
+		return strconv.FormatFloat(v, 'g', 4, 64)
+	case abs >= 1000:
+		return trimTrailingZeros(strconv.FormatFloat(v, 'f', 0, 64))
+	case abs >= 100:
+		return trimTrailingZeros(strconv.FormatFloat(v, 'f', 1, 64))
+	case abs >= 10:
+		return trimTrailingZeros(strconv.FormatFloat(v, 'f', 2, 64))
+	case abs >= 1:
+		return trimTrailingZeros(strconv.FormatFloat(v, 'f', 3, 64))
+	default:
+		return trimTrailingZeros(strconv.FormatFloat(v, 'f', 4, 64))
+	}
+}
+
+func fmtSignedNumber(v float64) string {
+	if v > 0 {
+		return "+" + fmtNumber(v)
+	}
+	return fmtNumber(v)
+}
+
+func fmtRange(low, high float64) string {
+	return fmt.Sprintf("[%s, %s]", fmtNumber(low), fmtNumber(high))
+}
+
+func fmtSignedRange(low, high float64) string {
+	return fmt.Sprintf("[%s, %s]", fmtSignedNumber(low), fmtSignedNumber(high))
+}
+
+// fmtValue formats a numeric value with a compact unit suffix.
+// Seconds are scaled to ns/us/ms/s; bytes shortened to B/KB/MB; everything
+// else gets compact human precision plus the unit suffix.
+func fmtValue(v float64, unit string) string {
+	switch unit {
+	case "seconds", "s":
+		switch {
+		case v == 0:
+			return "0s"
+		case math.Abs(v) < 1e-6:
+			return trimTrailingZeros(strconv.FormatFloat(v*1e9, 'f', 2, 64)) + "ns"
+		case math.Abs(v) < 1e-3:
+			return trimTrailingZeros(strconv.FormatFloat(v*1e6, 'f', 2, 64)) + "us"
+		case math.Abs(v) < 1:
+			return trimTrailingZeros(strconv.FormatFloat(v*1e3, 'f', 2, 64)) + "ms"
+		default:
+			return trimTrailingZeros(strconv.FormatFloat(v, 'f', 2, 64)) + "s"
+		}
+	case "bytes", "byte", "B":
+		abs := math.Abs(v)
+		switch {
+		case abs >= 1024*1024:
+			return trimTrailingZeros(strconv.FormatFloat(v/(1024*1024), 'f', 1, 64)) + "MB"
+		case abs >= 1024:
+			return trimTrailingZeros(strconv.FormatFloat(v/1024, 'f', 1, 64)) + "KB"
+		default:
+			return trimTrailingZeros(strconv.FormatFloat(v, 'f', 0, 64)) + "B"
+		}
+	default:
+		return fmtNumber(v) + shortUnit(unit)
+	}
+}
+
+func fmtValueRange(low, high float64, unit string) string {
+	return fmt.Sprintf("[%s, %s]", fmtValue(low, unit), fmtValue(high, unit))
+}
+
+func shortUnit(u string) string {
+	switch u {
+	case "cycles":
+		return "cyc"
+	case "instructions":
+		return "ins"
+	case "pass":
+		return ""
+	default:
+		return u
+	}
+}
+
+func trimTrailingZeros(s string) string {
+	if strings.ContainsAny(s, "eE") {
+		return s
+	}
+	s = strings.TrimRight(s, "0")
+	s = strings.TrimRight(s, ".")
+	if s == "-0" || s == "+0" || s == "" {
+		return "0"
+	}
+	return s
+}

--- a/internal/cli/display_format.go
+++ b/internal/cli/display_format.go
@@ -5,6 +5,8 @@ import (
 	"math"
 	"strconv"
 	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
 )
 
 // Human-facing CLI/TUI/report surfaces intentionally round more aggressively
@@ -57,6 +59,18 @@ func fmtSignedRange(low, high float64) string {
 	return fmt.Sprintf("[%s, %s]", fmtSignedNumber(low), fmtSignedNumber(high))
 }
 
+func formatGoalThresholdDecision(threshold float64, onThreshold string) string {
+	return fmt.Sprintf("threshold=%s -> %s", fmtNumber(threshold), onThreshold)
+}
+
+func formatSignedCI95(delta, low, high float64) string {
+	return fmt.Sprintf("%s  95%% CI %s", fmtSignedNumber(delta), fmtSignedRange(low, high))
+}
+
+func formatSignedCI(delta, low, high float64) string {
+	return fmt.Sprintf("%s  CI %s", fmtSignedNumber(delta), fmtSignedRange(low, high))
+}
+
 // fmtValue formats a numeric value with a compact unit suffix.
 // Seconds are scaled to ns/us/ms/s; bytes shortened to B/KB/MB; everything
 // else gets compact human precision plus the unit suffix.
@@ -92,6 +106,23 @@ func fmtValue(v float64, unit string) string {
 
 func fmtValueRange(low, high float64, unit string) string {
 	return fmt.Sprintf("[%s, %s]", fmtValue(low, unit), fmtValue(high, unit))
+}
+
+// formatPredictedEffect renders a PredictedEffect as a human-readable string
+// like "decrease host_timing by ≥0.05 (up to 0.1)".
+func formatPredictedEffect(pe *entity.PredictedEffect) string {
+	s := fmt.Sprintf("%s %s by ≥%s", pe.Direction, pe.Instrument, fmtNumber(pe.MinEffect))
+	if pe.MaxEffect > 0 {
+		s += fmt.Sprintf(" (up to %s)", fmtNumber(pe.MaxEffect))
+	}
+	return s
+}
+
+func formatPredictedEffectRange(pe *entity.PredictedEffect) string {
+	if pe.MaxEffect > 0 {
+		return fmt.Sprintf("%s–%s", fmtNumber(pe.MinEffect), fmtNumber(pe.MaxEffect))
+	}
+	return fmtNumber(pe.MinEffect)
 }
 
 func shortUnit(u string) string {

--- a/internal/cli/display_format_test.go
+++ b/internal/cli/display_format_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
 
 func TestFmtNumber(t *testing.T) {
 	t.Parallel()
@@ -74,5 +78,32 @@ func TestFmtValue(t *testing.T) {
 				t.Fatalf("fmtValue(%v, %q) = %q, want %q", tc.v, tc.unit, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestFormatHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got, want := formatGoalThresholdDecision(0.2, "ask_human"), "threshold=0.2 -> ask_human"; got != want {
+		t.Fatalf("formatGoalThresholdDecision() = %q, want %q", got, want)
+	}
+	if got, want := formatSignedCI95(-0.123456, -0.2, -0.05), "-0.1235  95% CI [-0.2, -0.05]"; got != want {
+		t.Fatalf("formatSignedCI95() = %q, want %q", got, want)
+	}
+	if got, want := formatSignedCI(0.123456, 0.05, 0.2), "+0.1235  CI [+0.05, +0.2]"; got != want {
+		t.Fatalf("formatSignedCI() = %q, want %q", got, want)
+	}
+
+	pe := &entity.PredictedEffect{
+		Instrument: "timing",
+		Direction:  "decrease",
+		MinEffect:  0.05,
+		MaxEffect:  0.1,
+	}
+	if got, want := formatPredictedEffect(pe), "decrease timing by ≥0.05 (up to 0.1)"; got != want {
+		t.Fatalf("formatPredictedEffect() = %q, want %q", got, want)
+	}
+	if got, want := formatPredictedEffectRange(pe), "0.05–0.1"; got != want {
+		t.Fatalf("formatPredictedEffectRange() = %q, want %q", got, want)
 	}
 }

--- a/internal/cli/display_format_test.go
+++ b/internal/cli/display_format_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import "testing"
+
+func TestFmtNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		v    float64
+		want string
+	}{
+		{name: "zero", v: 0, want: "0"},
+		{name: "whole number", v: 80, want: "80"},
+		{name: "two decimal medium value", v: 80.123456, want: "80.12"},
+		{name: "four decimal subunit value", v: 0.123456, want: "0.1235"},
+		{name: "tiny value keeps signal", v: 0.00987654, want: "0.009877"},
+		{name: "large value rounds compactly", v: 1234.56, want: "1235"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fmtNumber(tc.v); got != tc.want {
+				t.Fatalf("fmtNumber(%v) = %q, want %q", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFmtSignedNumber(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		v    float64
+		want string
+	}{
+		{name: "positive", v: 0.123456, want: "+0.1235"},
+		{name: "negative", v: -80.123456, want: "-80.12"},
+		{name: "zero", v: 0, want: "0"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fmtSignedNumber(tc.v); got != tc.want {
+				t.Fatalf("fmtSignedNumber(%v) = %q, want %q", tc.v, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFmtValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		v    float64
+		unit string
+		want string
+	}{
+		{name: "seconds scale to ms", v: 0.0801234, unit: "seconds", want: "80.12ms"},
+		{name: "seconds scale to us", v: 0.0001234, unit: "s", want: "123.4us"},
+		{name: "bytes scale to KB", v: 1536, unit: "bytes", want: "1.5KB"},
+		{name: "cycles abbreviate unit", v: 80.123456, unit: "cycles", want: "80.12cyc"},
+		{name: "integers keep unit", v: 42, unit: "widgets", want: "42widgets"},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := fmtValue(tc.v, tc.unit); got != tc.want {
+				t.Fatalf("fmtValue(%v, %q) = %q, want %q", tc.v, tc.unit, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cli/dryrun_test.go
+++ b/internal/cli/dryrun_test.go
@@ -9,6 +9,9 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
 )
 
 // researchHash walks .research/ under dir and returns a content hash over
@@ -98,6 +101,13 @@ func TestDryRun_ShortCircuitsAllMutatingVerbs(t *testing.T) {
 			setup: setupKilledHypothesis,
 			argsTail: func(ids []string) []string {
 				return []string{"hypothesis", "reopen", ids[0], "--reason", "back on"}
+			},
+		},
+		{
+			name:  "conclusion_withdraw",
+			setup: setupSupportedConclusion,
+			argsTail: func(ids []string) []string {
+				return []string{"conclusion", "withdraw", ids[0], "--reason", "bad benchmark"}
 			},
 		},
 		{
@@ -204,6 +214,42 @@ func setupPaused(t *testing.T, dir string) []string {
 		t.Fatalf("setup pause: %v", err)
 	}
 	return nil
+}
+
+func setupSupportedConclusion(t *testing.T, dir string) []string {
+	t.Helper()
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	now := nowUTC()
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "setup hypothesis",
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "fir", Direction: "decrease", MinEffect: 0.05},
+		KillIf:    []string{"tests fail"},
+		Status:    entity.StatusSupported,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatalf("write hypothesis: %v", err)
+	}
+	c := &entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   h.ID,
+		Verdict:      entity.VerdictSupported,
+		CandidateExp: "E-0001",
+		Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.1},
+		ReviewedBy:   "human:gate",
+		Author:       "agent:analyst",
+		CreatedAt:    now,
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		t.Fatalf("write conclusion: %v", err)
+	}
+	return []string{"C-0001"}
 }
 
 // TestDryRun_NonDryRunStillMutates sanity-checks that the fix didn't

--- a/internal/cli/event_payload_test.go
+++ b/internal/cli/event_payload_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +180,95 @@ func TestEventPayload_HypothesisReopenRecordsFromTo(t *testing.T) {
 	}
 	if got := payload["to"]; got != entity.StatusOpen {
 		t.Errorf("data.to = %v, want %q", got, entity.StatusOpen)
+	}
+}
+
+func TestConclusionWithdraw_RecordsAuditTrailAndUpdatesHypothesis(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	now := time.Now().UTC()
+	h := &entity.Hypothesis{
+		ID:     "H-0001",
+		GoalID: "G-0001",
+		Claim:  "tighten loop",
+		Predicts: entity.Predicts{
+			Instrument: "timing", Target: "fir", Direction: "decrease", MinEffect: 0.1,
+		},
+		KillIf:    []string{"tests fail"},
+		Status:    entity.StatusSupported,
+		Author:    "human",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+	c := &entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   h.ID,
+		Verdict:      entity.VerdictSupported,
+		CandidateExp: "E-0001",
+		Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.2},
+		ReviewedBy:   "human:gate",
+		Author:       "agent:analyst",
+		CreatedAt:    now,
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"conclusion", "withdraw", "C-0001",
+		"--reason", "benchmark setup was invalid",
+		"--author", "agent:orchestrator",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("conclusion withdraw: %v", err)
+	}
+
+	back, err := s.ReadConclusion("C-0001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := back.Verdict; got != entity.VerdictInconclusive {
+		t.Fatalf("conclusion verdict = %q, want %q", got, entity.VerdictInconclusive)
+	}
+	if got := back.Strict.RequestedFrom; got != entity.VerdictSupported {
+		t.Fatalf("strict.requested_from = %q, want %q", got, entity.VerdictSupported)
+	}
+	if got := back.ReviewedBy; got != "human:gate" {
+		t.Fatalf("reviewed_by = %q, want %q", got, "human:gate")
+	}
+	if !strings.Contains(back.Body, "# Withdrawal") || !strings.Contains(back.Body, "benchmark setup was invalid") {
+		t.Fatalf("withdrawal body missing audit trail:\n%s", back.Body)
+	}
+
+	hyp, err := s.ReadHypothesis("H-0001")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := hyp.Status; got != entity.StatusInconclusive {
+		t.Fatalf("hypothesis status = %q, want %q", got, entity.StatusInconclusive)
+	}
+
+	e := findLastEvent(t, s, "conclusion.withdraw")
+	if e == nil {
+		t.Fatal("conclusion.withdraw event not found")
+	}
+	if got := e.Actor; got != "agent:orchestrator" {
+		t.Fatalf("event actor = %q, want %q", got, "agent:orchestrator")
+	}
+	payload := decodePayload(t, e)
+	if got := payload["from"]; got != entity.VerdictSupported {
+		t.Errorf("data.from = %v, want %q", got, entity.VerdictSupported)
+	}
+	if got := payload["to"]; got != entity.VerdictInconclusive {
+		t.Errorf("data.to = %v, want %q", got, entity.VerdictInconclusive)
+	}
+	if got := payload["reason"]; got != "benchmark setup was invalid" {
+		t.Errorf("data.reason = %v, want %q", got, "benchmark setup was invalid")
 	}
 }
 

--- a/internal/cli/event_payload_test.go
+++ b/internal/cli/event_payload_test.go
@@ -272,6 +272,87 @@ func TestConclusionWithdraw_RecordsAuditTrailAndUpdatesHypothesis(t *testing.T) 
 	}
 }
 
+func TestConclusionDowngrade_UsesReviewerAsLessonEventActor(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+	now := time.Now().UTC()
+
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "tighten loop",
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "fir", Direction: "decrease", MinEffect: 0.1},
+		KillIf:    []string{"tests fail"},
+		Status:    entity.StatusUnreviewed,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+	c := &entity.Conclusion{
+		ID:         "C-0001",
+		Hypothesis: h.ID,
+		Verdict:    entity.VerdictSupported,
+		Author:     "agent:analyst",
+		CreatedAt:  now,
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+	l := &entity.Lesson{
+		ID:         "L-0001",
+		Claim:      "the loop shape is promising",
+		Scope:      entity.LessonScopeHypothesis,
+		Subjects:   []string{h.ID, c.ID},
+		Status:     entity.LessonStatusProvisional,
+		Provenance: &entity.LessonProvenance{SourceChain: entity.LessonSourceUnreviewedDecisive},
+		Author:     "agent:analyst",
+		CreatedAt:  now,
+	}
+	if err := s.WriteLesson(l); err != nil {
+		t.Fatal(err)
+	}
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"conclusion", "downgrade", "C-0001",
+		"--reason", "benchmark setup was invalid",
+		"--reviewed-by", "human:alice",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("conclusion downgrade: %v", err)
+	}
+
+	lessonEvent := findLastEvent(t, s, "lesson.invalidate")
+	if lessonEvent == nil {
+		t.Fatal("lesson.invalidate event not found")
+	}
+	if got := lessonEvent.Actor; got != "human:alice" {
+		t.Fatalf("lesson.invalidate actor = %q, want %q", got, "human:alice")
+	}
+	lessonPayload := decodePayload(t, lessonEvent)
+	if got := lessonPayload["hypothesis"]; got != h.ID {
+		t.Errorf("lesson payload hypothesis = %v, want %q", got, h.ID)
+	}
+	if got := lessonPayload["conclusion"]; got != c.ID {
+		t.Errorf("lesson payload conclusion = %v, want %q", got, c.ID)
+	}
+
+	conclusionEvent := findLastEvent(t, s, "conclusion.critic_downgrade")
+	if conclusionEvent == nil {
+		t.Fatal("conclusion.critic_downgrade event not found")
+	}
+	if got := conclusionEvent.Actor; got != "agent:critic" {
+		t.Fatalf("conclusion.critic_downgrade actor = %q, want %q", got, "agent:critic")
+	}
+	payload := decodePayload(t, conclusionEvent)
+	if got := payload["reviewed_by"]; got != "human:alice" {
+		t.Errorf("conclusion payload reviewed_by = %v, want %q", got, "human:alice")
+	}
+}
+
 func TestEventPayload_InstrumentRegisterEmitsFieldMap(t *testing.T) {
 	saveGlobals(t)
 	dir := t.TempDir()

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -436,7 +436,7 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 			w.Textf("  worktree: %s\n", wtPath)
 			w.Textln("  observations:")
 			for _, r := range results {
-				w.Textf("    %-16s %s = %g %s\n", r.ID, r.Inst, r.Value, r.Unit)
+				w.Textf("    %-16s %s = %s\n", r.ID, r.Inst, fmtValue(r.Value, r.Unit))
 			}
 			return nil
 		},

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -201,7 +201,7 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 	}
 	switch f.Assessment.Mode {
 	case "threshold":
-		w.Textf("goal_assessment: threshold=%s -> %s", fmtNumber(f.Assessment.Threshold), f.Assessment.OnThreshold)
+		w.Textf("goal_assessment: %s", formatGoalThresholdDecision(f.Assessment.Threshold, f.Assessment.OnThreshold))
 		if f.Assessment.Met {
 			w.Textf(" (met by %s; recommended=%s)\n", f.Assessment.MetByConclusion, f.Assessment.RecommendedAction)
 		} else {

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -188,7 +188,7 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 			if i == 0 {
 				marker = "* "
 			}
-			w.Textf("%s%s  %s  %s=%.6g", marker, r.Conclusion, r.Hypothesis, f.Goal.Objective.Instrument, r.Value)
+			w.Textf("%s%s  %s  %s=%s", marker, r.Conclusion, r.Hypothesis, f.Goal.Objective.Instrument, fmtNumber(r.Value))
 			if r.RescuedBy != "" {
 				w.Textf("  [rescued by %s]", r.RescuedBy)
 			}
@@ -201,7 +201,7 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 	}
 	switch f.Assessment.Mode {
 	case "threshold":
-		w.Textf("goal_assessment: threshold=%g -> %s", f.Assessment.Threshold, f.Assessment.OnThreshold)
+		w.Textf("goal_assessment: threshold=%s -> %s", fmtNumber(f.Assessment.Threshold), f.Assessment.OnThreshold)
 		if f.Assessment.Met {
 			w.Textf(" (met by %s; recommended=%s)\n", f.Assessment.MetByConclusion, f.Assessment.RecommendedAction)
 		} else {

--- a/internal/cli/goal_display.go
+++ b/internal/cli/goal_display.go
@@ -1,10 +1,6 @@
 package cli
 
-import (
-	"fmt"
-
-	"github.com/bytter/autoresearch/internal/entity"
-)
+import "github.com/bytter/autoresearch/internal/entity"
 
 func formatGoalObjective(g *entity.Goal) string {
 	if g == nil {
@@ -24,5 +20,5 @@ func formatGoalCompletion(g *entity.Goal) string {
 	if g.IsOpenEnded() {
 		return "open-ended -> continue_until_stall"
 	}
-	return fmt.Sprintf("threshold=%g -> %s", g.Completion.Threshold, g.EffectiveOnThreshold())
+	return formatGoalThresholdDecision(g.Completion.Threshold, g.EffectiveOnThreshold())
 }

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -330,6 +330,16 @@ func hypothesisKillCmd() *cobra.Command {
 			if h.Status == entity.StatusKilled {
 				return fmt.Errorf("%s is already killed", h.ID)
 			}
+			if !hypothesisStatusAllowsKill(h.Status) {
+				switch h.Status {
+				case entity.StatusUnreviewed:
+					return fmt.Errorf("%s is unreviewed — resolve the pending conclusion via `conclusion accept`, `conclusion downgrade`, or `conclusion withdraw` before killing it", h.ID)
+				case entity.StatusSupported, entity.StatusRefuted:
+					return fmt.Errorf("%s is %s — use `conclusion withdraw` or `conclusion downgrade` before killing it", h.ID, h.Status)
+				default:
+					return fmt.Errorf("%s has status %q; kill is only valid for open or inconclusive hypotheses", h.ID, h.Status)
+				}
+			}
 			prev := h.Status
 			h.Status = entity.StatusKilled
 			if err := dryRun(w, fmt.Sprintf("kill %s (%s)", h.ID, reason), map[string]any{"id": h.ID, "reason": reason}); err != nil {
@@ -412,6 +422,10 @@ and logged.`,
 // specific conclusion is used instead of searching. Returns the conclusion,
 // experiment, and any error.
 func resolveWinningExperiment(s *store.Store, hypID, conclusionID string) (*entity.Conclusion, *entity.Experiment, error) {
+	hyp, err := s.ReadHypothesis(hypID)
+	if err != nil {
+		return nil, nil, err
+	}
 	var concl *entity.Conclusion
 	if conclusionID != "" {
 		c, err := s.ReadConclusion(conclusionID)
@@ -427,13 +441,17 @@ func resolveWinningExperiment(s *store.Store, hypID, conclusionID string) (*enti
 		if err != nil {
 			return nil, nil, err
 		}
-		// Pick the best supported conclusion (largest |delta_frac|).
-		for _, c := range all {
-			if c.Verdict != entity.VerdictSupported {
-				continue
-			}
-			if concl == nil || abs(c.Effect.DeltaFrac) > abs(concl.Effect.DeltaFrac) {
-				concl = c
+		if hypothesisStatusAllowsDefaultWinningConclusion(hyp.Status) {
+			// Pick the best supported conclusion (largest |delta_frac|) only
+			// when the hypothesis's current accepted stance is still
+			// supported. Otherwise we fall back to the latest experiment.
+			for _, c := range all {
+				if c.Verdict != entity.VerdictSupported {
+					continue
+				}
+				if concl == nil || abs(c.Effect.DeltaFrac) > abs(concl.Effect.DeltaFrac) {
+					concl = c
+				}
 			}
 		}
 		if concl == nil {
@@ -571,6 +589,13 @@ Use --conclusion C-NNNN to pick a specific conclusion.`,
 			if err != nil {
 				return err
 			}
+			hyp, err := s.ReadHypothesis(args[0])
+			if err != nil {
+				return err
+			}
+			if hyp.Status != entity.StatusSupported {
+				return fmt.Errorf("hypothesis %s has status %q — only supported hypotheses can be applied", args[0], hyp.Status)
+			}
 			concl, exp, err := resolveWinningExperiment(s, args[0], conclusionID)
 			if err != nil {
 				return err
@@ -578,13 +603,8 @@ Use --conclusion C-NNNN to pick a specific conclusion.`,
 			if concl == nil || concl.Verdict != entity.VerdictSupported {
 				return fmt.Errorf("hypothesis %s has no supported conclusion — nothing to apply", args[0])
 			}
-			// Gate: hypothesis must have been reviewed (not still "unreviewed").
-			hyp, err := s.ReadHypothesis(args[0])
-			if err != nil {
-				return err
-			}
-			if hyp.Status == entity.StatusUnreviewed {
-				return fmt.Errorf("hypothesis %s is unreviewed — dispatch the gate reviewer to review %s first (or self-review with `conclusion accept %s --reviewed-by ...`)", args[0], concl.ID, concl.ID)
+			if concl.ReviewedBy == "" {
+				return fmt.Errorf("conclusion %s is not reviewed — dispatch the gate reviewer to review it before apply", concl.ID)
 			}
 			if exp.Branch == "" {
 				return fmt.Errorf("%s has no branch (status=%s)", exp.ID, exp.Status)

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	"github.com/bytter/autoresearch/internal/worktree"
 	"github.com/spf13/cobra"
@@ -441,10 +442,11 @@ func resolveWinningExperiment(s *store.Store, hypID, conclusionID string) (*enti
 		if err != nil {
 			return nil, nil, err
 		}
-		if hypothesisStatusAllowsDefaultWinningConclusion(hyp.Status) {
-			// Pick the best supported conclusion (largest |delta_frac|) only
-			// when the hypothesis's current accepted stance is still
-			// supported. Otherwise we fall back to the latest experiment.
+		if readmodel.SupportedConclusionCountsForReadSurface(hyp.Status) {
+			// Pick the best supported conclusion (largest |delta_frac|) when
+			// the hypothesis's read-side status still preserves that supported
+			// result (including pending review and the legacy killed back-compat
+			// case). Otherwise we fall back to the latest experiment.
 			for _, c := range all {
 				if c.Verdict != entity.VerdictSupported {
 					continue

--- a/internal/cli/hypothesis_lifecycle.go
+++ b/internal/cli/hypothesis_lifecycle.go
@@ -19,7 +19,3 @@ func hypothesisStatusAllowsKill(status string) bool {
 		return false
 	}
 }
-
-func hypothesisStatusAllowsDefaultWinningConclusion(status string) bool {
-	return status == entity.StatusSupported
-}

--- a/internal/cli/hypothesis_lifecycle.go
+++ b/internal/cli/hypothesis_lifecycle.go
@@ -1,0 +1,25 @@
+package cli
+
+import "github.com/bytter/autoresearch/internal/entity"
+
+func hypothesisStatusAllowsConclude(status string) bool {
+	switch status {
+	case entity.StatusOpen, entity.StatusInconclusive:
+		return true
+	default:
+		return false
+	}
+}
+
+func hypothesisStatusAllowsKill(status string) bool {
+	switch status {
+	case entity.StatusOpen, entity.StatusInconclusive:
+		return true
+	default:
+		return false
+	}
+}
+
+func hypothesisStatusAllowsDefaultWinningConclusion(status string) bool {
+	return status == entity.StatusSupported
+}

--- a/internal/cli/lesson.go
+++ b/internal/cli/lesson.go
@@ -468,8 +468,8 @@ may be exhausted.`,
 					if r.Linked {
 						link = " (linked via inspired_by)"
 					}
-					w.Textf("    %s (%s): actual delta_frac=%+.4f  %s%s\n",
-						r.ConclusionID, r.HypothesisID, r.ActualDelta, r.Classification, link)
+					w.Textf("    %s (%s): actual delta_frac=%s  %s%s\n",
+						r.ConclusionID, r.HypothesisID, fmtSignedNumber(r.ActualDelta), r.Classification, link)
 				}
 				w.Textln("")
 			}

--- a/internal/cli/lesson_accuracy.go
+++ b/internal/cli/lesson_accuracy.go
@@ -175,7 +175,7 @@ func classifyLessonAccuracy(pe *entity.PredictedEffect, c *entity.Conclusion) st
 
 func formatPredictedEffectRange(pe *entity.PredictedEffect) string {
 	if pe.MaxEffect > 0 {
-		return fmt.Sprintf("%.4f–%.4f", pe.MinEffect, pe.MaxEffect)
+		return fmt.Sprintf("%s–%s", fmtNumber(pe.MinEffect), fmtNumber(pe.MaxEffect))
 	}
-	return fmt.Sprintf("%.4f", pe.MinEffect)
+	return fmtNumber(pe.MinEffect)
 }

--- a/internal/cli/lesson_accuracy.go
+++ b/internal/cli/lesson_accuracy.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/store"
 )
@@ -171,11 +169,4 @@ func classifyLessonAccuracy(pe *entity.PredictedEffect, c *entity.Conclusion) st
 	default:
 		return lessonAccuracyHit
 	}
-}
-
-func formatPredictedEffectRange(pe *entity.PredictedEffect) string {
-	if pe.MaxEffect > 0 {
-		return fmt.Sprintf("%s–%s", fmtNumber(pe.MinEffect), fmtNumber(pe.MaxEffect))
-	}
-	return fmtNumber(pe.MinEffect)
 }

--- a/internal/cli/lesson_state.go
+++ b/internal/cli/lesson_state.go
@@ -14,6 +14,7 @@ type lessonSyncMode string
 const (
 	lessonSyncOnAccept    lessonSyncMode = "accept"
 	lessonSyncOnDowngrade lessonSyncMode = "downgrade"
+	lessonSyncOnWithdraw  lessonSyncMode = "withdraw"
 	lessonSyncOnAppeal    lessonSyncMode = "appeal"
 )
 

--- a/internal/cli/lifecycle_guard_test.go
+++ b/internal/cli/lifecycle_guard_test.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func seedHypothesisForLifecycleGuard(t *testing.T, s *store.Store, status string) string {
+	t.Helper()
+	now := time.Now().UTC()
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "tighten loop",
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "fir", Direction: "decrease", MinEffect: 0.1},
+		KillIf:    []string{"tests fail"},
+		Status:    status,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+	return h.ID
+}
+
+func TestConcludeRejectsNonReopenedLifecycleStates(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		wantSubstr string
+	}{
+		{
+			name:       "unreviewed",
+			status:     entity.StatusUnreviewed,
+			wantSubstr: "resolve the pending conclusion",
+		},
+		{
+			name:       "supported",
+			status:     entity.StatusSupported,
+			wantSubstr: "use `conclusion withdraw` or `conclusion downgrade` before concluding again",
+		},
+		{
+			name:       "refuted",
+			status:     entity.StatusRefuted,
+			wantSubstr: "use `conclusion withdraw` or `conclusion downgrade` before concluding again",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			saveGlobals(t)
+			dir, s := setupGoalStore(t)
+			hypID := seedHypothesisForLifecycleGuard(t, s, tc.status)
+
+			root := Root()
+			root.SetArgs([]string{
+				"-C", dir,
+				"conclude", hypID,
+				"--verdict", "supported",
+				"--observations", "O-0001",
+			})
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected conclude to be rejected")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestHypothesisKillRejectsDecisiveOrPendingStates(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     string
+		wantSubstr string
+	}{
+		{
+			name:       "unreviewed",
+			status:     entity.StatusUnreviewed,
+			wantSubstr: "resolve the pending conclusion",
+		},
+		{
+			name:       "supported",
+			status:     entity.StatusSupported,
+			wantSubstr: "use `conclusion withdraw` or `conclusion downgrade` before killing it",
+		},
+		{
+			name:       "refuted",
+			status:     entity.StatusRefuted,
+			wantSubstr: "use `conclusion withdraw` or `conclusion downgrade` before killing it",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			saveGlobals(t)
+			dir, s := setupGoalStore(t)
+			hypID := seedHypothesisForLifecycleGuard(t, s, tc.status)
+
+			root := Root()
+			root.SetArgs([]string{
+				"-C", dir,
+				"hypothesis", "kill", hypID,
+				"--reason", "stop this line",
+			})
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected hypothesis kill to be rejected")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("error = %q, want substring %q", err, tc.wantSubstr)
+			}
+		})
+	}
+}

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -79,30 +79,10 @@ type cliStatusResponse struct {
 	Counts            map[string]int `json:"counts"`
 }
 
+const scenarioReviewRationale = "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected."
+
 func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterStall(t *testing.T) {
-	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
-	registerScenarioInstruments(t, dir)
-
-	goal := runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
-		"--success-threshold", "0.1",
-		"--on-success", "stop",
-		"--constraint-max", "binary_size=1000",
-		"--constraint-require", "host_test=pass",
-	)
-	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+	dir, goal, baseline := setupLifecycleScenario(t)
 
 	hyp1 := runCLIJSON[cliIDResponse](t, dir,
 		"hypothesis", "add",
@@ -136,11 +116,7 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 		"--baseline-experiment", baseline.ID,
 		"--observations", observeResultID(t, obs1, "timing"),
 	)
-	runCLIJSON[cliIDResponse](t, dir,
-		"conclusion", "accept", concl1.ID,
-		"--reviewed-by", "human:gate",
-		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
-	)
+	acceptScenarioConclusion(t, dir, concl1.ID)
 
 	hyp2 := runCLIJSON[cliIDResponse](t, dir,
 		"hypothesis", "add",
@@ -246,29 +222,7 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 }
 
 func TestLifecycleScenario_WithdrawnAndRefutedHypothesisDropsOldWinFromCurrentTruthSurfaces(t *testing.T) {
-	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
-	registerScenarioInstruments(t, dir)
-
-	goal := runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
-		"--success-threshold", "0.1",
-		"--on-success", "stop",
-		"--constraint-max", "binary_size=1000",
-		"--constraint-require", "host_test=pass",
-	)
-	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+	dir, goal, baseline := setupLifecycleScenario(t)
 
 	hyp := runCLIJSON[cliIDResponse](t, dir,
 		"hypothesis", "add",
@@ -295,11 +249,7 @@ func TestLifecycleScenario_WithdrawnAndRefutedHypothesisDropsOldWinFromCurrentTr
 		"--baseline-experiment", baseline.ID,
 		"--observations", observeResultID(t, obs1, "timing"),
 	)
-	runCLIJSON[cliIDResponse](t, dir,
-		"conclusion", "accept", concl1.ID,
-		"--reviewed-by", "human:gate",
-		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
-	)
+	acceptScenarioConclusion(t, dir, concl1.ID)
 
 	runCLIJSON[cliIDResponse](t, dir,
 		"conclusion", "withdraw", concl1.ID,
@@ -323,11 +273,7 @@ func TestLifecycleScenario_WithdrawnAndRefutedHypothesisDropsOldWinFromCurrentTr
 		"--baseline-experiment", baseline.ID,
 		"--observations", observeResultID(t, obs2, "timing"),
 	)
-	runCLIJSON[cliIDResponse](t, dir,
-		"conclusion", "accept", concl2.ID,
-		"--reviewed-by", "human:gate",
-		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
-	)
+	acceptScenarioConclusion(t, dir, concl2.ID)
 
 	frontier := runCLIJSON[cliFrontierResponse](t, dir, "frontier", "--goal", goal.ID)
 	if frontier.ScopeGoalID != goal.ID || frontier.GoalID != goal.ID {
@@ -423,6 +369,43 @@ func registerScenarioInstruments(t *testing.T, dir string) {
 	)
 }
 
+func setupLifecycleScenario(t *testing.T) (dir string, goal cliIDResponse, baseline cliIDResponse) {
+	t.Helper()
+	saveGlobals(t)
+	dir = gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	goal = runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--success-threshold", "0.1",
+		"--on-success", "stop",
+		"--constraint-max", "binary_size=1000",
+		"--constraint-require", "host_test=pass",
+	)
+	baseline = runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+	return dir, goal, baseline
+}
+
+func acceptScenarioConclusion(t *testing.T, dir, conclID string) {
+	t.Helper()
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclusion", "accept", conclID,
+		"--reviewed-by", "human:gate",
+		"--rationale", scenarioReviewRationale,
+	)
+}
+
 func gitInitScenarioRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -472,42 +455,7 @@ func gitRun(t *testing.T, dir string, args ...string) {
 
 func runCLI(t *testing.T, dir string, args ...string) string {
 	t.Helper()
-
-	oldStdout, oldStderr := os.Stdout, os.Stderr
-	rOut, wOut, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stdout pipe: %v", err)
-	}
-	rErr, wErr, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("stderr pipe: %v", err)
-	}
-	outCh := make(chan string, 1)
-	errCh := make(chan string, 1)
-	go func() {
-		data, _ := io.ReadAll(rOut)
-		outCh <- string(data)
-	}()
-	go func() {
-		data, _ := io.ReadAll(rErr)
-		errCh <- string(data)
-	}()
-
-	os.Stdout = wOut
-	os.Stderr = wErr
-	defer func() {
-		os.Stdout = oldStdout
-		os.Stderr = oldStderr
-	}()
-
-	root := Root()
-	root.SetArgs(append([]string{"-C", dir}, args...))
-	execErr := root.Execute()
-
-	_ = wOut.Close()
-	_ = wErr.Close()
-	stdout := <-outCh
-	stderr := <-errCh
+	stdout, stderr, execErr := executeCLI(t, dir, args...)
 	if execErr != nil {
 		t.Fatalf("autoresearch %s: %v\nstdout:\n%s\nstderr:\n%s", strings.Join(args, " "), execErr, stdout, stderr)
 	}
@@ -526,6 +474,18 @@ func runCLIJSON[T any](t *testing.T, dir string, args ...string) T {
 
 func runCLIErr(t *testing.T, dir string, args ...string) error {
 	t.Helper()
+	stdout, stderr, execErr := executeCLI(t, dir, args...)
+	if execErr == nil {
+		return nil
+	}
+	if stdout != "" || stderr != "" {
+		return fmt.Errorf("%w\nstdout:\n%s\nstderr:\n%s", execErr, stdout, stderr)
+	}
+	return execErr
+}
+
+func executeCLI(t *testing.T, dir string, args ...string) (stdout, stderr string, execErr error) {
+	t.Helper()
 
 	oldStdout, oldStderr := os.Stdout, os.Stderr
 	rOut, wOut, err := os.Pipe()
@@ -556,19 +516,13 @@ func runCLIErr(t *testing.T, dir string, args ...string) error {
 
 	root := Root()
 	root.SetArgs(append([]string{"-C", dir}, args...))
-	execErr := root.Execute()
+	execErr = root.Execute()
 
 	_ = wOut.Close()
 	_ = wErr.Close()
-	stdout := <-outCh
-	stderr := <-errCh
-	if execErr == nil {
-		return nil
-	}
-	if stdout != "" || stderr != "" {
-		return fmt.Errorf("%w\nstdout:\n%s\nstderr:\n%s", execErr, stdout, stderr)
-	}
-	return execErr
+	stdout = <-outCh
+	stderr = <-errCh
+	return stdout, stderr, execErr
 }
 
 func observeResultID(t *testing.T, resp cliObserveAllResponse, inst string) string {

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -244,6 +245,154 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 	}
 }
 
+func TestLifecycleScenario_WithdrawnAndRefutedHypothesisDropsOldWinFromCurrentTruthSurfaces(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	goal := runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--success-threshold", "0.1",
+		"--on-success", "stop",
+		"--constraint-max", "binary_size=1000",
+		"--constraint-require", "host_test=pass",
+	)
+	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp1 := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl1 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp1.ID)
+	writeScenarioMetrics(t, impl1.Worktree, "80\n", "900\n")
+	gitCommitAll(t, impl1.Worktree, "improve timing")
+
+	obs1 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp1.ID, "--all")
+	concl1 := runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp.ID,
+		"--verdict", "supported",
+		"--baseline-experiment", baseline.ID,
+		"--observations", observeResultID(t, obs1, "timing"),
+	)
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclusion", "accept", concl1.ID,
+		"--reviewed-by", "human:gate",
+		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
+	)
+
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclusion", "withdraw", concl1.ID,
+		"--reason", "Follow-up inspection found the earlier benchmark setup was not trustworthy.",
+		"--author", "agent:orchestrator",
+	)
+
+	exp2 := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp2.ID)
+	writeScenarioMetrics(t, impl2.Worktree, "120\n", "900\n")
+	gitCommitAll(t, impl2.Worktree, "regress timing")
+
+	obs2 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp2.ID, "--all")
+	concl2 := runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp.ID,
+		"--verdict", "refuted",
+		"--baseline-experiment", baseline.ID,
+		"--observations", observeResultID(t, obs2, "timing"),
+	)
+	runCLIJSON[cliIDResponse](t, dir,
+		"conclusion", "accept", concl2.ID,
+		"--reviewed-by", "human:gate",
+		"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
+	)
+
+	frontier := runCLIJSON[cliFrontierResponse](t, dir, "frontier", "--goal", goal.ID)
+	if frontier.ScopeGoalID != goal.ID || frontier.GoalID != goal.ID {
+		t.Fatalf("frontier goal scope mismatch: %+v", frontier)
+	}
+	if frontier.GoalAssessment.Met || frontier.GoalAssessment.MetByConclusion != "" {
+		t.Fatalf("unexpected frontier goal_assessment: %+v", frontier.GoalAssessment)
+	}
+	if got, want := frontier.StalledFor, 0; got != want {
+		t.Fatalf("frontier stalled_for = %d, want %d", got, want)
+	}
+	if got, want := len(frontier.Frontier), 0; got != want {
+		t.Fatalf("frontier rows len = %d, want %d", got, want)
+	}
+
+	dashboard := runCLIJSON[cliDashboardResponse](t, dir, "dashboard", "--goal", goal.ID)
+	if dashboard.ScopeGoalID != goal.ID {
+		t.Fatalf("dashboard scope_goal_id = %q, want %q", dashboard.ScopeGoalID, goal.ID)
+	}
+	if got, want := dashboard.StalledFor, 0; got != want {
+		t.Fatalf("dashboard stalled_for = %d, want %d", got, want)
+	}
+	if got, want := len(dashboard.Frontier), 0; got != want {
+		t.Fatalf("dashboard frontier len = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["hypotheses"], 1; got != want {
+		t.Fatalf("dashboard counts[hypotheses] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["experiments"], 3; got != want {
+		t.Fatalf("dashboard counts[experiments] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["observations"], 9; got != want {
+		t.Fatalf("dashboard counts[observations] = %d, want %d", got, want)
+	}
+	if got, want := dashboard.Counts["conclusions"], 2; got != want {
+		t.Fatalf("dashboard counts[conclusions] = %d, want %d", got, want)
+	}
+
+	status := runCLIJSON[cliStatusResponse](t, dir, "status", "--goal", goal.ID)
+	if status.ScopeGoalID != goal.ID {
+		t.Fatalf("status scope_goal_id = %q, want %q", status.ScopeGoalID, goal.ID)
+	}
+	if status.MainCheckoutDirty {
+		t.Fatalf("status reported dirty main checkout for clean scenario")
+	}
+	if got, want := status.Counts["hypotheses"], 1; got != want {
+		t.Fatalf("status counts[hypotheses] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["experiments"], 3; got != want {
+		t.Fatalf("status counts[experiments] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["observations"], 9; got != want {
+		t.Fatalf("status counts[observations] = %d, want %d", got, want)
+	}
+	if got, want := status.Counts["conclusions"], 2; got != want {
+		t.Fatalf("status counts[conclusions] = %d, want %d", got, want)
+	}
+
+	if err := runCLIErr(t, dir, "hypothesis", "apply", hyp.ID); err == nil {
+		t.Fatal("expected hypothesis apply to be rejected after refutation")
+	} else if got, want := err.Error(), `only supported hypotheses can be applied`; !strings.Contains(got, want) {
+		t.Fatalf("apply error = %q, want substring %q", got, want)
+	}
+}
+
 func registerScenarioInstruments(t *testing.T, dir string) {
 	t.Helper()
 	runCLI(t, dir,
@@ -373,6 +522,53 @@ func runCLIJSON[T any](t *testing.T, dir string, args ...string) T {
 		t.Fatalf("decode JSON for %q: %v\n%s", strings.Join(args, " "), err, out)
 	}
 	return got
+}
+
+func runCLIErr(t *testing.T, dir string, args ...string) error {
+	t.Helper()
+
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	outCh := make(chan string, 1)
+	errCh := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(rOut)
+		outCh <- string(data)
+	}()
+	go func() {
+		data, _ := io.ReadAll(rErr)
+		errCh <- string(data)
+	}()
+
+	os.Stdout = wOut
+	os.Stderr = wErr
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	root := Root()
+	root.SetArgs(append([]string{"-C", dir}, args...))
+	execErr := root.Execute()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	stdout := <-outCh
+	stderr := <-errCh
+	if execErr == nil {
+		return nil
+	}
+	if stdout != "" || stderr != "" {
+		return fmt.Errorf("%w\nstdout:\n%s\nstderr:\n%s", execErr, stdout, stderr)
+	}
+	return execErr
 }
 
 func observeResultID(t *testing.T, resp cliObserveAllResponse, inst string) string {

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -109,7 +109,7 @@ observation firewall, made physical.`,
 				}
 				w.Textf("observed %d instruments on %s\n", len(results), expID)
 				for _, r := range results {
-					w.Textf("  %-16s %s = %g %s\n", r.ID, r.Inst, r.Value, r.Unit)
+					w.Textf("  %-16s %s = %s\n", r.ID, r.Inst, fmtValue(r.Value, r.Unit))
 				}
 				return nil
 			}
@@ -155,9 +155,9 @@ observation firewall, made physical.`,
 			}
 			w.Textf("recorded %s\n", obs.ID)
 			w.Textf("  instrument:  %s\n", instName)
-			w.Textf("  value:       %g %s\n", obs.Value, obs.Unit)
+			w.Textf("  value:       %s\n", fmtValue(obs.Value, obs.Unit))
 			if obs.Samples > 1 && obs.CILow != nil && obs.CIHigh != nil {
-				w.Textf("  samples:     %d (95%% CI [%g, %g], %s)\n", obs.Samples, *obs.CILow, *obs.CIHigh, obs.CIMethod)
+				w.Textf("  samples:     %d (95%% CI %s, %s)\n", obs.Samples, fmtValueRange(*obs.CILow, *obs.CIHigh, obs.Unit), obs.CIMethod)
 			}
 			if obs.Pass != nil {
 				w.Textf("  pass:        %v (exit=%d)\n", *obs.Pass, obs.ExitCode)

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -187,7 +187,7 @@ func renderReportMarkdown(r *reportData) string {
 	fmt.Fprintf(&sb, "- **Instrument**: `%s`\n", h.Predicts.Instrument)
 	fmt.Fprintf(&sb, "- **Target**: `%s`\n", h.Predicts.Target)
 	fmt.Fprintf(&sb, "- **Direction**: %s\n", h.Predicts.Direction)
-	fmt.Fprintf(&sb, "- **Minimum effect**: %.4f (fractional)\n", h.Predicts.MinEffect)
+	fmt.Fprintf(&sb, "- **Minimum effect**: %s (fractional)\n", fmtNumber(h.Predicts.MinEffect))
 	sb.WriteString("- **Kill criteria**:\n")
 	for _, k := range h.KillIf {
 		fmt.Fprintf(&sb, "  - %s\n", k)
@@ -217,9 +217,9 @@ func renderReportMarkdown(r *reportData) string {
 			if len(blk.Observations) > 0 {
 				sb.WriteString("- **Observations**:\n")
 				for _, o := range blk.Observations {
-					fmt.Fprintf(&sb, "  - %s `%s` = %.6g %s", o.ID, o.Instrument, o.Value, o.Unit)
+					fmt.Fprintf(&sb, "  - %s `%s` = %s", o.ID, o.Instrument, fmtValue(o.Value, o.Unit))
 					if o.Samples > 1 && o.CILow != nil && o.CIHigh != nil {
-						fmt.Fprintf(&sb, "  [%.6g, %.6g]  n=%d", *o.CILow, *o.CIHigh, o.Samples)
+						fmt.Fprintf(&sb, "  %s  n=%d", fmtValueRange(*o.CILow, *o.CIHigh, o.Unit), o.Samples)
 					}
 					if o.Pass != nil {
 						fmt.Fprintf(&sb, "  pass=%v", *o.Pass)
@@ -277,9 +277,9 @@ func renderReportMarkdown(r *reportData) string {
 			if c.BaselineExp != "" {
 				fmt.Fprintf(&sb, "- **Baseline experiment**: %s\n", c.BaselineExp)
 			}
-			fmt.Fprintf(&sb, "- **Effect on `%s`**: %+.4f (fractional)", c.Effect.Instrument, c.Effect.DeltaFrac)
+			fmt.Fprintf(&sb, "- **Effect on `%s`**: %s (fractional)", c.Effect.Instrument, fmtSignedNumber(c.Effect.DeltaFrac))
 			if c.Effect.CILowFrac != 0 || c.Effect.CIHighFrac != 0 {
-				fmt.Fprintf(&sb, "  95%% CI [%+.4f, %+.4f]", c.Effect.CILowFrac, c.Effect.CIHighFrac)
+				fmt.Fprintf(&sb, "  95%% CI %s", fmtSignedRange(c.Effect.CILowFrac, c.Effect.CIHighFrac))
 			}
 			sb.WriteString("\n")
 			if c.Effect.PValue > 0 {

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -254,7 +254,12 @@ func renderReportMarkdown(r *reportData) string {
 			}
 			fmt.Fprintf(&sb, "### %s — %s\n\n", c.ID, heading)
 			if c.Strict.RequestedFrom != "" {
-				fmt.Fprintf(&sb, "> **Downgraded** from `%s` — strict firewall rejected the requested verdict:\n", c.Strict.RequestedFrom)
+				switch conclusionAdjustmentKind(c) {
+				case conclusionAdjustmentWith:
+					fmt.Fprintf(&sb, "> **Withdrawn** from `%s` — the claim was explicitly retracted and moved back to inconclusive:\n", c.Strict.RequestedFrom)
+				default:
+					fmt.Fprintf(&sb, "> **Downgraded** from `%s` — the requested verdict no longer stands:\n", c.Strict.RequestedFrom)
+				}
 				for _, r := range c.Strict.Reasons {
 					fmt.Fprintf(&sb, "> - %s\n", r)
 				}

--- a/internal/cli/tui_helpers.go
+++ b/internal/cli/tui_helpers.go
@@ -357,18 +357,6 @@ func tuiMeterColor(used, limit float64, s string) string {
 	}
 }
 
-// ---- shared formatting ----
-
-// formatPredictedEffect renders a PredictedEffect as a human-readable string
-// like "decrease host_timing by ≥0.05 (up to 0.1)".
-func formatPredictedEffect(pe *entity.PredictedEffect) string {
-	s := fmt.Sprintf("%s %s by ≥%s", pe.Direction, pe.Instrument, fmtNumber(pe.MinEffect))
-	if pe.MaxEffect > 0 {
-		s += fmt.Sprintf(" (up to %s)", fmtNumber(pe.MaxEffect))
-	}
-	return s
-}
-
 // lessonAccuracyArrow returns a colored arrow when accuracy comparisons show
 // a dominant trend. Down means overshooting; up means undershooting.
 func lessonAccuracyArrow(summary lessonAccuracySummary) string {

--- a/internal/cli/tui_helpers.go
+++ b/internal/cli/tui_helpers.go
@@ -49,53 +49,6 @@ func truncLines(lines []string, width int) []string {
 	return out
 }
 
-// fmtValue formats a numeric value with a compact unit suffix.
-// Seconds are scaled to ns/us/ms/s; bytes shortened to B; everything
-// else gets 2 decimal places + the raw unit.
-func fmtValue(v float64, unit string) string {
-	switch unit {
-	case "seconds", "s":
-		switch {
-		case v == 0:
-			return "0s"
-		case v < 1e-6:
-			return fmt.Sprintf("%.2fns", v*1e9)
-		case v < 1e-3:
-			return fmt.Sprintf("%.2fus", v*1e6)
-		case v < 1:
-			return fmt.Sprintf("%.2fms", v*1e3)
-		default:
-			return fmt.Sprintf("%.2fs", v)
-		}
-	case "bytes":
-		if v >= 1024*1024 {
-			return fmt.Sprintf("%.1fMB", v/(1024*1024))
-		}
-		if v >= 1024 {
-			return fmt.Sprintf("%.1fKB", v/1024)
-		}
-		return fmt.Sprintf("%.0fB", v)
-	default:
-		if v == float64(int64(v)) {
-			return fmt.Sprintf("%d%s", int64(v), shortUnit(unit))
-		}
-		return fmt.Sprintf("%.2f%s", v, shortUnit(unit))
-	}
-}
-
-func shortUnit(u string) string {
-	switch u {
-	case "cycles":
-		return "cyc"
-	case "instructions":
-		return "ins"
-	case "pass":
-		return ""
-	default:
-		return u
-	}
-}
-
 // padRight right-pads s with spaces to the given *visible* width. Shorter
 // strings are extended; longer ones are returned unchanged (truncate first
 // if you need a hard cap).
@@ -407,11 +360,11 @@ func tuiMeterColor(used, limit float64, s string) string {
 // ---- shared formatting ----
 
 // formatPredictedEffect renders a PredictedEffect as a human-readable string
-// like "decrease host_timing by ≥0.0500 (up to 0.1000)".
+// like "decrease host_timing by ≥0.05 (up to 0.1)".
 func formatPredictedEffect(pe *entity.PredictedEffect) string {
-	s := fmt.Sprintf("%s %s by ≥%.4f", pe.Direction, pe.Instrument, pe.MinEffect)
+	s := fmt.Sprintf("%s %s by ≥%s", pe.Direction, pe.Instrument, fmtNumber(pe.MinEffect))
 	if pe.MaxEffect > 0 {
-		s += fmt.Sprintf(" (up to %.4f)", pe.MaxEffect)
+		s += fmt.Sprintf(" (up to %s)", fmtNumber(pe.MaxEffect))
 	}
 	return s
 }

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -350,7 +350,7 @@ func TestTUI_ObservationDetail(t *testing.T) {
 	}
 	nv, _ := v.update(obsDetailLoadedMsg{o: o}, nil)
 	out := stripANSI(nv.view(120, 25))
-	for _, want := range []string{"O-0003", "host_timing=1.2 s", "experiment=E-0007", "Artifacts (1):", "make test", "stdev", "warm"} {
+	for _, want := range []string{"O-0003", "host_timing=1.2s", "experiment=E-0007", "Artifacts (1):", "make test", "stdev", "warm"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("observation detail missing %q:\n%s", want, out)
 		}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -367,7 +367,7 @@ func TestTUI_ConclusionList(t *testing.T) {
 	}
 	nv, _ := v.update(concListLoadedMsg{list: cs}, nil)
 	out := stripANSI(nv.view(120, 20))
-	for _, want := range []string{"2 conclusions", "C-0001", "supported", "C-0002", "↓from supported"} {
+	for _, want := range []string{"2 conclusions", "C-0001", "supported", "C-0002", "downgraded from supported"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("conclusion list missing %q:\n%s", want, out)
 		}

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -207,8 +207,8 @@ func (v *conclusionDetailView) view(width, height int) string {
 			}
 			header := fmt.Sprintf("  %s (%s) %s", cc.Instrument, cc.Role, status)
 			if cc.Effect != nil {
-				header += fmt.Sprintf("  Δfrac=%s  CI%s",
-					fmtSignedNumber(cc.Effect.DeltaFrac), fmtSignedRange(cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
+				header += fmt.Sprintf("  Δfrac=%s",
+					formatSignedCI(cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
 			}
 			lines = append(lines, header)
 			for _, r := range cc.Reasons {

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -98,8 +98,8 @@ func (v *conclusionListView) view(width, height int) string {
 	rows := make([]string, len(v.filtered))
 	for i, c := range v.filtered {
 		extras := ""
-		if c.Strict.RequestedFrom != "" {
-			extras = tuiDim.Render("  ↓from " + c.Strict.RequestedFrom)
+		if summary := conclusionAdjustmentSummary(c); summary != "" {
+			extras = tuiDim.Render("  " + summary)
 		} else if c.Strict.RescuedBy != "" {
 			extras = tuiYellow.Render("  ⚕rescued:" + c.Strict.RescuedBy)
 		} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
@@ -178,8 +178,12 @@ func (v *conclusionDetailView) view(width, height int) string {
 		lines = append(lines, tuiDim.Render("candidate=")+c.CandidateExp+"  "+tuiDim.Render("baseline=")+emptyDash(c.BaselineExp))
 	}
 	if c.Strict.RequestedFrom != "" {
+		header := "⚠ downgraded from " + c.Strict.RequestedFrom
+		if conclusionAdjustmentKind(c) == conclusionAdjustmentWith {
+			header = "↺ withdrawn from " + c.Strict.RequestedFrom
+		}
 		lines = append(lines, "")
-		lines = append(lines, tuiBoldYellow.Render("⚠ downgraded from "+c.Strict.RequestedFrom))
+		lines = append(lines, tuiBoldYellow.Render(header))
 		for _, r := range c.Strict.Reasons {
 			lines = append(lines, "  · "+r)
 		}

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -111,9 +111,9 @@ func (v *conclusionListView) view(width, height int) string {
 		} else if c.Verdict == entity.VerdictSupported || c.Verdict == entity.VerdictRefuted {
 			review = tuiYellow.Render("±")
 		}
-		rows[i] = fmt.Sprintf("%-8s  %s %s hyp=%-8s  Δfrac=%+.4f  p=%.4g%s",
+		rows[i] = fmt.Sprintf("%-8s  %s %s hyp=%-8s  Δfrac=%s  p=%.4g%s",
 			c.ID, padRight(tuiVerdictBadge(c.Verdict), 12), review,
-			c.Hypothesis, c.Effect.DeltaFrac, c.Effect.PValue, extras)
+			c.Hypothesis, fmtSignedNumber(c.Effect.DeltaFrac), c.Effect.PValue, extras)
 	}
 	return renderFilteredListBody(header, rows, v.cursor, width, height)
 }
@@ -207,8 +207,8 @@ func (v *conclusionDetailView) view(width, height int) string {
 			}
 			header := fmt.Sprintf("  %s (%s) %s", cc.Instrument, cc.Role, status)
 			if cc.Effect != nil {
-				header += fmt.Sprintf("  Δfrac=%+.4f  CI[%+.4f,%+.4f]",
-					cc.Effect.DeltaFrac, cc.Effect.CILowFrac, cc.Effect.CIHighFrac)
+				header += fmt.Sprintf("  Δfrac=%s  CI%s",
+					fmtSignedNumber(cc.Effect.DeltaFrac), fmtSignedRange(cc.Effect.CILowFrac, cc.Effect.CIHighFrac))
 			}
 			lines = append(lines, header)
 			for _, r := range cc.Reasons {
@@ -219,10 +219,10 @@ func (v *conclusionDetailView) view(width, height int) string {
 	lines = append(lines, "")
 	lines = append(lines, tuiBold.Render("Effect:"))
 	lines = append(lines, fmt.Sprintf("  instrument=%s  test=%s", c.Effect.Instrument, c.StatTest))
-	lines = append(lines, fmt.Sprintf("  delta_abs=%+.6g  delta_frac=%+.4f",
-		c.Effect.DeltaAbs, c.Effect.DeltaFrac))
-	lines = append(lines, fmt.Sprintf("  abs_ci=[%.6g,%.6g]  frac_ci=[%+.4f,%+.4f]",
-		c.Effect.CILowAbs, c.Effect.CIHighAbs, c.Effect.CILowFrac, c.Effect.CIHighFrac))
+	lines = append(lines, fmt.Sprintf("  delta_abs=%s  delta_frac=%s",
+		fmtSignedNumber(c.Effect.DeltaAbs), fmtSignedNumber(c.Effect.DeltaFrac)))
+	lines = append(lines, fmt.Sprintf("  abs_ci=%s  frac_ci=%s",
+		fmtSignedRange(c.Effect.CILowAbs, c.Effect.CIHighAbs), fmtSignedRange(c.Effect.CILowFrac, c.Effect.CIHighFrac)))
 	lines = append(lines, fmt.Sprintf("  p_value=%.4g  method=%s  n=(cand=%d, base=%d)",
 		c.Effect.PValue, c.Effect.CIMethod, c.Effect.NCandidate, c.Effect.NBaseline))
 	lines = append(lines, "")

--- a/internal/cli/tui_view_dashboard.go
+++ b/internal/cli/tui_view_dashboard.go
@@ -439,12 +439,12 @@ func (v *dashboardView) renderFrontierPanel(width, height int) string {
 		if i == 0 {
 			marker = tuiBoldYellow.Render("* ")
 		}
-		line := fmt.Sprintf("%s%s  %s  %s=%.6g",
+		line := fmt.Sprintf("%s%s  %s  %s=%s",
 			marker,
 			tuiCyan.Render(r.Conclusion),
 			tuiCyan.Render(r.Hypothesis),
 			snap.Goal.Objective.Instrument,
-			r.Value)
+			fmtNumber(r.Value))
 		if r.Classification == experimentClassificationDead {
 			line += "  " + tuiDim.Render(experimentClassificationMarker(r.Classification))
 		}

--- a/internal/cli/tui_view_experiment.go
+++ b/internal/cli/tui_view_experiment.go
@@ -217,10 +217,10 @@ func (v *experimentDetailView) view(width, height int) string {
 		rows = append(rows, []string{"id", "measurement", "n", "ci", "pass"})
 		for i := 0; i < max; i++ {
 			o := v.obs[i]
-			meas := fmt.Sprintf("%s=%.6g %s", o.Instrument, o.Value, o.Unit)
+			meas := fmt.Sprintf("%s=%s", o.Instrument, fmtValue(o.Value, o.Unit))
 			ci := ""
 			if o.CILow != nil && o.CIHigh != nil {
-				ci = fmt.Sprintf("[%.6g, %.6g]", *o.CILow, *o.CIHigh)
+				ci = fmtValueRange(*o.CILow, *o.CIHigh, o.Unit)
 			}
 			pass := ""
 			if o.Pass != nil {
@@ -266,11 +266,11 @@ func (v *experimentDetailView) view(width, height int) string {
 			srows = append(srows, []string{
 				k,
 				fmt.Sprintf("%d", s.N),
-				fmt.Sprintf("%.6g", s.Mean),
-				fmt.Sprintf("[%.6g, %.6g]", s.CILow, s.CIHigh),
-				fmt.Sprintf("%.4g", s.StdDev),
-				fmt.Sprintf("%.6g", s.Min),
-				fmt.Sprintf("%.6g", s.Max),
+				fmtNumber(s.Mean),
+				fmtRange(s.CILow, s.CIHigh),
+				fmtNumber(s.StdDev),
+				fmtNumber(s.Min),
+				fmtNumber(s.Max),
 				s.CIMethod,
 			})
 		}

--- a/internal/cli/tui_view_hypothesis.go
+++ b/internal/cli/tui_view_hypothesis.go
@@ -323,8 +323,8 @@ func (v *hypothesisDetailView) renderLines(width int) ([]string, []hypDetailLink
 	} else {
 		for _, c := range v.concls {
 			extras := ""
-			if c.Strict.RequestedFrom != "" {
-				extras = tuiDim.Render("  (downgraded from " + c.Strict.RequestedFrom + ")")
+			if summary := conclusionAdjustmentSummary(c); summary != "" {
+				extras = tuiDim.Render("  (" + summary + ")")
 			} else if c.Strict.RescuedBy != "" {
 				extras = tuiYellow.Render("  (rescued by " + c.Strict.RescuedBy + ")")
 			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {

--- a/internal/cli/tui_view_hypothesis.go
+++ b/internal/cli/tui_view_hypothesis.go
@@ -330,8 +330,8 @@ func (v *hypothesisDetailView) renderLines(width int) ([]string, []hypDetailLink
 			} else if c.Strict.Directional && c.Verdict == entity.VerdictSupported {
 				extras = tuiDim.Render("  (directional)")
 			}
-			lines = append(lines, fmt.Sprintf("  %s  %s  delta_frac=%.4f  p=%.4g%s",
-				c.ID, tuiVerdictBadge(c.Verdict), c.Effect.DeltaFrac, c.Effect.PValue, extras))
+			lines = append(lines, fmt.Sprintf("  %s  %s  delta_frac=%s  p=%.4g%s",
+				c.ID, tuiVerdictBadge(c.Verdict), fmtSignedNumber(c.Effect.DeltaFrac), c.Effect.PValue, extras))
 			links = append(links, hypDetailLink{kind: hypDetailLinkConclusion, id: c.ID, line: len(lines) - 1})
 		}
 	}
@@ -344,7 +344,7 @@ func (v *hypothesisDetailView) renderLines(width int) ([]string, []hypDetailLink
 		for _, o := range v.obs {
 			ci := ""
 			if o.CILow != nil && o.CIHigh != nil {
-				ci = fmt.Sprintf("[%s, %s]", fmtValue(*o.CILow, o.Unit), fmtValue(*o.CIHigh, o.Unit))
+				ci = fmtValueRange(*o.CILow, *o.CIHigh, o.Unit)
 			}
 			pass := ""
 			if o.Pass != nil {

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -286,7 +286,7 @@ func (v *frontierView) view(width, height int) string {
 	assessment := ""
 	switch v.assessment.Mode {
 	case "threshold":
-		assessment = fmt.Sprintf("threshold=%g -> %s", v.assessment.Threshold, v.assessment.OnThreshold)
+		assessment = fmt.Sprintf("threshold=%s -> %s", fmtNumber(v.assessment.Threshold), v.assessment.OnThreshold)
 		if v.assessment.Met {
 			assessment += " (met)"
 		}
@@ -303,13 +303,13 @@ func (v *frontierView) view(width, height int) string {
 		if i == 0 {
 			marker = tuiBoldYellow.Render("* ")
 		}
-		rows[i] = fmt.Sprintf("%s%s  %s  %s=%.6g  Δfrac=%+.4f",
+		rows[i] = fmt.Sprintf("%s%s  %s  %s=%s  Δfrac=%s",
 			marker,
 			tuiCyan.Render(r.Conclusion),
 			tuiCyan.Render(r.Hypothesis),
 			v.goal.Objective.Instrument,
-			r.Value,
-			r.DeltaFrac)
+			fmtNumber(r.Value),
+			fmtSignedNumber(r.DeltaFrac))
 		if r.Classification == experimentClassificationDead {
 			rows[i] += "  " + tuiDim.Render(experimentClassificationMarker(r.Classification))
 		}

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -286,7 +286,7 @@ func (v *frontierView) view(width, height int) string {
 	assessment := ""
 	switch v.assessment.Mode {
 	case "threshold":
-		assessment = fmt.Sprintf("threshold=%s -> %s", fmtNumber(v.assessment.Threshold), v.assessment.OnThreshold)
+		assessment = formatGoalThresholdDecision(v.assessment.Threshold, v.assessment.OnThreshold)
 		if v.assessment.Met {
 			assessment += " (met)"
 		}

--- a/internal/cli/tui_view_observation.go
+++ b/internal/cli/tui_view_observation.go
@@ -66,7 +66,7 @@ func (v *observationDetailView) view(width, height int) string {
 	}
 	o := v.o
 	lines := []string{}
-	lines = append(lines, tuiBold.Render(o.ID)+"  "+tuiCyan.Render(o.Instrument)+"="+fmt.Sprintf("%.6g %s", o.Value, o.Unit))
+	lines = append(lines, tuiBold.Render(o.ID)+"  "+tuiCyan.Render(o.Instrument)+"="+fmtValue(o.Value, o.Unit))
 	lines = append(lines, tuiDim.Render("experiment=")+o.Experiment+"  "+tuiDim.Render("author=")+o.Author)
 	lines = append(lines, tuiDim.Render("measured_at=")+o.MeasuredAt.UTC().Format(time.RFC3339))
 	lines = append(lines, "")
@@ -76,7 +76,7 @@ func (v *observationDetailView) view(width, height int) string {
 		{"exit", fmt.Sprintf("%d", o.ExitCode)},
 	}
 	if o.CILow != nil && o.CIHigh != nil {
-		kv = append(kv, [2]string{"ci", fmt.Sprintf("[%.6g, %.6g] (%s)", *o.CILow, *o.CIHigh, emptyDash(o.CIMethod))})
+		kv = append(kv, [2]string{"ci", fmt.Sprintf("%s (%s)", fmtValueRange(*o.CILow, *o.CIHigh, o.Unit), emptyDash(o.CIMethod))})
 	}
 	if o.Pass != nil {
 		pass := tuiRed.Render("fail")

--- a/internal/cli/winning_experiment_test.go
+++ b/internal/cli/winning_experiment_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func setupWinningExperimentStore(t *testing.T, hypStatus string) *store.Store {
+	t.Helper()
+	s := mustCreateCLIStore(t)
+	now := time.Now().UTC()
+
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		Claim:     "tighten loop",
+		Predicts:  entity.Predicts{Instrument: "host_timing", Target: "fir", Direction: "decrease", MinEffect: 0.1},
+		KillIf:    []string{"tests fail"},
+		Status:    hypStatus,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range []*entity.Experiment{
+		{ID: "E-0001", Hypothesis: h.ID, Status: entity.ExpAnalyzed, Branch: "autoresearch/E-0001", CreatedAt: now.Add(-1 * time.Minute)},
+		{ID: "E-0002", Hypothesis: h.ID, Status: entity.ExpMeasured, Branch: "autoresearch/E-0002", CreatedAt: now},
+	} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c := &entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   h.ID,
+		Verdict:      entity.VerdictSupported,
+		CandidateExp: "E-0001",
+		Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.2},
+		ReviewedBy:   "agent:gate",
+		Author:       "agent:analyst",
+		CreatedAt:    now.Add(-30 * time.Second),
+	}
+	if err := s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestResolveWinningExperiment_UsesSupportedWinnerWhenHypothesisIsCurrentlySupported(t *testing.T) {
+	s := setupWinningExperimentStore(t, entity.StatusSupported)
+
+	concl, exp, err := resolveWinningExperiment(s, "H-0001", "")
+	if err != nil {
+		t.Fatalf("resolveWinningExperiment: %v", err)
+	}
+	if concl == nil || concl.ID != "C-0001" {
+		t.Fatalf("conclusion = %+v, want C-0001", concl)
+	}
+	if exp == nil || exp.ID != "E-0001" {
+		t.Fatalf("experiment = %+v, want E-0001", exp)
+	}
+}
+
+func TestResolveWinningExperiment_FallsBackToLatestExperimentWhenHypothesisIsNotCurrentlySupported(t *testing.T) {
+	for _, status := range []string{entity.StatusRefuted, entity.StatusKilled, entity.StatusInconclusive, entity.StatusUnreviewed} {
+		t.Run(status, func(t *testing.T) {
+			s := setupWinningExperimentStore(t, status)
+
+			concl, exp, err := resolveWinningExperiment(s, "H-0001", "")
+			if err != nil {
+				t.Fatalf("resolveWinningExperiment: %v", err)
+			}
+			if concl != nil {
+				t.Fatalf("conclusion = %+v, want nil", concl)
+			}
+			if exp == nil || exp.ID != "E-0002" {
+				t.Fatalf("experiment = %+v, want latest E-0002", exp)
+			}
+		})
+	}
+}
+
+func TestResolveWinningExperiment_ExplicitHistoricalConclusionStillWorks(t *testing.T) {
+	s := setupWinningExperimentStore(t, entity.StatusRefuted)
+
+	concl, exp, err := resolveWinningExperiment(s, "H-0001", "C-0001")
+	if err != nil {
+		t.Fatalf("resolveWinningExperiment: %v", err)
+	}
+	if concl == nil || concl.ID != "C-0001" {
+		t.Fatalf("conclusion = %+v, want C-0001", concl)
+	}
+	if exp == nil || exp.ID != "E-0001" {
+		t.Fatalf("experiment = %+v, want E-0001", exp)
+	}
+}

--- a/internal/cli/winning_experiment_test.go
+++ b/internal/cli/winning_experiment_test.go
@@ -49,8 +49,27 @@ func setupWinningExperimentStore(t *testing.T, hypStatus string) *store.Store {
 	return s
 }
 
-func TestResolveWinningExperiment_UsesSupportedWinnerWhenHypothesisIsCurrentlySupported(t *testing.T) {
-	s := setupWinningExperimentStore(t, entity.StatusSupported)
+func TestResolveWinningExperiment_UsesSupportedWinnerWhenHypothesisCurrentTruthStillPointsAtIt(t *testing.T) {
+	for _, status := range []string{entity.StatusSupported, entity.StatusUnreviewed} {
+		t.Run(status, func(t *testing.T) {
+			s := setupWinningExperimentStore(t, status)
+
+			concl, exp, err := resolveWinningExperiment(s, "H-0001", "")
+			if err != nil {
+				t.Fatalf("resolveWinningExperiment: %v", err)
+			}
+			if concl == nil || concl.ID != "C-0001" {
+				t.Fatalf("conclusion = %+v, want C-0001", concl)
+			}
+			if exp == nil || exp.ID != "E-0001" {
+				t.Fatalf("experiment = %+v, want E-0001", exp)
+			}
+		})
+	}
+}
+
+func TestResolveWinningExperiment_LegacyKilledHypothesisKeepsHistoricalSupportedWinner(t *testing.T) {
+	s := setupWinningExperimentStore(t, entity.StatusKilled)
 
 	concl, exp, err := resolveWinningExperiment(s, "H-0001", "")
 	if err != nil {
@@ -64,8 +83,8 @@ func TestResolveWinningExperiment_UsesSupportedWinnerWhenHypothesisIsCurrentlySu
 	}
 }
 
-func TestResolveWinningExperiment_FallsBackToLatestExperimentWhenHypothesisIsNotCurrentlySupported(t *testing.T) {
-	for _, status := range []string{entity.StatusRefuted, entity.StatusKilled, entity.StatusInconclusive, entity.StatusUnreviewed} {
+func TestResolveWinningExperiment_FallsBackToLatestExperimentWhenHypothesisDoesNotRetainSupportedWinner(t *testing.T) {
+	for _, status := range []string{entity.StatusRefuted, entity.StatusInconclusive} {
 		t.Run(status, func(t *testing.T) {
 			s := setupWinningExperimentStore(t, status)
 

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -51,6 +51,7 @@ YAML authoring or file editing. When a human says:
 | "Resume" | ` + "`autoresearch resume`" + ` |
 | "What's the current best?" | ` + "`autoresearch frontier`" + `, summarize |
 | "Show me the writeup for H-0001" | ` + "`autoresearch report H-0001`" + ` |
+| "That conclusion no longer stands" | ` + "`autoresearch conclusion withdraw C-0007 --reason \"...\"`" + ` |
 | "What changed in the winning experiment?" | ` + "`autoresearch hypothesis diff H-0001`" + ` |
 | "Ship that optimization" | ` + "`autoresearch hypothesis apply H-0001`" + ` (cherry-picks the winning experiment) |
 | "Where's the worktree for H-0003?" | ` + "`autoresearch hypothesis worktree H-0003`" + ` |
@@ -106,8 +107,9 @@ by hand, you are lying to future-you — don't.
                      └─> conclude     (status: analyzed)    -- stats firewall applied
                           ├─> hypothesis: unreviewed     (supported/refuted pending gate review)
                           │    ├─ conclusion accept  → hypothesis: supported | refuted
-                          │    └─ conclusion downgrade → hypothesis: inconclusive
-                          │         └─ conclusion appeal → hypothesis: unreviewed (re-review)
+                          │    ├─ conclusion downgrade → hypothesis: inconclusive
+                          │    ├─ conclusion withdraw  → hypothesis: inconclusive
+                          │    └─ conclusion appeal    → hypothesis: unreviewed (critic-only re-review)
                           └─> hypothesis: inconclusive   (no review needed)
 
 Every hypothesis is bound to the goal that was active when it was
@@ -279,11 +281,15 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
     autoresearch conclusion downgrade  <C-id> --reason "..." [--reviewed-by agent:gate-reviewer]
         # Gate reviewer's rejection: flips supported|refuted → inconclusive,
         # preserving the original verdict in strict_check.downgraded_from.
+    autoresearch conclusion withdraw   <C-id> --reason "..." [--author ...]
+        # Main-session / author-side retraction: flips supported|refuted
+        # (or a still-unreviewed decisive claim) back to inconclusive with
+        # explicit withdrawal provenance in the event log and conclusion body.
     autoresearch conclusion appeal     <C-id> --rebuttal "..."
         # Appeal a critic downgrade: restores original verdict, clears
         # reviewed_by, records rebuttal. Only valid for critic downgrades.
 
-Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provisional until gate review resolves them via ` + "`conclusion accept`" + ` or ` + "`conclusion downgrade`" + `. If a delegated one-cycle ` + "`research-orchestrator`" + ` returns a decisive conclusion, the parent/main session owns the next handoff: dispatch ` + "`research-gate-reviewer`" + ` from the parent, do not nest another orchestrator, and do not start another cycle while the chain is still ` + "`unreviewed`" + `. If you cannot dispatch a reviewer, stop after writing the conclusion and yield to the human/main session.
+Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provisional until gate review resolves them via ` + "`conclusion accept`" + ` or ` + "`conclusion downgrade`" + `. If later evidence means the claim should no longer stand, use ` + "`conclusion withdraw`" + ` to move the hypothesis back to ` + "`inconclusive`" + ` before re-concluding. If a delegated one-cycle ` + "`research-orchestrator`" + ` returns a decisive conclusion, the parent/main session owns the next handoff: dispatch ` + "`research-gate-reviewer`" + ` from the parent, do not nest another orchestrator, and do not start another cycle while the chain is still ` + "`unreviewed`" + `. If you cannot dispatch a reviewer, stop after writing the conclusion and yield to the human/main session.
 
 ### Artifact navigation (bounded by default)
     autoresearch artifact list   [--goal G-NNNN|all] [--experiment E-XXXX | --observation O-XXXX]

--- a/internal/readmodel/current_truth.go
+++ b/internal/readmodel/current_truth.go
@@ -1,0 +1,21 @@
+package readmodel
+
+import "github.com/bytter/autoresearch/internal/entity"
+
+// SupportedConclusionCountsForReadSurface reports whether a historical
+// supported conclusion should still be used as the default supported winner on
+// read surfaces. This includes current accepted/pending truth and a legacy
+// killed-state back-compat exception.
+func SupportedConclusionCountsForReadSurface(status string) bool {
+	switch status {
+	case "", entity.StatusSupported, entity.StatusUnreviewed:
+		return true
+	case entity.StatusKilled:
+		// Back-compat: older stores may still contain supported->killed
+		// histories. Preserve those accepted wins on read-only historical
+		// surfaces even though new lifecycle guards stop producing them.
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/readmodel/current_truth_test.go
+++ b/internal/readmodel/current_truth_test.go
@@ -1,0 +1,34 @@
+package readmodel
+
+import (
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestSupportedConclusionCountsForReadSurface(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+		want   bool
+	}{
+		{name: "missing legacy status", status: "", want: true},
+		{name: "supported", status: entity.StatusSupported, want: true},
+		{name: "unreviewed", status: entity.StatusUnreviewed, want: true},
+		{name: "legacy killed", status: entity.StatusKilled, want: true},
+		{name: "refuted", status: entity.StatusRefuted, want: false},
+		{name: "inconclusive", status: entity.StatusInconclusive, want: false},
+		{name: "open", status: entity.StatusOpen, want: false},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SupportedConclusionCountsForReadSurface(tc.status); got != tc.want {
+				t.Fatalf("SupportedConclusionCountsForReadSurface(%q) = %v, want %v", tc.status, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -196,7 +196,7 @@ func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 			continue
 		}
 		class := ExperimentReadClassForID(expClassByID, c.CandidateExp)
-		if !supportedConclusionCountsForCurrentTruth(class.HypothesisStatus) {
+		if !SupportedConclusionCountsForReadSurface(class.HypothesisStatus) {
 			continue
 		}
 		obs := obsByExp[c.CandidateExp]
@@ -306,27 +306,13 @@ func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp ma
 	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
 		return 0, false
 	}
-	if !supportedConclusionCountsForCurrentTruth(class.HypothesisStatus) {
+	if !SupportedConclusionCountsForReadSurface(class.HypothesisStatus) {
 		return 0, false
 	}
 	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
 		return 0, false
 	}
 	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
-}
-
-func supportedConclusionCountsForCurrentTruth(status string) bool {
-	switch status {
-	case "", entity.StatusSupported, entity.StatusUnreviewed:
-		return true
-	case entity.StatusKilled:
-		// Back-compat: older stores may still contain supported->killed
-		// histories. Preserve those accepted wins on read-only historical
-		// surfaces even though new lifecycle guards stop producing them.
-		return true
-	default:
-		return false
-	}
 }
 
 func betterFrontierValue(direction string, candidate, incumbent float64) bool {

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -85,11 +85,11 @@ func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	requireByInst := frontierRequireConstraints(goal)
 
 	for _, c := range concls {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		class := ExperimentReadClassForID(expClassByID, c.CandidateExp)
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst, class)
 		if !ok {
 			continue
 		}
-		class := ExperimentReadClassForID(expClassByID, c.CandidateExp)
 		rows = append(rows, FrontierRow{
 			Conclusion:       c.ID,
 			Hypothesis:       c.Hypothesis,
@@ -113,7 +113,7 @@ func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	hasBest := false
 	var bestRow FrontierRow
 	for _, c := range sortedByTime {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst, ExperimentReadClassForID(expClassByID, c.CandidateExp))
 		if ok {
 			cur := FrontierRow{
 				Value:          val,
@@ -170,7 +170,6 @@ func FrontierRowBetter(goal *entity.Goal, a, b FrontierRow) bool {
 }
 
 func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierGoalAssessment {
-	_ = expClassByID
 	if goal == nil || goal.IsOpenEnded() {
 		return FrontierGoalAssessment{
 			Mode:              "open_ended",
@@ -193,11 +192,11 @@ func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 		if c == nil || c.ReviewedBy == "" {
 			continue
 		}
-		// goal_assessment is about accepted historical wins, not loop
-		// actionability. Once a supported conclusion is accepted, its parent
-		// hypothesis becomes supported and the experiment read class goes dead;
-		// the assessment must still be able to report the goal as met.
 		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
+			continue
+		}
+		class := ExperimentReadClassForID(expClassByID, c.CandidateExp)
+		if !supportedConclusionCountsForCurrentTruth(class.HypothesisStatus) {
 			continue
 		}
 		obs := obsByExp[c.CandidateExp]
@@ -300,17 +299,34 @@ func frontierRequireConstraints(goal *entity.Goal) map[string]string {
 	return requireByInst
 }
 
-func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string) (float64, bool) {
+func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string, class ExperimentReadClass) (float64, bool) {
 	if goal == nil || c == nil {
 		return 0, false
 	}
 	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
 		return 0, false
 	}
+	if !supportedConclusionCountsForCurrentTruth(class.HypothesisStatus) {
+		return 0, false
+	}
 	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
 		return 0, false
 	}
 	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
+}
+
+func supportedConclusionCountsForCurrentTruth(status string) bool {
+	switch status {
+	case "", entity.StatusSupported, entity.StatusUnreviewed:
+		return true
+	case entity.StatusKilled:
+		// Back-compat: older stores may still contain supported->killed
+		// histories. Preserve those accepted wins on read-only historical
+		// surfaces even though new lifecycle guards stop producing them.
+		return true
+	default:
+		return false
+	}
 }
 
 func betterFrontierValue(direction string, candidate, incumbent float64) bool {

--- a/internal/readmodel/frontier_test.go
+++ b/internal/readmodel/frontier_test.go
@@ -41,6 +41,40 @@ func TestAssessGoalCompletion_CountsReviewedSupportedCandidatesAfterAcceptance(t
 	}
 }
 
+func TestAssessGoalCompletion_IgnoresHistoricalSupportedCandidateOnceHypothesisIsRefuted(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Completion: &entity.Completion{
+			Threshold:   0.2,
+			OnThreshold: entity.GoalOnThresholdStop,
+		},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-3000",
+			Hypothesis:   "H-3000",
+			Verdict:      entity.VerdictSupported,
+			ReviewedBy:   "agent:gate",
+			CandidateExp: "E-3000",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.3},
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-3000": {{Instrument: "host_timing", Value: 0.70}},
+	}
+	expClassByID := map[string]ExperimentReadClass{
+		"E-3000": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusRefuted,
+		},
+	}
+
+	got := AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
+	if got.Met || got.MetByConclusion != "" || got.RecommendedAction != "continue" {
+		t.Fatalf("unexpected assessment: %+v", got)
+	}
+}
+
 func TestComputeFrontierFromObservations_StalledForCountsLaterConclusionsAfterAcceptedWin(t *testing.T) {
 	goal := &entity.Goal{
 		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
@@ -141,5 +175,70 @@ func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
 	}
 	if got.Rows[0].Classification != ExperimentClassificationDead {
 		t.Fatalf("row classification = %q, want %q", got.Rows[0].Classification, ExperimentClassificationDead)
+	}
+}
+
+func TestComputeFrontierFromObservations_RefutedHypothesisDropsHistoricalSupportedRow(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0001",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.25},
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-0001": {{Instrument: "host_timing", Value: 0.75}},
+	}
+
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]ExperimentReadClass{
+		"E-0001": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusRefuted,
+		},
+	})
+	if got, want := len(rows), 0; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := stalled, 0; got != want {
+		t.Fatalf("stalled_for = %d, want %d", got, want)
+	}
+}
+
+func TestComputeFrontierFromObservations_LegacyKilledHypothesisKeepsHistoricalSupportedRow(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			CandidateExp: "E-0001",
+			Effect:       entity.Effect{Instrument: "host_timing", DeltaFrac: -0.25},
+		},
+	}
+	obsByExp := map[string][]*entity.Observation{
+		"E-0001": {{Instrument: "host_timing", Value: 0.75}},
+	}
+
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]ExperimentReadClass{
+		"E-0001": {
+			Classification:   ExperimentClassificationDead,
+			HypothesisStatus: entity.StatusKilled,
+		},
+	})
+	if got, want := len(rows), 1; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := rows[0].HypothesisStatus, entity.StatusKilled; got != want {
+		t.Fatalf("row hypothesis_status = %q, want %q", got, want)
+	}
+	if got, want := stalled, 0; got != want {
+		t.Fatalf("stalled_for = %d, want %d", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Stacked on #32.
Addresses #33.

This hardens the hypothesis/conclusion lifecycle so the current hypothesis
status is the authoritative accepted stance, instead of letting later command
flows silently coexist with stale supported winners.

The change adds an explicit author-side `conclusion withdraw` path, tightens
`conclude` and `hypothesis kill` so decisive or pending hypotheses must be
resolved before further lifecycle transitions, and stops default winner
resolution from treating older supported conclusions as current truth once the
hypothesis is no longer currently supported.

## What changed

- add `conclusion withdraw` with its own audit/event path, distinct from critic downgrade
- reject `conclude` and `hypothesis kill` from `unreviewed`, `supported`, and `refuted`
- make `hypothesis apply` require a currently `supported` hypothesis instead of any historical supported conclusion
- treat `refuted` / `inconclusive` hypotheses as non-contributors to current-truth frontier and goal assessment
- keep legacy `supported -> killed` histories visible on read-only historical surfaces as back-compat
- update README / DATAMODEL / CLAUDE and managed agent docs for the new lifecycle contract

## Tests

- `make test`
- new CLI lifecycle scenario for withdraw + later accepted refutation
- new lifecycle guard tests for conclude / kill
- new winner-resolution tests
- new event + dry-run coverage for `conclusion withdraw`
