### PR TITLE
Fix stale TUI timing on quiet refresh ticks

### DIFF
--- a/internal/cli/tui_app.go
+++ b/internal/cli/tui_app.go
@@ -16,9 +16,10 @@ import (
 // ---- messages ----
 
 // tuiTickMsg is internal to the root update loop: it schedules a poll of
-// the event log and reschedules itself. Views no longer observe ticks
+// the event log and reschedules itself. Views no longer observe raw ticks
 // directly — they react to storeChangedMsg when the poll surfaces new
-// events that actually changed something in .research/.
+// events, and time-sensitive views can opt into quiet-tick repaints via
+// tuiQuietTickView below.
 type tuiTickMsg time.Time
 type tuiErrMsg struct{ err error }
 
@@ -26,11 +27,13 @@ type tuiErrMsg struct{ err error }
 // sees new events in events.jsonl. Views decide whether to reload based
 // on what changed — most list and aggregate views just reload on any
 // change; detail views can narrow to events with a matching subject.
-// Quiet ticks produce no storeChangedMsg at all, so scroll and cursor
-// state are preserved whenever .research/ hasn't changed.
+// Quiet polls still emit storeChangedMsg with an empty events slice so the
+// root can advance the offset and offer an opt-in repaint hook for views
+// with elapsed/age fields. Non-opted-in views still see nothing.
 type storeChangedMsg struct {
-	events []store.Event
-	newOff int64
+	events   []store.Event
+	newOff   int64
+	polledAt time.Time
 }
 
 // eventOffsetPrimedMsg carries the initial byte offset into events.jsonl
@@ -81,6 +84,14 @@ type tuiView interface {
 	update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd)
 	view(width, height int) string
 	hints() []tuiHint
+}
+
+// tuiQuietTickView is an opt-in repaint hook for views whose output includes
+// time-derived values like elapsed or "in flight". Implementations must update
+// only render-time state; they must not reload store data or reset cursor /
+// pager state on quiet polls.
+type tuiQuietTickView interface {
+	quietTick(at time.Time, s *store.Store) (tuiView, tea.Cmd)
 }
 
 // ---- root model ----
