### PR TITLE
Add evidence side-artifacts for mechanism audit trails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,11 @@ get a new file plus an entry in the `groups` slice in `Root()`.
 - **Output.** Every verb supports `--json`. Use the `output` package; don't
   hand-roll JSON. Text output is for humans; JSON is the agent contract and
   must stay stable across patches.
+- **Read surfaces should be total.** If a reviewer-facing read path joins
+  cross-entity evidence (for example `conclusion show --json` joining cited
+  observations), do not silently drop unreadable references. Surface the read
+  issue explicitly and keep it distinct from "evidence capture was configured
+  but failed" and from "no evidence was configured".
 - **Errors.** Sentinel errors live in `internal/cli/errors.go`. `ErrPaused`
   → exit 3, `ErrBudgetExhausted` → exit 4. Don't invent new exit codes
   without updating `cmd/autoresearch/main.go` and the README/agent doc.

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -285,6 +285,24 @@ and failures are recorded on the observation rather than failing it.
 
 No lifecycle: observations do not have a status.
 
+### Derived read-side joins
+
+`conclusion show --json` is a read projection over the stored conclusion plus
+additive observation-side evidence joins keyed by cited observation id. These
+fields are not persisted on `Conclusion`; they are assembled at read time so a
+reviewer can audit the cited evidence chain without issuing extra observation
+reads.
+
+| JSON field | Derived from | Meaning |
+| --- | --- | --- |
+| `observation_artifacts` | `Observation.Artifacts` | Artifact metadata for readable cited observations. Values are metadata only, never artifact bytes. |
+| `observation_evidence_failures` | `Observation.EvidenceFailures` | Non-fatal evidence capture failures for readable cited observations where evidence capture was configured but failed. |
+| `observation_read_issues` | read error on `Store.ReadObservation(id)` | Cited observations that could not be read at all (for example missing or corrupt persisted state). |
+
+These three cases are intentionally distinct. `observation_evidence_failures`
+and `observation_read_issues` do **not** mean "no evidence configured"; they
+mean the persisted audit chain is incomplete in different ways.
+
 ---
 
 ## Conclusion
@@ -369,6 +387,12 @@ a clean primary win. The frontier's sort uses rescuers as a bounded
 tiebreak when primary values are within `NeutralBandFrac`: a rescued
 candidate whose rescuer wins displaces the prior best at the same
 primary tier.
+
+`conclusion show --json` therefore exposes both the persisted conclusion and
+the read-side evidence joins above. The stored `Observations[]` list remains
+authoritative even if one cited observation later becomes unreadable; the read
+surface reports that breakage via `observation_read_issues` rather than
+silently dropping the citation.
 
 ### Derived frontier snapshot
 

--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -267,6 +267,7 @@ observations are not mutated once written.
 | `CIMethod` | `string` | `ci_method` | e.g. `bootstrap-bca`. |
 | `Pass` | `*bool` | `pass` | For boolean instruments (e.g. `host_test=pass`). |
 | `Artifacts` | `[]Artifact` | `artifacts` | Content-addressed output files. |
+| `EvidenceFailures` | `[]EvidenceFailure` | `evidence_failures` | Non-fatal evidence side-artifact commands that failed after the primary measurement. |
 | `RawArtifact`, `RawSHA` | `string` | `raw_artifact`, `raw_sha` | Legacy single-artifact fields; kept in sync by `Normalize()`. |
 | `Command` | `string` | `command` | Command that produced the observation. |
 | `ExitCode` | `int` | `exit_code` | |
@@ -278,6 +279,9 @@ observations are not mutated once written.
 **`Artifact`** (`internal/entity/observation.go:12-18`): `Name`, `SHA`,
 `Path` (relative to `.research/`), `Bytes`, `Mime`. Artifacts live at
 `.research/artifacts/AB/CDEF…/<filename>` (see [On-disk layout](#on-disk-layout)).
+Evidence side-artifacts use logical names like `evidence/mechanism`;
+their combined stdout+stderr is stored alongside the primary artifact,
+and failures are recorded on the observation rather than failing it.
 
 No lifecycle: observations do not have a status.
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ The core nouns are:
 | **Instrument** | A command plus parser that turns program behavior into a number or pass/fail result. | Makes optimization targets measurable and repeatable. |
 | **Artifact** | Content-addressed captured output attached to an observation. | Preserves the exact evidence a reviewer or human needs to audit a measurement. |
 
+Some artifacts are evidence side-artifacts: analysis outputs captured
+alongside a measurement so later mechanism claims are auditable from
+persisted state.
+
 `analyze` is a read-only computation over observations, not a first-class stored
 entity. It summarizes an experiment relative to the baseline and prepares the
 material a later `conclude` step will judge.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,10 @@ The core nouns are:
 
 Some artifacts are evidence side-artifacts: analysis outputs captured
 alongside a measurement so later mechanism claims are auditable from
-persisted state.
+persisted state. Reviewer-facing read surfaces preserve that audit chain:
+`conclusion show --json` distinguishes readable evidence artifacts,
+non-fatal evidence capture failures, and cited observations whose
+persisted evidence can no longer be read.
 
 `analyze` is a read-only computation over observations, not a first-class stored
 entity. It summarizes an experiment relative to the baseline and prepares the

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -21,7 +21,9 @@ func conclusionCommands() []*cobra.Command {
 
 type conclusionShowJSON struct {
 	*entity.Conclusion
-	ObservationArtifacts map[string][]entity.Artifact `json:"observation_artifacts,omitempty"`
+	ObservationArtifacts        map[string][]entity.Artifact        `json:"observation_artifacts,omitempty"`
+	ObservationEvidenceFailures map[string][]entity.EvidenceFailure `json:"observation_evidence_failures,omitempty"`
+	ObservationReadIssues       map[string]string                   `json:"observation_read_issues,omitempty"`
 }
 
 func conclusionListCmd() *cobra.Command {
@@ -103,18 +105,29 @@ func conclusionShowCmd() *cobra.Command {
 			if w.IsJSON() {
 				out := conclusionShowJSON{Conclusion: c}
 				if len(c.Observations) > 0 {
-					obsArts := make(map[string][]entity.Artifact, len(c.Observations))
 					for _, id := range c.Observations {
 						obs, err := s.ReadObservation(id)
 						if err != nil {
+							if out.ObservationReadIssues == nil {
+								out.ObservationReadIssues = make(map[string]string, len(c.Observations))
+							}
+							out.ObservationReadIssues[id] = err.Error()
 							continue
+						}
+						if out.ObservationArtifacts == nil {
+							out.ObservationArtifacts = make(map[string][]entity.Artifact, len(c.Observations))
 						}
 						arts := make([]entity.Artifact, len(obs.Artifacts))
 						copy(arts, obs.Artifacts)
-						obsArts[id] = arts
-					}
-					if len(obsArts) > 0 {
-						out.ObservationArtifacts = obsArts
+						out.ObservationArtifacts[id] = arts
+						if len(obs.EvidenceFailures) > 0 {
+							if out.ObservationEvidenceFailures == nil {
+								out.ObservationEvidenceFailures = make(map[string][]entity.EvidenceFailure, len(c.Observations))
+							}
+							failures := make([]entity.EvidenceFailure, len(obs.EvidenceFailures))
+							copy(failures, obs.EvidenceFailures)
+							out.ObservationEvidenceFailures[id] = failures
+						}
 					}
 				}
 				return w.JSON(out)

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -103,34 +103,7 @@ func conclusionShowCmd() *cobra.Command {
 				return err
 			}
 			if w.IsJSON() {
-				out := conclusionShowJSON{Conclusion: c}
-				if len(c.Observations) > 0 {
-					for _, id := range c.Observations {
-						obs, err := s.ReadObservation(id)
-						if err != nil {
-							if out.ObservationReadIssues == nil {
-								out.ObservationReadIssues = make(map[string]string, len(c.Observations))
-							}
-							out.ObservationReadIssues[id] = err.Error()
-							continue
-						}
-						if out.ObservationArtifacts == nil {
-							out.ObservationArtifacts = make(map[string][]entity.Artifact, len(c.Observations))
-						}
-						arts := make([]entity.Artifact, len(obs.Artifacts))
-						copy(arts, obs.Artifacts)
-						out.ObservationArtifacts[id] = arts
-						if len(obs.EvidenceFailures) > 0 {
-							if out.ObservationEvidenceFailures == nil {
-								out.ObservationEvidenceFailures = make(map[string][]entity.EvidenceFailure, len(c.Observations))
-							}
-							failures := make([]entity.EvidenceFailure, len(obs.EvidenceFailures))
-							copy(failures, obs.EvidenceFailures)
-							out.ObservationEvidenceFailures[id] = failures
-						}
-					}
-				}
-				return w.JSON(out)
+				return w.JSON(buildConclusionShowJSON(s, c))
 			}
 			w.Textf("id:           %s\n", c.ID)
 			w.Textf("hypothesis:   %s\n", c.Hypothesis)

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -19,6 +19,11 @@ func conclusionCommands() []*cobra.Command {
 	return []*cobra.Command{c}
 }
 
+type conclusionShowJSON struct {
+	*entity.Conclusion
+	ObservationArtifacts map[string][]entity.Artifact `json:"observation_artifacts,omitempty"`
+}
+
 func conclusionListCmd() *cobra.Command {
 	var hyp, verdict, goalFlag string
 	c := &cobra.Command{
@@ -96,7 +101,23 @@ func conclusionShowCmd() *cobra.Command {
 				return err
 			}
 			if w.IsJSON() {
-				return w.JSON(c)
+				out := conclusionShowJSON{Conclusion: c}
+				if len(c.Observations) > 0 {
+					obsArts := make(map[string][]entity.Artifact, len(c.Observations))
+					for _, id := range c.Observations {
+						obs, err := s.ReadObservation(id)
+						if err != nil {
+							continue
+						}
+						arts := make([]entity.Artifact, len(obs.Artifacts))
+						copy(arts, obs.Artifacts)
+						obsArts[id] = arts
+					}
+					if len(obsArts) > 0 {
+						out.ObservationArtifacts = obsArts
+					}
+				}
+				return w.JSON(out)
 			}
 			w.Textf("id:           %s\n", c.ID)
 			w.Textf("hypothesis:   %s\n", c.Hypothesis)

--- a/internal/cli/conclusion_show_test.go
+++ b/internal/cli/conclusion_show_test.go
@@ -1,0 +1,142 @@
+package cli
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type conclusionShowTestResponse struct {
+	ID                   string                       `json:"id"`
+	Observations         []string                     `json:"observations"`
+	ObservationArtifacts map[string][]entity.Artifact `json:"observation_artifacts,omitempty"`
+}
+
+func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
+	saveGlobals(t)
+	dir := t.TempDir()
+	s, err := store.Create(dir, store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.WriteObservation(&entity.Observation{
+		ID:         "O-0001",
+		Experiment: "E-0001",
+		Instrument: "timing",
+		MeasuredAt: time.Now().UTC(),
+		Value:      100,
+		Unit:       "ns",
+		Samples:    1,
+		Artifacts: []entity.Artifact{{
+			Name:  "scalar",
+			SHA:   "abc123",
+			Path:  "artifacts/ab/c123/scalar.json",
+			Bytes: 42,
+			Mime:  "application/json",
+		}},
+		Command: "echo cycles: 100",
+		Author:  "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID:         "O-0002",
+		Experiment: "E-0001",
+		Instrument: "timing",
+		MeasuredAt: time.Now().UTC(),
+		Value:      101,
+		Unit:       "ns",
+		Samples:    1,
+		Command:    "echo cycles: 101",
+		Author:     "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteConclusion(&entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   "H-0001",
+		Verdict:      entity.VerdictSupported,
+		Observations: []string{"O-0001", "O-0002", "O-9999"},
+		CandidateExp: "E-0001",
+		BaselineExp:  "E-0000",
+		Effect: entity.Effect{
+			Instrument: "timing",
+			DeltaAbs:   -20,
+			DeltaFrac:  -0.2,
+			CILowAbs:   -25,
+			CIHighAbs:  -15,
+			CILowFrac:  -0.25,
+			CIHighFrac: -0.15,
+			PValue:     0.01,
+			CIMethod:   "bootstrap_bca_95",
+			NCandidate: 3,
+			NBaseline:  3,
+		},
+		StatTest:  "mann_whitney_u",
+		Strict:    entity.Strict{Passed: true},
+		Author:    "agent:orchestrator",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got := runCLIJSON[conclusionShowTestResponse](t, dir, "conclusion", "show", "C-0001")
+	if got.ID != "C-0001" {
+		t.Fatalf("id = %q, want C-0001", got.ID)
+	}
+	if len(got.Observations) != 3 {
+		t.Fatalf("observations len = %d, want 3", len(got.Observations))
+	}
+	if gotArts, ok := got.ObservationArtifacts["O-0001"]; !ok || len(gotArts) != 1 {
+		t.Fatalf("joined artifacts for O-0001 = %+v", got.ObservationArtifacts["O-0001"])
+	}
+	if gotArts, ok := got.ObservationArtifacts["O-0002"]; !ok || len(gotArts) != 0 {
+		t.Fatalf("joined artifacts for O-0002 = %+v", got.ObservationArtifacts["O-0002"])
+	}
+	if _, ok := got.ObservationArtifacts["O-9999"]; ok {
+		t.Fatalf("missing observation should not be joined: %+v", got.ObservationArtifacts)
+	}
+}
+
+func TestConclusionShowJSON_OmitsObservationArtifactsWhenNoObservations(t *testing.T) {
+	saveGlobals(t)
+	dir := t.TempDir()
+	s, err := store.Create(dir, store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteConclusion(&entity.Conclusion{
+		ID:         "C-0002",
+		Hypothesis: "H-0002",
+		Verdict:    entity.VerdictInconclusive,
+		Effect: entity.Effect{
+			Instrument: "timing",
+			CIMethod:   "bootstrap_bca_95",
+		},
+		StatTest:  "mann_whitney_u",
+		Strict:    entity.Strict{Passed: true},
+		Author:    "agent:orchestrator",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	raw := runCLI(t, dir, "--json", "conclusion", "show", "C-0002")
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, raw)
+	}
+	if _, ok := payload["observation_artifacts"]; ok {
+		t.Fatalf("unexpected observation_artifacts field: %+v", payload)
+	}
+}

--- a/internal/cli/conclusion_show_test.go
+++ b/internal/cli/conclusion_show_test.go
@@ -9,14 +9,6 @@ import (
 	"github.com/bytter/autoresearch/internal/store"
 )
 
-type conclusionShowTestResponse struct {
-	ID                          string                              `json:"id"`
-	Observations                []string                            `json:"observations"`
-	ObservationArtifacts        map[string][]entity.Artifact        `json:"observation_artifacts,omitempty"`
-	ObservationEvidenceFailures map[string][]entity.EvidenceFailure `json:"observation_evidence_failures,omitempty"`
-	ObservationReadIssues       map[string]string                   `json:"observation_read_issues,omitempty"`
-}
-
 func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	saveGlobals(t)
 	dir := t.TempDir()
@@ -114,7 +106,10 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := runCLIJSON[conclusionShowTestResponse](t, dir, "conclusion", "show", "C-0001")
+	got := runCLIJSON[conclusionShowJSON](t, dir, "conclusion", "show", "C-0001")
+	if got.Conclusion == nil {
+		t.Fatal("decoded conclusion is nil")
+	}
 	if got.ID != "C-0001" {
 		t.Fatalf("id = %q, want C-0001", got.ID)
 	}

--- a/internal/cli/conclusion_show_test.go
+++ b/internal/cli/conclusion_show_test.go
@@ -10,9 +10,11 @@ import (
 )
 
 type conclusionShowTestResponse struct {
-	ID                   string                       `json:"id"`
-	Observations         []string                     `json:"observations"`
-	ObservationArtifacts map[string][]entity.Artifact `json:"observation_artifacts,omitempty"`
+	ID                          string                              `json:"id"`
+	Observations                []string                            `json:"observations"`
+	ObservationArtifacts        map[string][]entity.Artifact        `json:"observation_artifacts,omitempty"`
+	ObservationEvidenceFailures map[string][]entity.EvidenceFailure `json:"observation_evidence_failures,omitempty"`
+	ObservationReadIssues       map[string]string                   `json:"observation_read_issues,omitempty"`
 }
 
 func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
@@ -59,11 +61,36 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID:         "O-0003",
+		Experiment: "E-0001",
+		Instrument: "timing",
+		MeasuredAt: time.Now().UTC(),
+		Value:      102,
+		Unit:       "ns",
+		Samples:    1,
+		Artifacts: []entity.Artifact{{
+			Name:  "evidence/mechanism",
+			SHA:   "def456",
+			Path:  "artifacts/de/f456/mechanism.txt",
+			Bytes: 64,
+			Mime:  "text/plain",
+		}},
+		EvidenceFailures: []entity.EvidenceFailure{{
+			Name:     "profile",
+			ExitCode: 7,
+			Error:    "tool crashed",
+		}},
+		Command: "echo cycles: 102",
+		Author:  "test",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if err := s.WriteConclusion(&entity.Conclusion{
 		ID:           "C-0001",
 		Hypothesis:   "H-0001",
 		Verdict:      entity.VerdictSupported,
-		Observations: []string{"O-0001", "O-0002", "O-9999"},
+		Observations: []string{"O-0001", "O-0002", "O-0003", "O-9999"},
 		CandidateExp: "E-0001",
 		BaselineExp:  "E-0000",
 		Effect: entity.Effect{
@@ -91,8 +118,8 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	if got.ID != "C-0001" {
 		t.Fatalf("id = %q, want C-0001", got.ID)
 	}
-	if len(got.Observations) != 3 {
-		t.Fatalf("observations len = %d, want 3", len(got.Observations))
+	if len(got.Observations) != 4 {
+		t.Fatalf("observations len = %d, want 4", len(got.Observations))
 	}
 	if gotArts, ok := got.ObservationArtifacts["O-0001"]; !ok || len(gotArts) != 1 {
 		t.Fatalf("joined artifacts for O-0001 = %+v", got.ObservationArtifacts["O-0001"])
@@ -100,8 +127,20 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	if gotArts, ok := got.ObservationArtifacts["O-0002"]; !ok || len(gotArts) != 0 {
 		t.Fatalf("joined artifacts for O-0002 = %+v", got.ObservationArtifacts["O-0002"])
 	}
-	if _, ok := got.ObservationArtifacts["O-9999"]; ok {
-		t.Fatalf("missing observation should not be joined: %+v", got.ObservationArtifacts)
+	if gotArts, ok := got.ObservationArtifacts["O-0003"]; !ok || len(gotArts) != 1 {
+		t.Fatalf("joined artifacts for O-0003 = %+v", got.ObservationArtifacts["O-0003"])
+	}
+	if gotFailures, ok := got.ObservationEvidenceFailures["O-0003"]; !ok || len(gotFailures) != 1 {
+		t.Fatalf("joined evidence failures for O-0003 = %+v", got.ObservationEvidenceFailures["O-0003"])
+	}
+	if gotFailures := got.ObservationEvidenceFailures["O-0003"][0]; gotFailures.Name != "profile" || gotFailures.ExitCode != 7 {
+		t.Fatalf("unexpected evidence failure for O-0003: %+v", gotFailures)
+	}
+	if got.ObservationReadIssues["O-9999"] != "observation not found" {
+		t.Fatalf("missing observation read issue = %q, want %q", got.ObservationReadIssues["O-9999"], "observation not found")
+	}
+	if _, ok := got.ObservationReadIssues["O-0001"]; ok {
+		t.Fatalf("read issue unexpectedly recorded for readable observation: %+v", got.ObservationReadIssues)
 	}
 }
 
@@ -138,5 +177,11 @@ func TestConclusionShowJSON_OmitsObservationArtifactsWhenNoObservations(t *testi
 	}
 	if _, ok := payload["observation_artifacts"]; ok {
 		t.Fatalf("unexpected observation_artifacts field: %+v", payload)
+	}
+	if _, ok := payload["observation_evidence_failures"]; ok {
+		t.Fatalf("unexpected observation_evidence_failures field: %+v", payload)
+	}
+	if _, ok := payload["observation_read_issues"]; ok {
+		t.Fatalf("unexpected observation_read_issues field: %+v", payload)
 	}
 }

--- a/internal/cli/event_payload_test.go
+++ b/internal/cli/event_payload_test.go
@@ -201,6 +201,7 @@ func TestEventPayload_InstrumentRegisterEmitsFieldMap(t *testing.T) {
 		"--unit", "bool",
 		"--min-samples", "1",
 		"--requires", "build=pass",
+		"--evidence", "mechanism=printf trace",
 	})
 	if err := root.Execute(); err != nil {
 		t.Fatalf("instrument register: %v", err)
@@ -217,14 +218,14 @@ func TestEventPayload_InstrumentRegisterEmitsFieldMap(t *testing.T) {
 	payload := decodePayload(t, e)
 
 	// Must have lowercase field-map keys (not capitalized struct field names).
-	wantKeys := []string{"cmd", "parser", "unit", "min_samples", "requires"}
+	wantKeys := []string{"cmd", "parser", "unit", "min_samples", "requires", "evidence"}
 	for _, k := range wantKeys {
 		if _, ok := payload[k]; !ok {
 			t.Errorf("payload missing key %q; got %v", k, payload)
 		}
 	}
 	// Must NOT carry the raw-struct shape (capitalized Go field names).
-	for _, k := range []string{"Cmd", "Parser", "Unit", "MinSamples", "Requires"} {
+	for _, k := range []string{"Cmd", "Parser", "Unit", "MinSamples", "Requires", "Evidence"} {
 		if _, ok := payload[k]; ok {
 			t.Errorf("payload leaked raw struct key %q", k)
 		}
@@ -242,5 +243,93 @@ func TestEventPayload_InstrumentRegisterEmitsFieldMap(t *testing.T) {
 	}
 	if len(reqs) != 1 || reqs[0] != "build=pass" {
 		t.Errorf("data.requires = %v, want [build=pass]", reqs)
+	}
+	evidence, ok := payload["evidence"].([]any)
+	if !ok {
+		t.Fatalf("data.evidence not a list: %T", payload["evidence"])
+	}
+	if len(evidence) != 1 {
+		t.Fatalf("data.evidence len = %d, want 1", len(evidence))
+	}
+	ev, ok := evidence[0].(map[string]any)
+	if !ok {
+		t.Fatalf("data.evidence[0] not an object: %T", evidence[0])
+	}
+	if ev["name"] != "mechanism" || ev["cmd"] != "printf trace" {
+		t.Fatalf("unexpected evidence payload: %+v", ev)
+	}
+	if _, ok := ev["Name"]; ok {
+		t.Fatalf("evidence payload leaked raw struct key Name: %+v", ev)
+	}
+}
+
+func TestEventPayload_ObservationRecordIncludesEvidenceFailures(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: t.TempDir()},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	registerScenarioTimingInstrument(t, dir, "broken=echo nope >&2; exit 7")
+	registerScenarioSupportInstruments(t, dir)
+	goal := runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-require", "host_test=pass",
+	)
+	if goal.ID == "" {
+		t.Fatal("goal id missing")
+	}
+
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "improve timing")
+	runCLI(t, dir, "observe", exp.ID, "--instrument", "timing")
+
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := findLastEvent(t, s, "observation.record")
+	if e == nil {
+		t.Fatal("observation.record event not found")
+	}
+	payload := decodePayload(t, e)
+	failures, ok := payload["evidence_failures"].([]any)
+	if !ok {
+		t.Fatalf("data.evidence_failures not a list: %T", payload["evidence_failures"])
+	}
+	if len(failures) != 1 {
+		t.Fatalf("data.evidence_failures len = %d, want 1", len(failures))
+	}
+	failure, ok := failures[0].(map[string]any)
+	if !ok {
+		t.Fatalf("data.evidence_failures[0] not an object: %T", failures[0])
+	}
+	if failure["name"] != "broken" {
+		t.Fatalf("failure name = %v, want broken", failure["name"])
+	}
+	if failure["exit_code"] != float64(7) {
+		t.Fatalf("failure exit_code = %v, want 7", failure["exit_code"])
 	}
 }

--- a/internal/cli/evidence_helpers.go
+++ b/internal/cli/evidence_helpers.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
 )
 
 func formatEvidenceFailure(f entity.EvidenceFailure) string {
@@ -13,4 +14,58 @@ func formatEvidenceFailure(f entity.EvidenceFailure) string {
 		return label + ": " + detail
 	}
 	return label
+}
+
+func buildConclusionShowJSON(s *store.Store, c *entity.Conclusion) conclusionShowJSON {
+	out := conclusionShowJSON{Conclusion: c}
+	joinConclusionObservationEvidence(&out, s, c.Observations)
+	return out
+}
+
+func joinConclusionObservationEvidence(out *conclusionShowJSON, s *store.Store, ids []string) {
+	capHint := len(ids)
+	for _, id := range ids {
+		obs, err := s.ReadObservation(id)
+		if err != nil {
+			ensureObservationReadIssues(out, capHint)[id] = err.Error()
+			continue
+		}
+		ensureObservationArtifacts(out, capHint)[id] = cloneArtifacts(obs.Artifacts)
+		if len(obs.EvidenceFailures) > 0 {
+			ensureObservationEvidenceFailures(out, capHint)[id] = cloneEvidenceFailures(obs.EvidenceFailures)
+		}
+	}
+}
+
+func ensureObservationArtifacts(out *conclusionShowJSON, capHint int) map[string][]entity.Artifact {
+	if out.ObservationArtifacts == nil {
+		out.ObservationArtifacts = make(map[string][]entity.Artifact, capHint)
+	}
+	return out.ObservationArtifacts
+}
+
+func ensureObservationEvidenceFailures(out *conclusionShowJSON, capHint int) map[string][]entity.EvidenceFailure {
+	if out.ObservationEvidenceFailures == nil {
+		out.ObservationEvidenceFailures = make(map[string][]entity.EvidenceFailure, capHint)
+	}
+	return out.ObservationEvidenceFailures
+}
+
+func ensureObservationReadIssues(out *conclusionShowJSON, capHint int) map[string]string {
+	if out.ObservationReadIssues == nil {
+		out.ObservationReadIssues = make(map[string]string, capHint)
+	}
+	return out.ObservationReadIssues
+}
+
+func cloneArtifacts(in []entity.Artifact) []entity.Artifact {
+	out := make([]entity.Artifact, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneEvidenceFailures(in []entity.EvidenceFailure) []entity.EvidenceFailure {
+	out := make([]entity.EvidenceFailure, len(in))
+	copy(out, in)
+	return out
 }

--- a/internal/cli/evidence_helpers.go
+++ b/internal/cli/evidence_helpers.go
@@ -9,7 +9,10 @@ import (
 )
 
 func formatEvidenceFailure(f entity.EvidenceFailure) string {
-	label := fmt.Sprintf("%s (exit %d)", f.Name, f.ExitCode)
+	label := f.Name
+	if f.ExitCode != 0 {
+		label = fmt.Sprintf("%s (exit %d)", f.Name, f.ExitCode)
+	}
 	if detail := strings.TrimSpace(f.Error); detail != "" {
 		return label + ": " + detail
 	}

--- a/internal/cli/evidence_helpers.go
+++ b/internal/cli/evidence_helpers.go
@@ -1,0 +1,16 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func formatEvidenceFailure(f entity.EvidenceFailure) string {
+	label := fmt.Sprintf("%s (exit %d)", f.Name, f.ExitCode)
+	if detail := strings.TrimSpace(f.Error); detail != "" {
+		return label + ": " + detail
+	}
+	return label
+}

--- a/internal/cli/evidence_helpers_test.go
+++ b/internal/cli/evidence_helpers_test.go
@@ -6,6 +6,11 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 )
 
+const (
+	testEvidenceName          = "mechanism"
+	testEvidenceSpawnTraceErr = `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`
+)
+
 func TestFormatEvidenceFailure(t *testing.T) {
 	tests := []struct {
 		name string
@@ -15,27 +20,27 @@ func TestFormatEvidenceFailure(t *testing.T) {
 		{
 			name: "exit only",
 			in: entity.EvidenceFailure{
-				Name:     "mechanism",
+				Name:     testEvidenceName,
 				ExitCode: 7,
 			},
-			want: "mechanism (exit 7)",
+			want: testEvidenceName + " (exit 7)",
 		},
 		{
 			name: "spawn error omits meaningless zero exit",
 			in: entity.EvidenceFailure{
-				Name:  "mechanism",
-				Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+				Name:  testEvidenceName,
+				Error: testEvidenceSpawnTraceErr,
 			},
-			want: `mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+			want: testEvidenceName + ": " + testEvidenceSpawnTraceErr,
 		},
 		{
 			name: "exit and error",
 			in: entity.EvidenceFailure{
-				Name:     "mechanism",
+				Name:     testEvidenceName,
 				ExitCode: 7,
 				Error:    "trace command failed",
 			},
-			want: "mechanism (exit 7): trace command failed",
+			want: testEvidenceName + " (exit 7): trace command failed",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/cli/evidence_helpers_test.go
+++ b/internal/cli/evidence_helpers_test.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestFormatEvidenceFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		in   entity.EvidenceFailure
+		want string
+	}{
+		{
+			name: "exit only",
+			in: entity.EvidenceFailure{
+				Name:     "mechanism",
+				ExitCode: 7,
+			},
+			want: "mechanism (exit 7)",
+		},
+		{
+			name: "spawn error omits meaningless zero exit",
+			in: entity.EvidenceFailure{
+				Name:  "mechanism",
+				Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+			},
+			want: `mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+		},
+		{
+			name: "exit and error",
+			in: entity.EvidenceFailure{
+				Name:     "mechanism",
+				ExitCode: 7,
+				Error:    "trace command failed",
+			},
+			want: "mechanism (exit 7): trace command failed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatEvidenceFailure(tt.in); got != tt.want {
+				t.Fatalf("formatEvidenceFailure(%+v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/instrument.go
+++ b/internal/cli/instrument.go
@@ -60,6 +60,13 @@ func instrumentListCmd() *cobra.Command {
 				if len(inst.Requires) > 0 {
 					extra += fmt.Sprintf("  requires=%s", strings.Join(inst.Requires, ","))
 				}
+				if len(inst.Evidence) > 0 {
+					names := make([]string, 0, len(inst.Evidence))
+					for _, ev := range inst.Evidence {
+						names = append(names, ev.Name)
+					}
+					extra += fmt.Sprintf("  evidence=%s", strings.Join(names, ","))
+				}
 				w.Textf("  %-16s  parser=%-18s  unit=%-12s%s\n", n, inst.Parser, unit, extra)
 			}
 			return nil
@@ -67,15 +74,59 @@ func instrumentListCmd() *cobra.Command {
 	}
 }
 
+func parseEvidenceSpecs(raw []string) ([]store.EvidenceSpec, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]store.EvidenceSpec, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+	for _, item := range raw {
+		item = strings.TrimSpace(item)
+		name, cmd, ok := strings.Cut(item, "=")
+		if !ok {
+			return nil, fmt.Errorf("invalid --evidence %q: want name=cmd", item)
+		}
+		name = strings.TrimSpace(name)
+		cmd = strings.TrimSpace(cmd)
+		if name == "" {
+			return nil, fmt.Errorf("invalid --evidence %q: name is required", item)
+		}
+		if cmd == "" {
+			return nil, fmt.Errorf("invalid --evidence %q: command is required", item)
+		}
+		if name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+			return nil, fmt.Errorf("invalid --evidence name %q: must not contain path separators", name)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate --evidence name %q", name)
+		}
+		seen[name] = struct{}{}
+		out = append(out, store.EvidenceSpec{Name: name, Cmd: cmd})
+	}
+	return out, nil
+}
+
+func evidenceEventData(specs []store.EvidenceSpec) []map[string]any {
+	out := make([]map[string]any, 0, len(specs))
+	for _, spec := range specs {
+		out = append(out, map[string]any{
+			"name": spec.Name,
+			"cmd":  spec.Cmd,
+		})
+	}
+	return out
+}
+
 func instrumentRegisterCmd() *cobra.Command {
 	var (
-		cmdStr     []string
-		parser     string
-		pattern    string
-		unit       string
-		requires   []string
-		minSamples int
-		author     string
+		cmdStr      []string
+		parser      string
+		pattern     string
+		unit        string
+		requires    []string
+		evidenceRaw []string
+		minSamples  int
+		author      string
 	)
 	c := &cobra.Command{
 		Use:   "register <name>",
@@ -84,6 +135,10 @@ func instrumentRegisterCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
 			name := args[0]
+			evidence, err := parseEvidenceSpecs(evidenceRaw)
+			if err != nil {
+				return err
+			}
 
 			s, err := openStoreLive()
 			if err != nil {
@@ -95,6 +150,7 @@ func instrumentRegisterCmd() *cobra.Command {
 				Pattern:    pattern,
 				Unit:       unit,
 				Requires:   requires,
+				Evidence:   evidence,
 				MinSamples: minSamples,
 			}
 			if err := dryRun(w, fmt.Sprintf("register instrument %q (unit=%s)", name, unit), map[string]any{"name": name, "instrument": inst}); err != nil {
@@ -117,6 +173,9 @@ func instrumentRegisterCmd() *cobra.Command {
 			if len(inst.Requires) > 0 {
 				eventData["requires"] = inst.Requires
 			}
+			if len(inst.Evidence) > 0 {
+				eventData["evidence"] = evidenceEventData(inst.Evidence)
+			}
 			if err := emitEvent(s, "instrument.register", author, name, eventData); err != nil {
 				return err
 			}
@@ -131,6 +190,7 @@ func instrumentRegisterCmd() *cobra.Command {
 	c.Flags().StringVar(&pattern, "pattern", "", "regex with exactly one capture group (required for builtin:scalar)")
 	c.Flags().StringVar(&unit, "unit", "", "unit of measurement (e.g. cycles, bytes, seconds, instructions)")
 	c.Flags().StringArrayVar(&requires, "requires", nil, "prerequisite as 'instrument=pass' (repeatable); observe will refuse to run this instrument until prerequisites have passing observations")
+	c.Flags().StringArrayVar(&evidenceRaw, "evidence", nil, "optional evidence side-artifact as 'name=cmd' (repeatable); runs via `sh -c` after the primary measurement and records non-fatal failures on the observation")
 	c.Flags().IntVar(&minSamples, "min-samples", 0, "minimum samples required (strict mode)")
 	addAuthorFlag(c, &author, "")
 	return c

--- a/internal/cli/instrument_test.go
+++ b/internal/cli/instrument_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -76,5 +77,99 @@ func TestInstrumentRegister_CmdRepeatableArgv(t *testing.T) {
 		if inst.Cmd[i] != w {
 			t.Errorf("Cmd[%d] = %q, want %q", i, inst.Cmd[i], w)
 		}
+	}
+}
+
+func TestInstrumentRegister_EvidenceStoredInOrder(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupGoalStore(t)
+
+	root := Root()
+	root.SetArgs([]string{
+		"-C", dir,
+		"instrument", "register", "timing_probe",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "echo cycles: 42",
+		"--parser", "builtin:scalar",
+		"--pattern", `cycles:\s*(\d+)`,
+		"--unit", "cycles",
+		"--evidence", "mechanism=printf candidate",
+		"--evidence", "summary=printf summary",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	cfg, err := s.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+	inst := cfg.Instruments["timing_probe"]
+	if got, want := len(inst.Evidence), 2; got != want {
+		t.Fatalf("Evidence len = %d, want %d", got, want)
+	}
+	if inst.Evidence[0].Name != "mechanism" || inst.Evidence[0].Cmd != "printf candidate" {
+		t.Fatalf("Evidence[0] = %+v", inst.Evidence[0])
+	}
+	if inst.Evidence[1].Name != "summary" || inst.Evidence[1].Cmd != "printf summary" {
+		t.Fatalf("Evidence[1] = %+v", inst.Evidence[1])
+	}
+}
+
+func TestInstrumentRegister_EvidenceValidation(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupGoalStore(t)
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "missing equals",
+			args: []string{"--evidence", "mechanism"},
+			want: "want name=cmd",
+		},
+		{
+			name: "missing name",
+			args: []string{"--evidence", "=printf trace"},
+			want: "name is required",
+		},
+		{
+			name: "missing command",
+			args: []string{"--evidence", "mechanism="},
+			want: "command is required",
+		},
+		{
+			name: "duplicate names",
+			args: []string{"--evidence", "mechanism=printf one", "--evidence", "mechanism=printf two"},
+			want: "duplicate --evidence name",
+		},
+		{
+			name: "path separator in name",
+			args: []string{"--evidence", "bad/name=printf trace"},
+			want: "must not contain path separators",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := Root()
+			root.SetArgs(append([]string{
+				"-C", dir,
+				"instrument", "register", "timing_probe",
+				"--cmd", "true",
+				"--parser", "builtin:passfail",
+				"--unit", "bool",
+			}, tc.args...))
+			err := root.Execute()
+			if err == nil {
+				t.Fatal("expected register to fail")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/store"
 )
 
@@ -48,6 +49,8 @@ type cliConclusionShowResponse struct {
 		Bytes int64  `json:"bytes"`
 		Mime  string `json:"mime,omitempty"`
 	} `json:"observation_artifacts,omitempty"`
+	ObservationEvidenceFailures map[string][]entity.EvidenceFailure `json:"observation_evidence_failures,omitempty"`
+	ObservationReadIssues       map[string]string                   `json:"observation_read_issues,omitempty"`
 }
 
 type cliExperimentListRow struct {
@@ -366,6 +369,12 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 	writeScenarioMetrics(t, impl2.Worktree, "95\n", "900\n")
 	gitCommitAll(t, impl2.Worktree, "small tweak")
 	obs2 := runCLIJSON[cliIDResponse](t, dir, "observe", exp2.ID, "--instrument", "timing")
+	concl2 := runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp2.ID,
+		"--verdict", "inconclusive",
+		"--baseline-experiment", baseline.ID,
+		"--observations", obs2.ID,
+	)
 
 	secondObs, err := s.ReadObservation(obs2.ID)
 	if err != nil {
@@ -376,6 +385,24 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 	}
 	if secondObs.EvidenceFailures[0].Name != "broken" || secondObs.EvidenceFailures[0].ExitCode != 7 {
 		t.Fatalf("unexpected evidence failure: %+v", secondObs.EvidenceFailures[0])
+	}
+	concl2Entity, err := s.ReadConclusion(concl2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	concl2Entity.Observations = append(concl2Entity.Observations, "O-9999")
+	if err := s.WriteConclusion(concl2Entity); err != nil {
+		t.Fatal(err)
+	}
+	show2 := runCLIJSON[cliConclusionShowResponse](t, dir, "conclusion", "show", concl2.ID)
+	if got, want := len(show2.ObservationEvidenceFailures[obs2.ID]), 1; got != want {
+		t.Fatalf("conclusion show evidence failures len = %d, want %d", got, want)
+	}
+	if got := show2.ObservationEvidenceFailures[obs2.ID][0]; got.Name != "broken" || got.ExitCode != 7 {
+		t.Fatalf("unexpected conclusion show evidence failure: %+v", got)
+	}
+	if got, want := show2.ObservationReadIssues["O-9999"], "observation not found"; got != want {
+		t.Fatalf("conclusion show read issue = %q, want %q", got, want)
 	}
 	e := findLastEvent(t, s, "observation.record")
 	if e == nil {

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -38,6 +38,18 @@ type cliAnalyzeResponse struct {
 	} `json:"rows"`
 }
 
+type cliConclusionShowResponse struct {
+	ID                   string   `json:"id"`
+	Observations         []string `json:"observations"`
+	ObservationArtifacts map[string][]struct {
+		Name  string `json:"name"`
+		SHA   string `json:"sha"`
+		Path  string `json:"path"`
+		Bytes int64  `json:"bytes"`
+		Mime  string `json:"mime,omitempty"`
+	} `json:"observation_artifacts,omitempty"`
+}
+
 type cliExperimentListRow struct {
 	ID               string `json:"id"`
 	Classification   string `json:"classification"`
@@ -244,9 +256,157 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 	}
 }
 
+func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	writeScenarioMechanism(t, dir, "baseline trace\n")
+	gitRun(t, dir, "add", "mechanism.txt")
+	gitRun(t, dir, "commit", "-m", "add mechanism trace")
+
+	registerScenarioTimingInstrument(t, dir, "mechanism=cat mechanism.txt")
+	registerScenarioSupportInstruments(t, dir)
+
+	goal := runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--success-threshold", "0.1",
+		"--on-success", "stop",
+		"--constraint-max", "binary_size=1000",
+		"--constraint-require", "host_test=pass",
+	)
+	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
+	writeScenarioMechanism(t, impl.Worktree, "candidate trace\n")
+	gitRun(t, impl.Worktree, "add", "timing.txt", "size.txt", "mechanism.txt")
+	gitRun(t, impl.Worktree, "commit", "-m", "improve timing")
+
+	obs := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	timingObsID := observeResultID(t, obs, "timing")
+	concl := runCLIJSON[cliIDResponse](t, dir,
+		"conclude", hyp.ID,
+		"--verdict", "supported",
+		"--baseline-experiment", baseline.ID,
+		"--observations", timingObsID,
+	)
+	show := runCLIJSON[cliConclusionShowResponse](t, dir, "conclusion", "show", concl.ID)
+	arts, ok := show.ObservationArtifacts[timingObsID]
+	if !ok {
+		t.Fatalf("observation_artifacts missing timing observation %s: %+v", timingObsID, show.ObservationArtifacts)
+	}
+	if got, want := len(arts), 2; got != want {
+		t.Fatalf("artifact count = %d, want %d", got, want)
+	}
+	foundEvidence := false
+	for _, art := range arts {
+		if art.Name == "evidence/mechanism" {
+			foundEvidence = true
+			if art.SHA == "" || art.Path == "" || art.Bytes == 0 {
+				t.Fatalf("evidence artifact metadata incomplete: %+v", art)
+			}
+		}
+	}
+	if !foundEvidence {
+		t.Fatalf("evidence artifact missing from conclusion show: %+v", arts)
+	}
+
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstObs, err := s.ReadObservation(timingObsID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(firstObs.EvidenceFailures); got != 0 {
+		t.Fatalf("first observation EvidenceFailures len = %d, want 0", got)
+	}
+
+	registerScenarioTimingInstrument(t, dir, "broken=echo nope >&2; exit 7")
+
+	hyp2 := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "a smaller tweak might still help",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.05",
+		"--kill-if", "tests fail",
+	)
+	exp2 := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp2.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing",
+	)
+	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp2.ID)
+	writeScenarioMetrics(t, impl2.Worktree, "95\n", "900\n")
+	gitCommitAll(t, impl2.Worktree, "small tweak")
+	obs2 := runCLIJSON[cliIDResponse](t, dir, "observe", exp2.ID, "--instrument", "timing")
+
+	secondObs, err := s.ReadObservation(obs2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(secondObs.EvidenceFailures), 1; got != want {
+		t.Fatalf("second observation EvidenceFailures len = %d, want %d", got, want)
+	}
+	if secondObs.EvidenceFailures[0].Name != "broken" || secondObs.EvidenceFailures[0].ExitCode != 7 {
+		t.Fatalf("unexpected evidence failure: %+v", secondObs.EvidenceFailures[0])
+	}
+	e := findLastEvent(t, s, "observation.record")
+	if e == nil {
+		t.Fatal("observation.record event not found")
+	}
+	payload := decodePayload(t, e)
+	failures, ok := payload["evidence_failures"].([]any)
+	if !ok || len(failures) != 1 {
+		t.Fatalf("event evidence_failures = %#v", payload["evidence_failures"])
+	}
+	failure, ok := failures[0].(map[string]any)
+	if !ok {
+		t.Fatalf("event evidence failure not object: %T", failures[0])
+	}
+	if failure["name"] != "broken" || failure["exit_code"] != float64(7) {
+		t.Fatalf("unexpected event evidence failure: %+v", failure)
+	}
+	if goal.ID == "" {
+		t.Fatal("goal id missing")
+	}
+}
+
 func registerScenarioInstruments(t *testing.T, dir string) {
 	t.Helper()
-	runCLI(t, dir,
+	registerScenarioTimingInstrument(t, dir)
+	registerScenarioSupportInstruments(t, dir)
+}
+
+func registerScenarioTimingInstrument(t *testing.T, dir string, evidence ...string) {
+	t.Helper()
+	args := []string{
 		"instrument", "register", "timing",
 		"--cmd", "sh",
 		"--cmd", "-c",
@@ -254,7 +414,15 @@ func registerScenarioInstruments(t *testing.T, dir string) {
 		"--parser", "builtin:scalar",
 		"--pattern", "([0-9]+)",
 		"--unit", "ns",
-	)
+	}
+	for _, ev := range evidence {
+		args = append(args, "--evidence", ev)
+	}
+	runCLI(t, dir, args...)
+}
+
+func registerScenarioSupportInstruments(t *testing.T, dir string) {
+	t.Helper()
 	runCLI(t, dir,
 		"instrument", "register", "binary_size",
 		"--cmd", "sh",
@@ -304,6 +472,13 @@ func writeScenarioMetrics(t *testing.T, dir, timing, size string) {
 	}
 	if err := os.WriteFile(filepath.Join(dir, "size.txt"), []byte(size), 0o644); err != nil {
 		t.Fatalf("write size.txt: %v", err)
+	}
+}
+
+func writeScenarioMechanism(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "mechanism.txt"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write mechanism.txt: %v", err)
 	}
 }
 

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/store"
 )
 
@@ -37,20 +36,6 @@ type cliAnalyzeResponse struct {
 			DeltaFrac float64 `json:"delta_frac"`
 		} `json:"comparison,omitempty"`
 	} `json:"rows"`
-}
-
-type cliConclusionShowResponse struct {
-	ID                   string   `json:"id"`
-	Observations         []string `json:"observations"`
-	ObservationArtifacts map[string][]struct {
-		Name  string `json:"name"`
-		SHA   string `json:"sha"`
-		Path  string `json:"path"`
-		Bytes int64  `json:"bytes"`
-		Mime  string `json:"mime,omitempty"`
-	} `json:"observation_artifacts,omitempty"`
-	ObservationEvidenceFailures map[string][]entity.EvidenceFailure `json:"observation_evidence_failures,omitempty"`
-	ObservationReadIssues       map[string]string                   `json:"observation_read_issues,omitempty"`
 }
 
 type cliExperimentListRow struct {
@@ -316,7 +301,7 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 		"--baseline-experiment", baseline.ID,
 		"--observations", timingObsID,
 	)
-	show := runCLIJSON[cliConclusionShowResponse](t, dir, "conclusion", "show", concl.ID)
+	show := runCLIJSON[conclusionShowJSON](t, dir, "conclusion", "show", concl.ID)
 	arts, ok := show.ObservationArtifacts[timingObsID]
 	if !ok {
 		t.Fatalf("observation_artifacts missing timing observation %s: %+v", timingObsID, show.ObservationArtifacts)
@@ -394,7 +379,7 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 	if err := s.WriteConclusion(concl2Entity); err != nil {
 		t.Fatal(err)
 	}
-	show2 := runCLIJSON[cliConclusionShowResponse](t, dir, "conclusion", "show", concl2.ID)
+	show2 := runCLIJSON[conclusionShowJSON](t, dir, "conclusion", "show", concl2.ID)
 	if got, want := len(show2.ObservationEvidenceFailures[obs2.ID]), 1; got != want {
 		t.Fatalf("conclusion show evidence failures len = %d, want %d", got, want)
 	}

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/firewall"
@@ -73,25 +74,26 @@ func runAndRecordObservation(
 		unit = inst.Unit
 	}
 	obs := &entity.Observation{
-		ID:          id,
-		Experiment:  exp.ID,
-		Instrument:  instName,
-		MeasuredAt:  result.FinishedAt.UTC(),
-		Value:       result.Value,
-		Unit:        unit,
-		Samples:     result.SamplesN,
-		PerSample:   result.PerSample,
-		CILow:       result.CILow,
-		CIHigh:      result.CIHigh,
-		CIMethod:    result.CIMethod,
-		Pass:        result.Pass,
-		Artifacts:   obsArts,
-		Command:     result.Command,
-		ExitCode:    result.ExitCode,
-		Worktree:    exp.Worktree,
-		BaselineSHA: exp.Baseline.SHA,
-		Author:      or(author, "agent:observer"),
-		Aux:         result.Aux,
+		ID:               id,
+		Experiment:       exp.ID,
+		Instrument:       instName,
+		MeasuredAt:       result.FinishedAt.UTC(),
+		Value:            result.Value,
+		Unit:             unit,
+		Samples:          result.SamplesN,
+		PerSample:        result.PerSample,
+		CILow:            result.CILow,
+		CIHigh:           result.CIHigh,
+		CIMethod:         result.CIMethod,
+		Pass:             result.Pass,
+		Artifacts:        obsArts,
+		EvidenceFailures: result.EvidenceFailures,
+		Command:          result.Command,
+		ExitCode:         result.ExitCode,
+		Worktree:         exp.Worktree,
+		BaselineSHA:      exp.Baseline.SHA,
+		Author:           or(author, "agent:observer"),
+		Aux:              result.Aux,
 	}
 	obs.Normalize()
 	if err := s.WriteObservation(obs); err != nil {
@@ -122,11 +124,29 @@ func runAndRecordObservation(
 	if result.ExitCode != 0 {
 		eventData["exit_code"] = result.ExitCode
 	}
+	if len(result.EvidenceFailures) > 0 {
+		eventData["evidence_failures"] = summarizeEvidenceFailures(result.EvidenceFailures)
+	}
 	if err := emitEvent(s, "observation.record", or(author, "agent:observer"), id, eventData); err != nil {
 		return nil, err
 	}
 
 	return obs, nil
+}
+
+func summarizeEvidenceFailures(failures []entity.EvidenceFailure) []map[string]any {
+	out := make([]map[string]any, 0, len(failures))
+	for _, f := range failures {
+		rec := map[string]any{
+			"name":      f.Name,
+			"exit_code": f.ExitCode,
+		}
+		if snippet := truncate(strings.TrimSpace(f.Error), 200); snippet != "" {
+			rec["error"] = snippet
+		}
+		out = append(out, rec)
+	}
+	return out
 }
 
 // observeAll runs all given instruments in dependency-safe order against an

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -225,6 +225,12 @@ func renderReportMarkdown(r *reportData) string {
 						fmt.Fprintf(&sb, "  pass=%v", *o.Pass)
 					}
 					sb.WriteString("\n")
+					if len(o.EvidenceFailures) > 0 {
+						sb.WriteString("    - Evidence failures:\n")
+						for _, failure := range o.EvidenceFailures {
+							fmt.Fprintf(&sb, "      - %s\n", formatEvidenceFailure(failure))
+						}
+					}
 				}
 			}
 			if design := strings.TrimSpace(entity.ExtractSection(e.Body, "Design notes")); design != "" {

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -61,3 +61,56 @@ func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderReportMarkdown_ShowsObservationEvidenceSpawnFailure(t *testing.T) {
+	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	report := &reportData{
+		Hypothesis: &entity.Hypothesis{
+			ID:        "H-0001",
+			Claim:     "tighten the hot loop",
+			Status:    entity.StatusOpen,
+			Author:    "agent:orchestrator",
+			CreatedAt: now,
+			Predicts: entity.Predicts{
+				Instrument: "timing",
+				Target:     "kernel",
+				Direction:  "decrease",
+				MinEffect:  0.1,
+			},
+			KillIf: []string{"tests fail"},
+		},
+		Experiments: []*experimentBlock{{
+			Experiment: &entity.Experiment{
+				ID:          "E-0001",
+				Status:      entity.ExpMeasured,
+				Instruments: []string{"timing"},
+				Author:      "agent:impl",
+				Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abcdef1234567890"},
+			},
+			Observations: []*entity.Observation{{
+				ID:         "O-0001",
+				Experiment: "E-0001",
+				Instrument: "timing",
+				Value:      80,
+				Unit:       "ns",
+				Samples:    1,
+				EvidenceFailures: []entity.EvidenceFailure{{
+					Name:  "mechanism",
+					Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+				}},
+			}},
+		}},
+	}
+
+	out := renderReportMarkdown(report)
+	for _, want := range []string{
+		"## Experiments",
+		"O-0001 `timing` = 80 ns",
+		"Evidence failures:",
+		`mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
+	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
+	report := &reportData{
+		Hypothesis: &entity.Hypothesis{
+			ID:        "H-0001",
+			Claim:     "tighten the hot loop",
+			Status:    entity.StatusOpen,
+			Author:    "agent:orchestrator",
+			CreatedAt: now,
+			Predicts: entity.Predicts{
+				Instrument: "timing",
+				Target:     "kernel",
+				Direction:  "decrease",
+				MinEffect:  0.1,
+			},
+			KillIf: []string{"tests fail"},
+		},
+		Experiments: []*experimentBlock{{
+			Experiment: &entity.Experiment{
+				ID:          "E-0001",
+				Status:      entity.ExpMeasured,
+				Instruments: []string{"timing"},
+				Author:      "agent:impl",
+				Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abcdef1234567890"},
+			},
+			Observations: []*entity.Observation{{
+				ID:         "O-0001",
+				Experiment: "E-0001",
+				Instrument: "timing",
+				Value:      80,
+				Unit:       "ns",
+				Samples:    1,
+				EvidenceFailures: []entity.EvidenceFailure{{
+					Name:     "mechanism",
+					ExitCode: 7,
+					Error:    "trace collection failed",
+				}},
+			}},
+		}},
+	}
+
+	out := renderReportMarkdown(report)
+	for _, want := range []string{
+		"## Experiments",
+		"O-0001 `timing` = 80 ns",
+		"Evidence failures:",
+		"mechanism (exit 7): trace collection failed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("report missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/cli/report_test.go
+++ b/internal/cli/report_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 )
 
-func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
+func testReportWithObservationEvidenceFailures(failures ...entity.EvidenceFailure) *reportData {
 	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
-	report := &reportData{
+	return &reportData{
 		Hypothesis: &entity.Hypothesis{
 			ID:        "H-0001",
 			Claim:     "tighten the hot loop",
@@ -34,27 +34,31 @@ func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
 				Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abcdef1234567890"},
 			},
 			Observations: []*entity.Observation{{
-				ID:         "O-0001",
-				Experiment: "E-0001",
-				Instrument: "timing",
-				Value:      80,
-				Unit:       "ns",
-				Samples:    1,
-				EvidenceFailures: []entity.EvidenceFailure{{
-					Name:     "mechanism",
-					ExitCode: 7,
-					Error:    "trace collection failed",
-				}},
+				ID:               "O-0001",
+				Experiment:       "E-0001",
+				Instrument:       "timing",
+				Value:            80,
+				Unit:             "ns",
+				Samples:          1,
+				EvidenceFailures: failures,
 			}},
 		}},
 	}
+}
+
+func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
+	report := testReportWithObservationEvidenceFailures(entity.EvidenceFailure{
+		Name:     testEvidenceName,
+		ExitCode: 7,
+		Error:    "trace collection failed",
+	})
 
 	out := renderReportMarkdown(report)
 	for _, want := range []string{
 		"## Experiments",
 		"O-0001 `timing` = 80 ns",
 		"Evidence failures:",
-		"mechanism (exit 7): trace collection failed",
+		testEvidenceName + " (exit 7): trace collection failed",
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("report missing %q:\n%s", want, out)
@@ -63,51 +67,17 @@ func TestRenderReportMarkdown_ShowsObservationEvidenceFailures(t *testing.T) {
 }
 
 func TestRenderReportMarkdown_ShowsObservationEvidenceSpawnFailure(t *testing.T) {
-	now := time.Date(2026, 4, 18, 10, 0, 0, 0, time.UTC)
-	report := &reportData{
-		Hypothesis: &entity.Hypothesis{
-			ID:        "H-0001",
-			Claim:     "tighten the hot loop",
-			Status:    entity.StatusOpen,
-			Author:    "agent:orchestrator",
-			CreatedAt: now,
-			Predicts: entity.Predicts{
-				Instrument: "timing",
-				Target:     "kernel",
-				Direction:  "decrease",
-				MinEffect:  0.1,
-			},
-			KillIf: []string{"tests fail"},
-		},
-		Experiments: []*experimentBlock{{
-			Experiment: &entity.Experiment{
-				ID:          "E-0001",
-				Status:      entity.ExpMeasured,
-				Instruments: []string{"timing"},
-				Author:      "agent:impl",
-				Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abcdef1234567890"},
-			},
-			Observations: []*entity.Observation{{
-				ID:         "O-0001",
-				Experiment: "E-0001",
-				Instrument: "timing",
-				Value:      80,
-				Unit:       "ns",
-				Samples:    1,
-				EvidenceFailures: []entity.EvidenceFailure{{
-					Name:  "mechanism",
-					Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
-				}},
-			}},
-		}},
-	}
+	report := testReportWithObservationEvidenceFailures(entity.EvidenceFailure{
+		Name:  testEvidenceName,
+		Error: testEvidenceSpawnTraceErr,
+	})
 
 	out := renderReportMarkdown(report)
 	for _, want := range []string{
 		"## Experiments",
 		"O-0001 `timing` = 80 ns",
 		"Evidence failures:",
-		`mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+		testEvidenceName + ": " + testEvidenceSpawnTraceErr,
 	} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("report missing %q:\n%s", want, out)

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -322,42 +322,30 @@ func TestTUI_ExperimentDetailShowsDeadClassification(t *testing.T) {
 }
 
 func TestTUI_ObservationDetail(t *testing.T) {
-	v := newObservationDetailView("O-0003")
 	pass := true
 	ciLow, ciHigh := 1.1, 1.3
-	o := &entity.Observation{
-		ID:         "O-0003",
-		Experiment: "E-0007",
-		Instrument: "host_timing",
-		MeasuredAt: time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC),
-		Value:      1.2,
-		Unit:       "s",
-		Samples:    5,
-		PerSample:  []float64{1.1, 1.2, 1.3},
-		CILow:      &ciLow,
-		CIHigh:     &ciHigh,
-		CIMethod:   "bca",
-		Pass:       &pass,
-		Artifacts: []entity.Artifact{{
-			Name: "primary", SHA: "abcdef1234567890", Path: "artifacts/ab/abcdef1234567890", Bytes: 2048,
-		}},
-		EvidenceFailures: []entity.EvidenceFailure{{
-			Name:     "mechanism",
-			ExitCode: 7,
-			Error:    "profile tool crashed",
-		}},
-		Command:     "make test",
-		ExitCode:    0,
-		Worktree:    "/tmp/wt",
-		BaselineSHA: "fedcba9876543210",
-		Author:      "agent:observer",
-		Aux:         map[string]any{"stdev": 0.04, "warm": true},
-	}
-	nv, _ := v.update(obsDetailLoadedMsg{o: o}, nil)
-	out := stripANSI(nv.view(120, 40))
+	o := testObservationDetailEntity()
+	o.Samples = 5
+	o.PerSample = []float64{1.1, 1.2, 1.3}
+	o.CILow = &ciLow
+	o.CIHigh = &ciHigh
+	o.CIMethod = "bca"
+	o.Pass = &pass
+	o.Artifacts = []entity.Artifact{{
+		Name: "primary", SHA: "abcdef1234567890", Path: "artifacts/ab/abcdef1234567890", Bytes: 2048,
+	}}
+	o.EvidenceFailures = []entity.EvidenceFailure{{
+		Name:     testEvidenceName,
+		ExitCode: 7,
+		Error:    "profile tool crashed",
+	}}
+	o.Worktree = "/tmp/wt"
+	o.BaselineSHA = "fedcba9876543210"
+	o.Aux = map[string]any{"stdev": 0.04, "warm": true}
+	out := renderObservationDetailForTest(o, 40)
 	for _, want := range []string{
 		"O-0003", "host_timing=1.2 s", "experiment=E-0007", "Artifacts (1):",
-		"Evidence failures:", "mechanism (exit 7): profile tool crashed",
+		"Evidence failures:", testEvidenceName + " (exit 7): profile tool crashed",
 		"make test", "stdev", "warm",
 	} {
 		if !strings.Contains(out, want) {
@@ -366,9 +354,8 @@ func TestTUI_ObservationDetail(t *testing.T) {
 	}
 }
 
-func TestTUI_ObservationDetailShowsEvidenceSpawnFailure(t *testing.T) {
-	v := newObservationDetailView("O-0003")
-	o := &entity.Observation{
+func testObservationDetailEntity() *entity.Observation {
+	return &entity.Observation{
 		ID:         "O-0003",
 		Experiment: "E-0007",
 		Instrument: "host_timing",
@@ -376,19 +363,28 @@ func TestTUI_ObservationDetailShowsEvidenceSpawnFailure(t *testing.T) {
 		Value:      1.2,
 		Unit:       "s",
 		Samples:    1,
-		EvidenceFailures: []entity.EvidenceFailure{{
-			Name:  "mechanism",
-			Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
-		}},
-		Command:  "make test",
-		ExitCode: 0,
-		Author:   "agent:observer",
+		Command:    "make test",
+		ExitCode:   0,
+		Author:     "agent:observer",
 	}
+}
+
+func renderObservationDetailForTest(o *entity.Observation, height int) string {
+	v := newObservationDetailView(o.ID)
 	nv, _ := v.update(obsDetailLoadedMsg{o: o}, nil)
-	out := stripANSI(nv.view(120, 20))
+	return stripANSI(nv.view(120, height))
+}
+
+func TestTUI_ObservationDetailShowsEvidenceSpawnFailure(t *testing.T) {
+	o := testObservationDetailEntity()
+	o.EvidenceFailures = []entity.EvidenceFailure{{
+		Name:  testEvidenceName,
+		Error: testEvidenceSpawnTraceErr,
+	}}
+	out := renderObservationDetailForTest(o, 20)
 	for _, want := range []string{
 		"Evidence failures:",
-		`mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+		testEvidenceName + ": " + testEvidenceSpawnTraceErr,
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("observation detail missing %q:\n%s", want, out)

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -341,6 +341,11 @@ func TestTUI_ObservationDetail(t *testing.T) {
 		Artifacts: []entity.Artifact{{
 			Name: "primary", SHA: "abcdef1234567890", Path: "artifacts/ab/abcdef1234567890", Bytes: 2048,
 		}},
+		EvidenceFailures: []entity.EvidenceFailure{{
+			Name:     "mechanism",
+			ExitCode: 7,
+			Error:    "profile tool crashed",
+		}},
 		Command:     "make test",
 		ExitCode:    0,
 		Worktree:    "/tmp/wt",
@@ -349,8 +354,12 @@ func TestTUI_ObservationDetail(t *testing.T) {
 		Aux:         map[string]any{"stdev": 0.04, "warm": true},
 	}
 	nv, _ := v.update(obsDetailLoadedMsg{o: o}, nil)
-	out := stripANSI(nv.view(120, 25))
-	for _, want := range []string{"O-0003", "host_timing=1.2 s", "experiment=E-0007", "Artifacts (1):", "make test", "stdev", "warm"} {
+	out := stripANSI(nv.view(120, 40))
+	for _, want := range []string{
+		"O-0003", "host_timing=1.2 s", "experiment=E-0007", "Artifacts (1):",
+		"Evidence failures:", "mechanism (exit 7): profile tool crashed",
+		"make test", "stdev", "warm",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("observation detail missing %q:\n%s", want, out)
 		}

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -366,6 +366,36 @@ func TestTUI_ObservationDetail(t *testing.T) {
 	}
 }
 
+func TestTUI_ObservationDetailShowsEvidenceSpawnFailure(t *testing.T) {
+	v := newObservationDetailView("O-0003")
+	o := &entity.Observation{
+		ID:         "O-0003",
+		Experiment: "E-0007",
+		Instrument: "host_timing",
+		MeasuredAt: time.Date(2026, 4, 12, 11, 0, 0, 0, time.UTC),
+		Value:      1.2,
+		Unit:       "s",
+		Samples:    1,
+		EvidenceFailures: []entity.EvidenceFailure{{
+			Name:  "mechanism",
+			Error: `spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+		}},
+		Command:  "make test",
+		ExitCode: 0,
+		Author:   "agent:observer",
+	}
+	nv, _ := v.update(obsDetailLoadedMsg{o: o}, nil)
+	out := stripANSI(nv.view(120, 20))
+	for _, want := range []string{
+		"Evidence failures:",
+		`mechanism: spawn "sh -c echo trace": exec: "sh": executable file not found in $PATH`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("observation detail missing %q:\n%s", want, out)
+		}
+	}
+}
+
 func TestTUI_ConclusionList(t *testing.T) {
 	v := newConclusionListView(goalScope{All: true})
 	cs := []*entity.Conclusion{

--- a/internal/cli/tui_view_observation.go
+++ b/internal/cli/tui_view_observation.go
@@ -108,6 +108,14 @@ func (v *observationDetailView) view(width, height int) string {
 		lines = append(lines, renderTable(rows, "  "))
 	}
 
+	if len(o.EvidenceFailures) > 0 {
+		lines = append(lines, "")
+		lines = append(lines, tuiBold.Render("Evidence failures:"))
+		for _, failure := range o.EvidenceFailures {
+			lines = append(lines, "  - "+formatEvidenceFailure(failure))
+		}
+	}
+
 	if len(o.PerSample) > 0 {
 		lines = append(lines, "")
 		lines = append(lines, tuiBold.Render("Per-sample:"))

--- a/internal/entity/observation.go
+++ b/internal/entity/observation.go
@@ -17,6 +17,12 @@ type Artifact struct {
 	Mime  string `json:"mime,omitempty"`
 }
 
+type EvidenceFailure struct {
+	Name     string `json:"name"`
+	ExitCode int    `json:"exit_code"`
+	Error    string `json:"error,omitempty"`
+}
+
 type Observation struct {
 	ID         string    `json:"id"`
 	Experiment string    `json:"experiment"`
@@ -31,7 +37,8 @@ type Observation struct {
 	CIMethod   string    `json:"ci_method,omitempty"`
 	Pass       *bool     `json:"pass,omitempty"`
 
-	Artifacts []Artifact `json:"artifacts"`
+	Artifacts        []Artifact        `json:"artifacts"`
+	EvidenceFailures []EvidenceFailure `json:"evidence_failures,omitempty"`
 
 	// Legacy convenience pointers to the primary (first) artifact. Kept in
 	// sync by Normalize; older observations without the Artifacts list are

--- a/internal/entity/observation_test.go
+++ b/internal/entity/observation_test.go
@@ -114,3 +114,57 @@ func TestObservationLegacyBackfill(t *testing.T) {
 		t.Errorf("backfilled artifact: %+v", o.Artifacts[0])
 	}
 }
+
+func TestObservationRoundTrip_PreservesEvidenceFailures(t *testing.T) {
+	ciLow := 95.0
+	ciHigh := 105.0
+	obs := &entity.Observation{
+		ID:         "O-0001",
+		Experiment: "E-0001",
+		Instrument: "timing",
+		MeasuredAt: time.Date(2026, 4, 18, 11, 0, 0, 0, time.UTC),
+		Value:      100,
+		Unit:       "cycles",
+		Samples:    3,
+		PerSample:  []float64{98, 100, 102},
+		CILow:      &ciLow,
+		CIHigh:     &ciHigh,
+		CIMethod:   "bootstrap_bca_95",
+		Artifacts: []entity.Artifact{{
+			Name:  "scalar",
+			SHA:   "abc123",
+			Path:  "artifacts/ab/c123/scalar.json",
+			Bytes: 42,
+			Mime:  "application/json",
+		}},
+		EvidenceFailures: []entity.EvidenceFailure{{
+			Name:     "mechanism",
+			ExitCode: 7,
+		}},
+		Command:     "echo cycles: 100",
+		ExitCode:    0,
+		Worktree:    "/tmp/worktree",
+		BaselineSHA: "deadbeef",
+		Author:      "agent:observer",
+	}
+	data, err := obs.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+	back, err := entity.ParseObservation(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(back.EvidenceFailures), 1; got != want {
+		t.Fatalf("EvidenceFailures len = %d, want %d", got, want)
+	}
+	if got := back.EvidenceFailures[0]; got.Name != "mechanism" || got.ExitCode != 7 {
+		t.Fatalf("evidence failure lost: %+v", got)
+	}
+	if got, want := len(back.Artifacts), 1; got != want {
+		t.Fatalf("Artifacts len = %d, want %d", got, want)
+	}
+	if back.RawArtifact != obs.Artifacts[0].Path || back.RawSHA != obs.Artifacts[0].SHA {
+		t.Fatalf("legacy artifact fields not normalized: raw_artifact=%q raw_sha=%q", back.RawArtifact, back.RawSHA)
+	}
+}

--- a/internal/instrument/runner.go
+++ b/internal/instrument/runner.go
@@ -3,26 +3,26 @@
 //
 // Four built-in parsers are supported:
 //
-//   builtin:passfail — run cmd once; value=1 if exit==0 else 0, unit="pass".
-//                      Used for host_compile, host_test, and similar binary
-//                      outcomes.
-//   builtin:timing   — run cmd N times; value=mean seconds, per_sample + BCa
-//                      95% bootstrap CI (via internal/stats).
-//   builtin:size     — run cmd once; first numeric column is the "text" size
-//                      in bytes; all header columns land in aux. Tolerant of
-//                      both GNU `size` (text/data/bss) and Mach-O
-//                      `size` (__TEXT/__DATA/...) output formats.
-//   builtin:scalar   — run cmd N times; extract a single integer from each
-//                      stdout using a user-declared regex (instrument.Pattern,
-//                      set via `--pattern` at `instrument register` time).
-//                      The regex MUST have exactly one capture group. Returns
-//                      per_sample + BCa 95% CI. The unit is whatever the user
-//                      declared when registering — cycles, instructions,
-//                      page_faults, bytes, whatever the command prints.
-//                      Intended for any tool whose output contains a single
-//                      scalar: qemu semihosting, perf stat, objdump line
-//                      counts, cachegrind, etc. Nothing in the parser knows
-//                      about any specific tool.
+//	builtin:passfail — run cmd once; value=1 if exit==0 else 0, unit="pass".
+//	                   Used for host_compile, host_test, and similar binary
+//	                   outcomes.
+//	builtin:timing   — run cmd N times; value=mean seconds, per_sample + BCa
+//	                   95% bootstrap CI (via internal/stats).
+//	builtin:size     — run cmd once; first numeric column is the "text" size
+//	                   in bytes; all header columns land in aux. Tolerant of
+//	                   both GNU `size` (text/data/bss) and Mach-O
+//	                   `size` (__TEXT/__DATA/...) output formats.
+//	builtin:scalar   — run cmd N times; extract a single integer from each
+//	                   stdout using a user-declared regex (instrument.Pattern,
+//	                   set via `--pattern` at `instrument register` time).
+//	                   The regex MUST have exactly one capture group. Returns
+//	                   per_sample + BCa 95% CI. The unit is whatever the user
+//	                   declared when registering — cycles, instructions,
+//	                   page_faults, bytes, whatever the command prints.
+//	                   Intended for any tool whose output contains a single
+//	                   scalar: qemu semihosting, perf stat, objdump line
+//	                   counts, cachegrind, etc. Nothing in the parser knows
+//	                   about any specific tool.
 package instrument
 
 import (
@@ -37,6 +37,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/stats"
 	"github.com/bytter/autoresearch/internal/store"
 )
@@ -60,7 +61,8 @@ type ArtifactContent struct {
 }
 
 type Result struct {
-	Artifacts []ArtifactContent
+	Artifacts        []ArtifactContent
+	EvidenceFailures []entity.EvidenceFailure
 
 	Command    string
 	ExitCode   int
@@ -82,18 +84,26 @@ func Run(ctx context.Context, cfg Config) (*Result, error) {
 	if len(cfg.Instrument.Cmd) == 0 {
 		return nil, errors.New("instrument has no cmd")
 	}
+	var (
+		res *Result
+		err error
+	)
 	switch cfg.Instrument.Parser {
 	case "builtin:passfail":
-		return runPassFail(ctx, cfg)
+		res, err = runPassFail(ctx, cfg)
 	case "builtin:timing":
-		return runTiming(ctx, cfg)
+		res, err = runTiming(ctx, cfg)
 	case "builtin:size":
-		return runSize(ctx, cfg)
+		res, err = runSize(ctx, cfg)
 	case "builtin:scalar":
-		return runScalar(ctx, cfg)
+		res, err = runScalar(ctx, cfg)
 	default:
 		return nil, fmt.Errorf("unknown parser %q (available: builtin:passfail, builtin:timing, builtin:size, builtin:scalar)", cfg.Instrument.Parser)
 	}
+	if err != nil {
+		return nil, err
+	}
+	return runEvidence(ctx, cfg, res)
 }
 
 type execOutcome struct {
@@ -135,6 +145,41 @@ func execOnce(ctx context.Context, cfg Config, argv []string) (*execOutcome, err
 	}, nil
 }
 
+func execShell(ctx context.Context, cfg Config, script string) (*execOutcome, error) {
+	return execOnce(ctx, cfg, []string{"sh", "-c", script})
+}
+
+func runEvidence(ctx context.Context, cfg Config, res *Result) (*Result, error) {
+	if len(cfg.Instrument.Evidence) == 0 {
+		return res, nil
+	}
+	for _, spec := range cfg.Instrument.Evidence {
+		o, err := execShell(ctx, cfg, spec.Cmd)
+		if err != nil {
+			res.EvidenceFailures = append(res.EvidenceFailures, entity.EvidenceFailure{
+				Name:  spec.Name,
+				Error: err.Error(),
+			})
+			continue
+		}
+		if o.ExitCode != 0 {
+			res.EvidenceFailures = append(res.EvidenceFailures, entity.EvidenceFailure{
+				Name:     spec.Name,
+				ExitCode: o.ExitCode,
+			})
+			continue
+		}
+		res.Artifacts = append(res.Artifacts, ArtifactContent{
+			Name:     "evidence/" + spec.Name,
+			Filename: spec.Name + ".txt",
+			Content:  o.Stdout,
+			Mime:     "text/plain",
+		})
+	}
+	res.FinishedAt = time.Now()
+	return res, nil
+}
+
 func runPassFail(ctx context.Context, cfg Config) (*Result, error) {
 	o, err := execOnce(ctx, cfg, cfg.Instrument.Cmd)
 	if err != nil {
@@ -149,15 +194,16 @@ func runPassFail(ctx context.Context, cfg Config) (*Result, error) {
 		Artifacts: []ArtifactContent{
 			{Name: "stdout", Filename: "stdout.txt", Content: o.Stdout, Mime: "text/plain"},
 		},
-		Command:    o.Command,
-		ExitCode:   o.ExitCode,
-		StartedAt:  o.Start,
-		FinishedAt: o.Start.Add(o.Elapsed),
-		Value:      val,
-		Unit:       "pass",
-		SamplesN:   1,
-		Pass:       &pass,
-		Aux:        map[string]any{"elapsed_s": o.Elapsed.Seconds()},
+		EvidenceFailures: nil,
+		Command:          o.Command,
+		ExitCode:         o.ExitCode,
+		StartedAt:        o.Start,
+		FinishedAt:       o.Start.Add(o.Elapsed),
+		Value:            val,
+		Unit:             "pass",
+		SamplesN:         1,
+		Pass:             &pass,
+		Aux:              map[string]any{"elapsed_s": o.Elapsed.Seconds()},
 	}, nil
 }
 
@@ -207,17 +253,18 @@ func runTiming(ctx context.Context, cfg Config) (*Result, error) {
 		Artifacts: []ArtifactContent{
 			{Name: "timing", Filename: "timing.json", Content: raw, Mime: "application/json"},
 		},
-		Command:    strings.Join(cfg.Instrument.Cmd, " "),
-		ExitCode:   0,
-		StartedAt:  started,
-		FinishedAt: finished,
-		Value:      mean,
-		Unit:       "seconds",
-		SamplesN:   samples,
-		PerSample:  per,
-		CILow:      &low,
-		CIHigh:     &high,
-		CIMethod:   "bootstrap_bca_95",
+		EvidenceFailures: nil,
+		Command:          strings.Join(cfg.Instrument.Cmd, " "),
+		ExitCode:         0,
+		StartedAt:        started,
+		FinishedAt:       finished,
+		Value:            mean,
+		Unit:             "seconds",
+		SamplesN:         samples,
+		PerSample:        per,
+		CILow:            &low,
+		CIHigh:           &high,
+		CIMethod:         "bootstrap_bca_95",
 	}, nil
 }
 
@@ -237,14 +284,15 @@ func runSize(ctx context.Context, cfg Config) (*Result, error) {
 		Artifacts: []ArtifactContent{
 			{Name: "size", Filename: "size.txt", Content: o.Stdout, Mime: "text/plain"},
 		},
-		Command:    o.Command,
-		ExitCode:   o.ExitCode,
-		StartedAt:  o.Start,
-		FinishedAt: o.Start.Add(o.Elapsed),
-		Value:      float64(text),
-		Unit:       "bytes",
-		SamplesN:   1,
-		Aux:        aux,
+		EvidenceFailures: nil,
+		Command:          o.Command,
+		ExitCode:         o.ExitCode,
+		StartedAt:        o.Start,
+		FinishedAt:       o.Start.Add(o.Elapsed),
+		Value:            float64(text),
+		Unit:             "bytes",
+		SamplesN:         1,
+		Aux:              aux,
 	}, nil
 }
 
@@ -321,17 +369,18 @@ func runScalar(ctx context.Context, cfg Config) (*Result, error) {
 		Artifacts: []ArtifactContent{
 			{Name: "scalar", Filename: "scalar.json", Content: raw, Mime: "application/json"},
 		},
-		Command:    strings.Join(cfg.Instrument.Cmd, " "),
-		ExitCode:   0,
-		StartedAt:  started,
-		FinishedAt: finished,
-		Value:      summary.Mean,
-		Unit:       unit,
-		SamplesN:   samples,
-		PerSample:  per,
-		CILow:      &summary.CILow,
-		CIHigh:     &summary.CIHigh,
-		CIMethod:   "bootstrap_bca_95",
+		EvidenceFailures: nil,
+		Command:          strings.Join(cfg.Instrument.Cmd, " "),
+		ExitCode:         0,
+		StartedAt:        started,
+		FinishedAt:       finished,
+		Value:            summary.Mean,
+		Unit:             unit,
+		SamplesN:         samples,
+		PerSample:        per,
+		CILow:            &summary.CILow,
+		CIHigh:           &summary.CIHigh,
+		CIMethod:         "bootstrap_bca_95",
 	}, nil
 }
 
@@ -388,4 +437,3 @@ func parseSize(out []byte) (int64, map[string]any, error) {
 	}
 	return text, aux, nil
 }
-

--- a/internal/instrument/runner_test.go
+++ b/internal/instrument/runner_test.go
@@ -3,6 +3,7 @@ package instrument_test
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -374,6 +375,54 @@ func TestEvidence_FailureNonFatal(t *testing.T) {
 	}
 	if got := r.EvidenceFailures[0]; got.Name != "broken" || got.ExitCode != 7 || got.Error != "" {
 		t.Fatalf("unexpected evidence failure: %+v", got)
+	}
+}
+
+func TestEvidence_SpawnFailureRecordsErrorWithoutExitCode(t *testing.T) {
+	dir := t.TempDir()
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Fatalf("look up sh: %v", err)
+	}
+	t.Setenv("PATH", "")
+
+	r, err := instrument.Run(context.Background(), instrument.Config{
+		ProjectDir:  dir,
+		WorktreeDir: dir,
+		Instrument: store.Instrument{
+			Cmd:     []string{shell, "-c", "echo cycles: 99"},
+			Parser:  "builtin:scalar",
+			Pattern: `cycles:\s*(\d+)`,
+			Unit:    "cycles",
+			Evidence: []store.EvidenceSpec{
+				{Name: "mechanism", Cmd: "echo trace"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Value != 99 {
+		t.Fatalf("primary value = %v, want 99", r.Value)
+	}
+	if got, want := len(r.EvidenceFailures), 1; got != want {
+		t.Fatalf("EvidenceFailures len = %d, want %d", got, want)
+	}
+	got := r.EvidenceFailures[0]
+	if got.Name != "mechanism" {
+		t.Fatalf("EvidenceFailures[0].Name = %q, want %q", got.Name, "mechanism")
+	}
+	if got.ExitCode != 0 {
+		t.Fatalf("EvidenceFailures[0].ExitCode = %d, want 0 for spawn failure", got.ExitCode)
+	}
+	if got.Error == "" {
+		t.Fatal("EvidenceFailures[0].Error is empty, want spawn failure detail")
+	}
+	if !strings.Contains(got.Error, `spawn "sh -c echo trace"`) {
+		t.Fatalf("EvidenceFailures[0].Error = %q, want spawn context", got.Error)
+	}
+	if _, ok := findArtifact(r.Artifacts, "evidence/mechanism"); ok {
+		t.Fatal("spawn-failed evidence should not produce an artifact")
 	}
 }
 

--- a/internal/instrument/runner_test.go
+++ b/internal/instrument/runner_test.go
@@ -2,6 +2,9 @@ package instrument_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/bytter/autoresearch/internal/instrument"
@@ -80,7 +83,7 @@ func TestSize_GNUFormat(t *testing.T) {
 		WorktreeDir: dir,
 		Name:        "size_flash",
 		Instrument: store.Instrument{
-			Cmd: []string{"sh", "-c", `printf '   text\tdata\t bss\t dec\t hex\tfilename\n  1024\t 256\t  64\t1344\t540\ta.out\n'`},
+			Cmd:    []string{"sh", "-c", `printf '   text\tdata\t bss\t dec\t hex\tfilename\n  1024\t 256\t  64\t1344\t540\ta.out\n'`},
 			Parser: "builtin:size",
 		},
 	})
@@ -101,7 +104,7 @@ func TestSize_MachOFormat(t *testing.T) {
 		ProjectDir:  dir,
 		WorktreeDir: dir,
 		Instrument: store.Instrument{
-			Cmd: []string{"sh", "-c", `printf '__TEXT\t__DATA\t__OBJC\tothers\tdec\thex\n4096\t0\t0\t1024\t5120\t1400\n'`},
+			Cmd:    []string{"sh", "-c", `printf '__TEXT\t__DATA\t__OBJC\tothers\tdec\thex\n4096\t0\t0\t1024\t5120\t1400\n'`},
 			Parser: "builtin:size",
 		},
 	})
@@ -280,4 +283,114 @@ func TestScalar_UnitHonored(t *testing.T) {
 	if r.Unit != "instructions" || r.Value != 42 {
 		t.Errorf("result: %+v", r)
 	}
+}
+
+func TestEvidence_ArtifactUsesShellContext(t *testing.T) {
+	dir := t.TempDir()
+	r, err := instrument.Run(context.Background(), instrument.Config{
+		ProjectDir:  dir,
+		WorktreeDir: dir,
+		Instrument: store.Instrument{
+			Cmd:     []string{"sh", "-c", "echo cycles: 42"},
+			Parser:  "builtin:scalar",
+			Pattern: `cycles:\s*(\d+)`,
+			Unit:    "cycles",
+			Evidence: []store.EvidenceSpec{{
+				Name: "mechanism",
+				Cmd:  `printf '%s|%s|%s' "$WORKTREE" "$PROJECT" "$(pwd)"`,
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(r.EvidenceFailures), 0; got != want {
+		t.Fatalf("EvidenceFailures len = %d, want %d", got, want)
+	}
+	ev := artifactByName(t, r.Artifacts, "evidence/mechanism")
+	if ev.Filename != "mechanism.txt" {
+		t.Fatalf("evidence filename = %q, want mechanism.txt", ev.Filename)
+	}
+	if ev.Mime != "text/plain" {
+		t.Fatalf("evidence mime = %q, want text/plain", ev.Mime)
+	}
+	parts := strings.Split(string(ev.Content), "|")
+	if got, want := len(parts), 3; got != want {
+		t.Fatalf("evidence content parts = %d, want %d (%q)", got, want, ev.Content)
+	}
+	if parts[0] != dir || parts[1] != dir {
+		t.Fatalf("WORKTREE/PROJECT not propagated: %q", ev.Content)
+	}
+	gotPWD, err := filepath.EvalSymlinks(parts[2])
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", parts[2], err)
+	}
+	wantPWD, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", dir, err)
+	}
+	if gotPWD != wantPWD {
+		t.Fatalf("pwd = %q, want %q (from %q)", gotPWD, wantPWD, ev.Content)
+	}
+}
+
+func TestEvidence_FailureNonFatal(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "evidence.txt")
+	if err := os.WriteFile(marker, []byte("trace=ok\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r, err := instrument.Run(context.Background(), instrument.Config{
+		ProjectDir:  dir,
+		WorktreeDir: dir,
+		Instrument: store.Instrument{
+			Cmd:     []string{"sh", "-c", "echo cycles: 99"},
+			Parser:  "builtin:scalar",
+			Pattern: `cycles:\s*(\d+)`,
+			Unit:    "cycles",
+			Evidence: []store.EvidenceSpec{
+				{Name: "mechanism", Cmd: "cat evidence.txt"},
+				{Name: "broken", Cmd: "echo nope >&2; exit 7"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Value != 99 {
+		t.Fatalf("primary value = %v, want 99", r.Value)
+	}
+	if _, ok := findArtifact(r.Artifacts, "scalar"); !ok {
+		t.Fatal("primary scalar artifact missing")
+	}
+	if _, ok := findArtifact(r.Artifacts, "evidence/mechanism"); !ok {
+		t.Fatal("successful evidence artifact missing")
+	}
+	if _, ok := findArtifact(r.Artifacts, "evidence/broken"); ok {
+		t.Fatal("failed evidence should not produce an artifact")
+	}
+	if got, want := len(r.EvidenceFailures), 1; got != want {
+		t.Fatalf("EvidenceFailures len = %d, want %d", got, want)
+	}
+	if got := r.EvidenceFailures[0]; got.Name != "broken" || got.ExitCode != 7 || got.Error != "" {
+		t.Fatalf("unexpected evidence failure: %+v", got)
+	}
+}
+
+func artifactByName(t *testing.T, arts []instrument.ArtifactContent, name string) instrument.ArtifactContent {
+	t.Helper()
+	if art, ok := findArtifact(arts, name); ok {
+		return art
+	}
+	t.Fatalf("artifact %q not found in %+v", name, arts)
+	return instrument.ArtifactContent{}
+}
+
+func findArtifact(arts []instrument.ArtifactContent, name string) (instrument.ArtifactContent, bool) {
+	for _, art := range arts {
+		if art.Name == name {
+			return art, true
+		}
+	}
+	return instrument.ArtifactContent{}, false
 }

--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -26,7 +26,9 @@ positives, which are far more expensive than false negatives.
 2. `autoresearch conclusion show <C-id> --json` — the verdict, effect
    (vs absolute baseline), `incremental_effect` (vs frontier best, if
    present), `strict_check` (firewall's own assessment), interpretation,
-   author, and `observation_artifacts` for every cited observation.
+   author, plus evidence-side join fields for cited observations:
+   `observation_artifacts`, `observation_evidence_failures`, and
+   `observation_read_issues`.
 3. `autoresearch hypothesis show <hyp-id> --json` — the claim, predicted
    instrument, `min_effect`, `kill_if` clauses.
 4. Recompute the stats yourself:
@@ -52,15 +54,20 @@ the needed flag is genuinely absent from those references.
 
 6. **Verify mechanism claims against evidence artifacts** — the
    conclusion JSON carries `observation_artifacts`, keyed by observation
-   id. Evidence side-artifacts are named `evidence/<name>`. For every
-   mechanism claim in the interpretation, either confirm it is directly
-   visible in the diff or inspect the cited evidence artifact:
+   id. Evidence side-artifacts are named `evidence/<name>`. Use
+   `observation_evidence_failures` to distinguish "evidence capture was
+   configured but failed" from "no evidence was configured", and treat
+   any `observation_read_issues` entry as a broken persisted evidence
+   chain that must be investigated rather than silently ignored. For
+   every mechanism claim in the interpretation, either confirm it is
+   directly visible in the diff or inspect the cited evidence artifact:
 
        autoresearch artifact head <sha> --lines 100
        autoresearch artifact grep <sha> '<pattern>'
 
    Downgrade when a mechanism claim is supported by neither the diff nor
-   an evidence artifact.
+   an evidence artifact. A read issue or capture failure is not positive
+   evidence, and neither should be read as "no evidence was needed".
 
 7. **Review the code change for correctness and gaming** — this is as
    important as the statistics:

--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -26,7 +26,7 @@ positives, which are far more expensive than false negatives.
 2. `autoresearch conclusion show <C-id> --json` — the verdict, effect
    (vs absolute baseline), `incremental_effect` (vs frontier best, if
    present), `strict_check` (firewall's own assessment), interpretation,
-   author.
+   author, and `observation_artifacts` for every cited observation.
 3. `autoresearch hypothesis show <hyp-id> --json` — the claim, predicted
    instrument, `min_effect`, `kill_if` clauses.
 4. Recompute the stats yourself:
@@ -50,7 +50,19 @@ verbs. This brief plus `.claude/autoresearch.md` already covers
 and `conclusion accept` / `conclusion downgrade`. Use `--help` only if
 the needed flag is genuinely absent from those references.
 
-6. **Review the code change for correctness and gaming** — this is as
+6. **Verify mechanism claims against evidence artifacts** — the
+   conclusion JSON carries `observation_artifacts`, keyed by observation
+   id. Evidence side-artifacts are named `evidence/<name>`. For every
+   mechanism claim in the interpretation, either confirm it is directly
+   visible in the diff or inspect the cited evidence artifact:
+
+       autoresearch artifact head <sha> --lines 100
+       autoresearch artifact grep <sha> '<pattern>'
+
+   Downgrade when a mechanism claim is supported by neither the diff nor
+   an evidence artifact.
+
+7. **Review the code change for correctness and gaming** — this is as
    important as the statistics:
 
        git show autoresearch/<candidate-exp-id>
@@ -119,6 +131,10 @@ a reason. Good reasons:
 - **Mechanism mismatch**: "Interpretation claims loop unrolling, but
   the diff (git show autoresearch/E-NNNN) shows the inner loop is
   unchanged — the actual change was a deleted debug branch."
+- **Unsupported mechanism**: "Interpretation claims SIMPLIFY_TRACE
+  collapsed 14 redundant expressions, but no evidence artifact was
+  captured and the diff only shows constant folding. The mechanism is
+  unverifiable from persisted state."
 - **Inconclusive called refuted**: "kill_if clause 'flash grew > 64K'
   cited, but binary_size observation O-NNNN shows 61440 bytes — below
   the threshold. CI straddles zero; this is inconclusive, not refuted."

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -236,6 +236,22 @@ autoresearch experiment design <hyp-id> \
 3. Does it move the predicted instrument? → the hypothesis's instrument
 4. Does it violate constraints? → every constraint instrument from the goal
 
+If a mechanism claim will depend on qualitative analysis that is not
+already visible in the diff — a disassembly, subpass table, counter
+dump, intermediate-state summary — capture it as an evidence
+side-artifact on the instrument that owns the primary measurement:
+
+```sh
+autoresearch instrument register <name> \
+    ...existing flags... \
+    --evidence mechanism='profile-expr --json'
+```
+
+Evidence commands run after the primary measurement and persist combined
+stdout+stderr as `evidence/<name>` artifacts on the resulting
+observation. Use them to ground mechanism claims; do not write
+mechanism prose that depends on an uncaptured analysis.
+
 ### 3. Implement
 
 Create the worktree from the main project, then spawn a coder helper:
@@ -362,8 +378,16 @@ configure rescuers — the goal does.
 
 - Cite specific numbers from the analyze output.
 - Link the mechanism (the code change) to the measurement (the effect).
+- Every mechanism claim must be backed by either the diff itself or a
+  persisted evidence artifact on one of the cited observations. Name
+  the supporting observation / artifact when the diff alone is not
+  enough.
 - Acknowledge any constraint at risk.
 - Do NOT speculate about unmeasured causes — that's a new hypothesis.
+
+If the mechanism you want to describe is supported by neither the diff
+nor an evidence artifact, stop and surface a measurement-contract gap
+instead of writing the unsupported claim into the conclusion.
 
 ### 6. Record a lesson (required on decisive conclusions)
 

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -285,10 +285,16 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 
 Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provisional until gate review resolves them via ` + "`conclusion accept`" + ` or ` + "`conclusion downgrade`" + `. If a delegated one-cycle ` + "`research-orchestrator`" + ` returns a decisive conclusion, the parent/main session owns the next handoff: dispatch ` + "`research-gate-reviewer`" + ` from the parent, do not nest another orchestrator, and do not start another cycle while the chain is still ` + "`unreviewed`" + `. If you cannot dispatch a reviewer, stop after writing the conclusion and yield to the human/main session.
 
-In ` + "`--json`" + ` mode, ` + "`conclusion show`" + ` returns the conclusion plus an
-additive ` + "`observation_artifacts`" + ` map keyed by cited observation id. The values
-are artifact metadata only (` + "`name`" + ` / ` + "`sha`" + ` / ` + "`path`" + ` / ` + "`bytes`" + ` / ` + "`mime`" + `),
-never artifact content.
+In ` + "`--json`" + ` mode, ` + "`conclusion show`" + ` returns the conclusion plus three
+additive maps keyed by cited observation id:
+
+- ` + "`observation_artifacts`" + ` — artifact metadata only (` + "`name`" + ` / ` + "`sha`" + ` / ` + "`path`" + ` / ` + "`bytes`" + ` / ` + "`mime`" + `), never artifact content
+- ` + "`observation_evidence_failures`" + ` — non-fatal evidence-capture failures persisted on readable observations
+- ` + "`observation_read_issues`" + ` — cited observations that could not be read (for example missing or corrupt persisted evidence)
+
+Do not treat ` + "`observation_evidence_failures`" + ` or ` + "`observation_read_issues`" + ` as
+equivalent to "no evidence configured". They mean the evidence chain is
+incomplete and should be reviewed explicitly.
 
 ### Artifact navigation (bounded by default)
     autoresearch artifact list   [--goal G-NNNN|all] [--experiment E-XXXX | --observation O-XXXX]

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -285,6 +285,11 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 
 Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provisional until gate review resolves them via ` + "`conclusion accept`" + ` or ` + "`conclusion downgrade`" + `. If a delegated one-cycle ` + "`research-orchestrator`" + ` returns a decisive conclusion, the parent/main session owns the next handoff: dispatch ` + "`research-gate-reviewer`" + ` from the parent, do not nest another orchestrator, and do not start another cycle while the chain is still ` + "`unreviewed`" + `. If you cannot dispatch a reviewer, stop after writing the conclusion and yield to the human/main session.
 
+In ` + "`--json`" + ` mode, ` + "`conclusion show`" + ` returns the conclusion plus an
+additive ` + "`observation_artifacts`" + ` map keyed by cited observation id. The values
+are artifact metadata only (` + "`name`" + ` / ` + "`sha`" + ` / ` + "`path`" + ` / ` + "`bytes`" + ` / ` + "`mime`" + `),
+never artifact content.
+
 ### Artifact navigation (bounded by default)
     autoresearch artifact list   [--goal G-NNNN|all] [--experiment E-XXXX | --observation O-XXXX]
     autoresearch artifact stat   <sha-or-prefix>
@@ -301,7 +306,7 @@ Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provision
         --cmd a --cmd b --cmd c \                      # repeat --cmd once per argv element; commas in a value are preserved
         --parser builtin:{passfail|timing|size|scalar} \
         [--pattern 'regex with one capture group']  # required for builtin:scalar
-        --unit U [--requires inst=pass,...] [--min-samples N]
+        --unit U [--requires inst=pass,...] [--evidence name=cmd] [--min-samples N]
     autoresearch instrument list
     autoresearch instrument delete <name> [--reason "..."] [--force]
         # delete refuses while the instrument is referenced by the active
@@ -357,6 +362,13 @@ Examples of ` + "`builtin:scalar`" + ` instruments (the name is your choice):
 The parser requires an integer. If your tool emits a fractional number,
 scale it (as in the ccn example). If your tool emits multiple metrics,
 register multiple instruments with different patterns.
+
+Use ` + "`--evidence name=cmd`" + ` when a later mechanism claim depends on a
+qualitative readout that is not itself the primary measurement — for
+example a disassembly, subpass dump, or intermediate-state table. The
+CLI runs evidence commands after the primary measurement via ` + "`sh -c`" + `,
+captures combined stdout+stderr as an ` + "`evidence/<name>`" + ` artifact on the
+observation, and records non-fatal failures in ` + "`observation.evidence_failures`" + `.
 
 ## Strict-mode firewall
 

--- a/internal/integration/evidence_contract_test.go
+++ b/internal/integration/evidence_contract_test.go
@@ -1,0 +1,78 @@
+package integration_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/integration"
+)
+
+func TestSharedDocs_EvidenceArtifactGuidance(t *testing.T) {
+	claudeDoc := integration.ClaudeDoc("vtest")
+	codexDoc := integration.CodexDoc("vtest")
+
+	for name, doc := range map[string]string{
+		"claude": claudeDoc,
+		"codex":  codexDoc,
+	} {
+		for _, needle := range []string{
+			"--evidence name=cmd",
+			"observation_artifacts",
+			"evidence/<name>",
+			"observation.evidence_failures",
+		} {
+			if !strings.Contains(doc, needle) {
+				t.Fatalf("%s doc missing evidence-artifact guidance %q", name, needle)
+			}
+		}
+	}
+}
+
+func TestEmbeddedAgents_EvidenceArtifactContract(t *testing.T) {
+	agents, err := integration.EmbeddedAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexAgents, err := integration.EmbeddedCodexAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []struct {
+		label  string
+		agents []integration.AgentFile
+	}{
+		{label: "claude", agents: agents},
+		{label: "codex", agents: codexAgents},
+	}
+	for _, chk := range checks {
+		byName := map[string][]byte{}
+		for _, a := range chk.agents {
+			byName[a.Name] = a.Content
+		}
+		for role, needles := range map[string][]string{
+			"research-orchestrator": {
+				"--evidence mechanism='profile-expr --json'",
+				"evidence/<name>",
+				"measurement-contract gap",
+			},
+			"research-gate-reviewer": {
+				"observation_artifacts",
+				"supported by neither the diff nor",
+				"an evidence artifact.",
+				"Unsupported mechanism",
+			},
+		} {
+			content, ok := byName[role]
+			if !ok {
+				t.Fatalf("%s %s agent missing", chk.label, role)
+			}
+			for _, needle := range needles {
+				if !bytes.Contains(content, []byte(needle)) {
+					t.Fatalf("%s %s agent missing %q", chk.label, role, needle)
+				}
+			}
+		}
+	}
+}

--- a/internal/integration/evidence_contract_test.go
+++ b/internal/integration/evidence_contract_test.go
@@ -19,6 +19,8 @@ func TestSharedDocs_EvidenceArtifactGuidance(t *testing.T) {
 		for _, needle := range []string{
 			"--evidence name=cmd",
 			"observation_artifacts",
+			"observation_evidence_failures",
+			"observation_read_issues",
 			"evidence/<name>",
 			"observation.evidence_failures",
 		} {
@@ -59,6 +61,8 @@ func TestEmbeddedAgents_EvidenceArtifactContract(t *testing.T) {
 			},
 			"research-gate-reviewer": {
 				"observation_artifacts",
+				"observation_evidence_failures",
+				"observation_read_issues",
 				"supported by neither the diff nor",
 				"an evidence artifact.",
 				"Unsupported mechanism",

--- a/internal/store/config.go
+++ b/internal/store/config.go
@@ -31,20 +31,26 @@ type CommandSpec struct {
 	WorkDir string `yaml:"workdir,omitempty"`
 }
 
+type EvidenceSpec struct {
+	Name string `yaml:"name"`
+	Cmd  string `yaml:"cmd"`
+}
+
 type Instrument struct {
-	Cmd        []string `yaml:"cmd"`
-	Parser     string   `yaml:"parser"`
+	Cmd    []string `yaml:"cmd"`
+	Parser string   `yaml:"parser"`
 	// Pattern is the extraction regex used by parsers that pull a scalar out
 	// of command stdout (currently builtin:scalar). It MUST contain exactly
 	// one capture group producing a base-10 integer. Ignored by other parsers.
-	Pattern    string   `yaml:"pattern,omitempty"`
-	Unit       string   `yaml:"unit"`
-	MinSamples int      `yaml:"min_samples,omitempty"`
+	Pattern    string `yaml:"pattern,omitempty"`
+	Unit       string `yaml:"unit"`
+	MinSamples int    `yaml:"min_samples,omitempty"`
 	// Requires lists instrument prerequisites as "instrument=condition" pairs.
 	// Before running this instrument, the observe command checks that each
 	// prerequisite has a passing observation on the same experiment.
 	// v1 condition: "pass" — the prerequisite must have pass=true.
-	Requires   []string `yaml:"requires,omitempty"`
+	Requires []string       `yaml:"requires,omitempty"`
+	Evidence []EvidenceSpec `yaml:"evidence,omitempty"`
 }
 
 type Budgets struct {
@@ -76,7 +82,17 @@ func (s *Store) Config() (*Config, error) {
 	if cached.Instruments != nil {
 		out.Instruments = make(map[string]Instrument, len(cached.Instruments))
 		for k, v := range cached.Instruments {
-			out.Instruments[k] = v
+			inst := v
+			if len(v.Cmd) > 0 {
+				inst.Cmd = append([]string(nil), v.Cmd...)
+			}
+			if len(v.Requires) > 0 {
+				inst.Requires = append([]string(nil), v.Requires...)
+			}
+			if len(v.Evidence) > 0 {
+				inst.Evidence = append([]EvidenceSpec(nil), v.Evidence...)
+			}
+			out.Instruments[k] = inst
 		}
 	}
 	return &out, nil


### PR DESCRIPTION
## Summary
- add ordered `--evidence name=cmd` instrument side-artifacts and persist non-fatal `evidence_failures` on observations and `observation.record` events
- extend `conclusion show --json` with additive `observation_artifacts` metadata so reviewers can audit cited observations without re-running analysis
- update orchestrator/reviewer docs and add focused plus lifecycle scenario coverage for the full evidence-artifact chain

## Testing
- make test

Closes #31