@@ -151,19 +162,20 @@ func primeEventOffset(s *store.Store) tea.Cmd {
 // pollEvents reads any events appended to events.jsonl since offset and
 // returns them as a storeChangedMsg. Quiet polls (no new events) still
 // emit a storeChangedMsg with an empty slice so the root handler can
-// advance its offset, but the root filters empty batches out before
-// dispatching to the top view — so views that haven't hooked into the
-// refresh cycle see nothing, and their scroll/cursor state is preserved.
+// advance its offset. The root only forwards those quiet polls to
+// tuiQuietTickView implementations, so views without time-derived content
+// still avoid reload churn and preserve scroll/cursor state.
 func pollEvents(s *store.Store, offset int64) tea.Cmd {
 	if s == nil {
 		return nil
 	}
 	return func() tea.Msg {
+		polledAt := time.Now().UTC()
 		events, newOff, err := s.EventsSince(offset)
 		if err != nil {
-			return storeChangedMsg{newOff: offset}
+			return storeChangedMsg{newOff: offset, polledAt: polledAt}
 		}
-		return storeChangedMsg{events: events, newOff: newOff}
+		return storeChangedMsg{events: events, newOff: newOff, polledAt: polledAt}
 	}
 }
 
@@ -291,9 +303,14 @@ func (m tuiModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case storeChangedMsg:
 		m.eventOffset = msg.newOff
 		if len(msg.events) == 0 {
-			// Quiet poll — no changes to react to, no view churn, no
-			// chrome reload. Cursor and pager scroll stay where the
-			// user left them.
+			// Quiet poll — by default there's no reload and no chrome
+			// refresh. Views that render elapsed/age fields can opt into
+			// a repaint that preserves cursor and pager state.
+			if top, ok := m.top().(tuiQuietTickView); ok {
+				nv, cmd := top.quietTick(msg.polledAt, m.store)
+				m.setTop(nv)
+				return m, cmd
+			}
 			return m, nil
 		}
 		// Drop cache entries for any subjects these events mention, so

--- a/internal/cli/tui_refresh_test.go
+++ b/internal/cli/tui_refresh_test.go
@@ -10,6 +10,32 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+type staticTUIView struct{}
+
+func (v *staticTUIView) title() string                                       { return "static" }
+func (v *staticTUIView) kind() string                                        { return "test.static" }
+func (v *staticTUIView) init(_ *store.Store) tea.Cmd                         { return nil }
+func (v *staticTUIView) update(_ tea.Msg, _ *store.Store) (tuiView, tea.Cmd) { return v, nil }
+func (v *staticTUIView) view(_, _ int) string                                { return "" }
+func (v *staticTUIView) hints() []tuiHint                                    { return nil }
+
+type quietTickTestView struct {
+	ticks  int
+	lastAt time.Time
+}
+
+func (v *quietTickTestView) title() string                                       { return "tick" }
+func (v *quietTickTestView) kind() string                                        { return "test.tick" }
+func (v *quietTickTestView) init(_ *store.Store) tea.Cmd                         { return nil }
+func (v *quietTickTestView) update(_ tea.Msg, _ *store.Store) (tuiView, tea.Cmd) { return v, nil }
+func (v *quietTickTestView) view(_, _ int) string                                { return "" }
+func (v *quietTickTestView) hints() []tuiHint                                    { return nil }
+func (v *quietTickTestView) quietTick(at time.Time, _ *store.Store) (tuiView, tea.Cmd) {
+	v.ticks++
+	v.lastAt = at
+	return v, nil
+}
+
 // TestTUI_LessonDetail_PreservesScrollAcrossReloads is the regression anchor
 // for issue #25. Before the fix, every refresh tick re-issued a reload of
 // the current entity and the loadedMsg handler called pager.gotoTop(),
@@ -129,12 +155,12 @@ func TestTUI_Artifact_ScrollResetOnlyOnUserModeChange(t *testing.T) {
 	}
 }
 
-// TestTUI_StoreChangedMsg_EmptyBatchIsNoop verifies the app-level behavior
-// that a quiet poll (no new events) produces no view churn. This is the
-// load-bearing property that makes scroll preservation work: if there's
-// nothing new in events.jsonl, the top view is not asked to reload.
-func TestTUI_StoreChangedMsg_EmptyBatchIsNoop(t *testing.T) {
+// TestTUI_StoreChangedMsg_EmptyBatchIsNoopForNonTickViews verifies the
+// app-level behavior that a quiet poll (no new events) still produces no
+// reload path for views that have not opted into elapsed-time repaints.
+func TestTUI_StoreChangedMsg_EmptyBatchIsNoopForNonTickViews(t *testing.T) {
 	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
+	m.stack = []tuiView{&staticTUIView{}}
 	m.eventOffset = 42
 
 	updated, cmd := m.Update(storeChangedMsg{events: nil, newOff: 99})
@@ -147,6 +173,32 @@ func TestTUI_StoreChangedMsg_EmptyBatchIsNoop(t *testing.T) {
 	}
 	if cmd != nil {
 		t.Errorf("empty batch should not emit commands; got %v", cmd)
+	}
+}
+
+func TestTUI_StoreChangedMsg_EmptyBatchDispatchesQuietTickToOptInView(t *testing.T) {
+	at := time.Date(2026, 4, 19, 12, 30, 0, 0, time.UTC)
+	m := newTuiModel(nil, goalScope{All: true}, 2*time.Second)
+	m.stack = []tuiView{&quietTickTestView{}}
+	m.eventOffset = 42
+
+	updated, cmd := m.Update(storeChangedMsg{events: nil, newOff: 99, polledAt: at})
+	nm := updated.(tuiModel)
+	if nm.eventOffset != 99 {
+		t.Fatalf("eventOffset = %d, want 99", nm.eventOffset)
+	}
+	if cmd != nil {
+		t.Fatalf("quiet tick repaint should not emit commands; got %v", cmd)
+	}
+	v, ok := nm.top().(*quietTickTestView)
+	if !ok {
+		t.Fatalf("top view = %T, want *quietTickTestView", nm.top())
+	}
+	if v.ticks != 1 {
+		t.Fatalf("quietTick count = %d, want 1", v.ticks)
+	}
+	if !v.lastAt.Equal(at) {
+		t.Fatalf("quietTick time = %s, want %s", v.lastAt, at)
 	}
 }
 

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -136,6 +136,40 @@ func TestTUI_DashboardNarrowFallback(t *testing.T) {
 	}
 }
 
+func TestTUI_DashboardQuietTickAdvancesElapsedFieldsWithoutResettingState(t *testing.T) {
+	v := newDashboardView(goalScope{All: true})
+	snap := tuiRichSnapshot()
+	nv, _ := v.update(dashLoadedMsg{snap: snap}, nil)
+	d := nv.(*dashboardView)
+	d.focus = dashFocusInFlight
+	d.cursors[dashFocusInFlight] = 0
+
+	plain := stripANSI(d.view(140, 40))
+	if !strings.Contains(plain, "1.2h/8h") {
+		t.Fatalf("initial dashboard budget missing captured elapsed time:\n%s", plain)
+	}
+	if !strings.Contains(plain, "02:00") {
+		t.Fatalf("initial dashboard in-flight elapsed missing captured time:\n%s", plain)
+	}
+
+	later := snap.CapturedAt.Add(65 * time.Second)
+	nv, _ = d.quietTick(later, nil)
+	d = nv.(*dashboardView)
+	plain = stripANSI(d.view(140, 40))
+	if !strings.Contains(plain, "1.2h/8h") {
+		t.Fatalf("dashboard budget should stay at one decimal hour over a 65s quiet tick:\n%s", plain)
+	}
+	if !strings.Contains(plain, "03:05") {
+		t.Fatalf("dashboard in-flight elapsed did not advance on quiet tick:\n%s", plain)
+	}
+	if got := d.cursors[dashFocusInFlight]; got != 0 {
+		t.Fatalf("quiet tick changed in-flight cursor: got %d want 0", got)
+	}
+	if d.focus != dashFocusInFlight {
+		t.Fatalf("quiet tick changed focus: got %v want %v", d.focus, dashFocusInFlight)
+	}
+}
+
 func TestTUI_DashboardLessonPanelUsesAccuracyArrows(t *testing.T) {
 	snap := tuiRichSnapshot()
 	snap.RecentLessons = []*entity.Lesson{
@@ -668,6 +702,26 @@ func TestTUI_StatusViewShowsStalledMeterForGoalScope(t *testing.T) {
 	out := stripANSI(nv.view(100, 30))
 	if !strings.Contains(out, "stalled 2/5") {
 		t.Fatalf("goal-scoped status view should show stalled meter:\n%s", out)
+	}
+}
+
+func TestTUI_StatusQuietTickAdvancesElapsedBudget(t *testing.T) {
+	snap := tuiRichSnapshot()
+	v := newStatusView(goalScope{All: true})
+	nv, _ := v.update(dashLoadedMsg{snap: snap}, nil)
+	status := nv.(*statusView)
+
+	plain := stripANSI(status.view(100, 30))
+	if !strings.Contains(plain, "1.2h/8h elapsed") {
+		t.Fatalf("initial status budget missing captured elapsed time:\n%s", plain)
+	}
+
+	later := snap.CapturedAt.Add(30 * time.Minute)
+	nv, _ = status.quietTick(later, nil)
+	status = nv.(*statusView)
+	plain = stripANSI(status.view(100, 30))
+	if !strings.Contains(plain, "1.7h/8h elapsed") {
+		t.Fatalf("status budget did not advance on quiet tick:\n%s", plain)
 	}
 }
 

--- a/internal/cli/tui_view_dashboard.go
+++ b/internal/cli/tui_view_dashboard.go
@@ -19,6 +19,7 @@ type dashboardView struct {
 	scope goalScope
 	snap  *dashboardSnapshot
 	err   error
+	now   time.Time
 
 	focus        dashFocus
 	cursors      [dashPanelCount]int
@@ -67,6 +68,49 @@ func newDashboardView(scope goalScope) *dashboardView {
 
 func (v *dashboardView) title() string { return "Dashboard" }
 
+func dashboardRenderTime(snap *dashboardSnapshot, at time.Time) time.Time {
+	if !at.IsZero() {
+		if snap != nil && !snap.CapturedAt.IsZero() && at.Before(snap.CapturedAt) {
+			return snap.CapturedAt
+		}
+		return at
+	}
+	if snap != nil {
+		return snap.CapturedAt
+	}
+	return time.Time{}
+}
+
+func dashboardLiveElapsedHours(snap *dashboardSnapshot, at time.Time) float64 {
+	if snap == nil {
+		return 0
+	}
+	elapsed := snap.Budgets.Usage.ElapsedH
+	renderAt := dashboardRenderTime(snap, at)
+	if renderAt.IsZero() || snap.CapturedAt.IsZero() {
+		return elapsed
+	}
+	if delta := renderAt.Sub(snap.CapturedAt); delta > 0 {
+		elapsed += delta.Hours()
+	}
+	return elapsed
+}
+
+func dashboardLiveInFlightElapsed(snap *dashboardSnapshot, row dashboardInFlight, at time.Time) time.Duration {
+	elapsed := time.Duration(row.ElapsedS) * time.Second
+	renderAt := dashboardRenderTime(snap, at)
+	if renderAt.IsZero() || snap == nil || snap.CapturedAt.IsZero() {
+		return elapsed
+	}
+	if delta := renderAt.Sub(snap.CapturedAt); delta > 0 {
+		elapsed += delta
+	}
+	if elapsed < 0 {
+		return 0
+	}
+	return elapsed
+}
+
 func (v *dashboardView) init(s *store.Store) tea.Cmd {
 	v.eventsLoading = true
 	cmds := []tea.Cmd{
@@ -87,6 +131,11 @@ func (v *dashboardView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	case dashLoadedMsg:
 		v.snap = msg.snap
 		v.err = msg.err
+		if msg.snap != nil {
+			v.now = msg.snap.CapturedAt
+		} else {
+			v.now = time.Time{}
+		}
 		return v, nil
 	case dashEventsLoadedMsg:
 		selected := v.selectedEventKey()
@@ -156,6 +205,14 @@ func (v *dashboardView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 		v.rightOverlay = nv
 		return v, cmd
 	}
+	return v, nil
+}
+
+func (v *dashboardView) quietTick(at time.Time, _ *store.Store) (tuiView, tea.Cmd) {
+	if v.snap == nil {
+		return v, nil
+	}
+	v.now = dashboardRenderTime(v.snap, at.UTC())
 	return v, nil
 }
 
@@ -328,9 +385,10 @@ func (v *dashboardView) renderTopStrip(width int) string {
 		parts = append(parts, fmt.Sprintf("%d exp", snap.Budgets.Usage.Experiments))
 	}
 	if snap.Budgets.Limits.MaxWallTimeH > 0 {
+		elapsedH := dashboardLiveElapsedHours(snap, v.now)
 		s := fmt.Sprintf("%.1fh/%dh",
-			snap.Budgets.Usage.ElapsedH, snap.Budgets.Limits.MaxWallTimeH)
-		parts = append(parts, tuiMeterColor(snap.Budgets.Usage.ElapsedH,
+			elapsedH, snap.Budgets.Limits.MaxWallTimeH)
+		parts = append(parts, tuiMeterColor(elapsedH,
 			float64(snap.Budgets.Limits.MaxWallTimeH), s))
 	}
 	if snap.Budgets.Limits.FrontierStallK > 0 {
@@ -471,7 +529,7 @@ func (v *dashboardView) renderInFlightPanel(width, height int) string {
 	for _, r := range v.snap.InFlight {
 		elapsed := "?"
 		if r.ImplementedAt != nil {
-			elapsed = formatElapsed(time.Duration(r.ElapsedS) * time.Second)
+			elapsed = formatElapsed(dashboardLiveInFlightElapsed(v.snap, r, v.now))
 		}
 		line := fmt.Sprintf("%-8s  %s  %s  inst=%s",
 			r.ID,

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/readmodel"
@@ -527,6 +528,7 @@ type statusView struct {
 	scope goalScope
 	snap  *dashboardSnapshot
 	err   error
+	now   time.Time
 }
 
 func newStatusView(scope goalScope) *statusView { return &statusView{scope: scope} }
@@ -545,10 +547,23 @@ func (v *statusView) update(msg tea.Msg, s *store.Store) (tuiView, tea.Cmd) {
 	case dashLoadedMsg:
 		v.snap = msg.snap
 		v.err = msg.err
+		if msg.snap != nil {
+			v.now = msg.snap.CapturedAt
+		} else {
+			v.now = time.Time{}
+		}
 		return v, nil
 	case storeChangedMsg:
 		return v, v.init(s)
 	}
+	return v, nil
+}
+
+func (v *statusView) quietTick(at time.Time, _ *store.Store) (tuiView, tea.Cmd) {
+	if v.snap == nil {
+		return v, nil
+	}
+	v.now = dashboardRenderTime(v.snap, at.UTC())
 	return v, nil
 }
 
@@ -593,10 +608,11 @@ func (v *statusView) view(width, height int) string {
 		lines = append(lines, fmt.Sprintf("  %d experiments (no limit)", snap.Budgets.Usage.Experiments))
 	}
 	if snap.Budgets.Limits.MaxWallTimeH > 0 {
+		elapsedH := dashboardLiveElapsedHours(snap, v.now)
 		lines = append(lines, fmt.Sprintf("  %s", tuiMeterColor(
-			snap.Budgets.Usage.ElapsedH,
+			elapsedH,
 			float64(snap.Budgets.Limits.MaxWallTimeH),
-			fmt.Sprintf("%.1fh/%dh elapsed", snap.Budgets.Usage.ElapsedH, snap.Budgets.Limits.MaxWallTimeH),
+			fmt.Sprintf("%.1fh/%dh elapsed", elapsedH, snap.Budgets.Limits.MaxWallTimeH),
 		)))
 	}
 	if snap.Budgets.Limits.FrontierStallK > 0 && !snap.ScopeAll {


### PR DESCRIPTION
## Summary
- add an opt-in quiet-tick repaint hook for time-sensitive TUI views
- keep dashboard and status elapsed fields advancing from the captured snapshot without store reloads
- add regression tests for quiet-tick routing and state preservation

## Testing
- make test

Fixes #37