### PR TITLE
Fix frontier status-aware badges

### DIFF
--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -535,8 +535,8 @@ func renderDashboardFrontier(w io.Writer, snap *dashboardSnapshot, a *ansi) {
 				marker = " " + a.boldYellow("*")
 			}
 			dead := ""
-			if r.Classification == experimentClassificationDead {
-				dead = "  " + a.dim(experimentClassificationMarker(r.Classification))
+			if marker := frontierClassificationMarker(r.Classification, r.HypothesisStatus); marker != "" {
+				dead = "  " + a.dim(marker)
 			}
 			fmt.Fprintf(w, " %s %s  %s  %s=%.6g%s\n",
 				marker, a.cyan(r.Conclusion), a.cyan(r.Hypothesis), snap.Goal.Objective.Instrument, r.Value, dead)

--- a/internal/cli/dashboard_test.go
+++ b/internal/cli/dashboard_test.go
@@ -418,6 +418,27 @@ func TestRenderDashboard_StatusGlyphs(t *testing.T) {
 	}
 }
 
+func TestRenderDashboard_FrontierUsesHypothesisStatusMarker(t *testing.T) {
+	snap := baseSnapshot()
+	snap.Goal = &entity.Goal{
+		Objective: entity.Objective{Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease"},
+	}
+	snap.Frontier = []frontierRow{{
+		Conclusion: "C-0001", Hypothesis: "H-0001", Value: 750067, DeltaFrac: -0.25,
+		Classification: experimentClassificationDead, HypothesisStatus: entity.StatusSupported,
+	}}
+
+	var buf bytes.Buffer
+	renderDashboard(&buf, snap, 120, "snapshot", nil)
+	out := buf.String()
+	if !strings.Contains(out, "[supported]") {
+		t.Fatalf("dashboard frontier missing supported marker:\n%s", out)
+	}
+	if strings.Contains(out, "[dead]") {
+		t.Fatalf("dashboard frontier should not show dead marker for supported hypotheses:\n%s", out)
+	}
+}
+
 // TestRenderDashboard_Colored exercises the color-on rendering path. We
 // bypass TTY detection by constructing an *ansi{enabled: true} directly, so
 // the test is deterministic regardless of the host environment, NO_COLOR, or

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -192,8 +192,8 @@ func renderFrontierSection(w *output.Writer, f goalFrontier, stallK int) {
 			if r.RescuedBy != "" {
 				w.Textf("  [rescued by %s]", r.RescuedBy)
 			}
-			if r.Classification == experimentClassificationDead {
-				w.Textf("  %s", experimentClassificationMarker(r.Classification))
+			if marker := frontierClassificationMarker(r.Classification, r.HypothesisStatus); marker != "" {
+				w.Textf("  %s", marker)
 			}
 			w.Textln("")
 		}

--- a/internal/cli/frontier_test.go
+++ b/internal/cli/frontier_test.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/output"
+)
+
+func TestRenderFrontierSection_UsesHypothesisStatusMarker(t *testing.T) {
+	var buf bytes.Buffer
+	w := output.New(&buf, &bytes.Buffer{}, false)
+
+	renderFrontierSection(w, goalFrontier{
+		Goal: &entity.Goal{
+			ID:        "G-0001",
+			Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"},
+		},
+		Rows: []frontierRow{{
+			Conclusion: "C-0001", Hypothesis: "H-0001", Value: 750067,
+			Classification: experimentClassificationDead, HypothesisStatus: entity.StatusSupported,
+		}},
+		Assessment: frontierGoalAssessment{Mode: "open_ended", RecommendedAction: "continue"},
+	}, 0)
+
+	out := buf.String()
+	if !strings.Contains(out, "[supported]") {
+		t.Fatalf("frontier output missing supported marker:\n%s", out)
+	}
+	if strings.Contains(out, "[dead]") {
+		t.Fatalf("frontier output should not show dead marker for supported hypotheses:\n%s", out)
+	}
+}

--- a/internal/cli/read_classification.go
+++ b/internal/cli/read_classification.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 )
@@ -62,4 +63,22 @@ func experimentClassificationMarker(classification string) string {
 		return "[dead]"
 	}
 	return ""
+}
+
+func frontierClassificationMarker(classification, hypothesisStatus string) string {
+	if classification != experimentClassificationDead {
+		return ""
+	}
+	switch hypothesisStatus {
+	case entity.StatusSupported:
+		return "[supported]"
+	case entity.StatusRefuted:
+		return "[refuted]"
+	case entity.StatusKilled:
+		return "[killed]"
+	case entity.StatusUnreviewed:
+		return "[pending review]"
+	default:
+		return experimentClassificationMarker(classification)
+	}
 }

--- a/internal/cli/read_classification_test.go
+++ b/internal/cli/read_classification_test.go
@@ -89,4 +89,22 @@ func TestExperimentClassificationHelpers(t *testing.T) {
 	if got := experimentClassificationMarker(experimentClassificationLive); got != "" {
 		t.Fatalf("marker(live) = %q, want empty", got)
 	}
+	if got, want := frontierClassificationMarker(experimentClassificationDead, entity.StatusSupported), "[supported]"; got != want {
+		t.Fatalf("frontier marker(supported) = %q, want %q", got, want)
+	}
+	if got, want := frontierClassificationMarker(experimentClassificationDead, entity.StatusRefuted), "[refuted]"; got != want {
+		t.Fatalf("frontier marker(refuted) = %q, want %q", got, want)
+	}
+	if got, want := frontierClassificationMarker(experimentClassificationDead, entity.StatusKilled), "[killed]"; got != want {
+		t.Fatalf("frontier marker(killed) = %q, want %q", got, want)
+	}
+	if got, want := frontierClassificationMarker(experimentClassificationDead, entity.StatusUnreviewed), "[pending review]"; got != want {
+		t.Fatalf("frontier marker(unreviewed) = %q, want %q", got, want)
+	}
+	if got, want := frontierClassificationMarker(experimentClassificationDead, ""), "[dead]"; got != want {
+		t.Fatalf("frontier marker(fallback) = %q, want %q", got, want)
+	}
+	if got := frontierClassificationMarker(experimentClassificationLive, entity.StatusSupported); got != "" {
+		t.Fatalf("frontier marker(live) = %q, want empty", got)
+	}
 }

--- a/internal/cli/tui_test.go
+++ b/internal/cli/tui_test.go
@@ -624,7 +624,7 @@ func TestTUI_FrontierView(t *testing.T) {
 	}
 }
 
-func TestTUI_FrontierViewShowsDeadClassification(t *testing.T) {
+func TestTUI_FrontierViewShowsHypothesisStatusMarker(t *testing.T) {
 	v := newFrontierView(goalScope{GoalID: "G-0001"})
 	g := &entity.Goal{Objective: entity.Objective{Instrument: "qemu_cycles", Direction: "decrease"}}
 	rows := []frontierRow{{
@@ -637,8 +637,28 @@ func TestTUI_FrontierViewShowsDeadClassification(t *testing.T) {
 		assessment: frontierGoalAssessment{Mode: "open_ended", RecommendedAction: "continue"},
 	}, nil)
 	out := stripANSI(nv.view(120, 20))
-	if !strings.Contains(out, "[dead]") {
-		t.Fatalf("frontier view missing dead marker:\n%s", out)
+	if !strings.Contains(out, "[supported]") {
+		t.Fatalf("frontier view missing supported marker:\n%s", out)
+	}
+	if strings.Contains(out, "[dead]") {
+		t.Fatalf("frontier view should not show dead marker for supported hypotheses:\n%s", out)
+	}
+}
+
+func TestTUI_DashboardFrontierShowsHypothesisStatusMarker(t *testing.T) {
+	v := newDashboardView(goalScope{All: true})
+	snap := tuiRichSnapshot()
+	snap.Frontier = []frontierRow{{
+		Conclusion: "C-0001", Hypothesis: "H-0001", Value: 750067, DeltaFrac: -0.25,
+		Classification: experimentClassificationDead, HypothesisStatus: entity.StatusSupported,
+	}}
+	nv, _ := v.update(dashLoadedMsg{snap: snap}, nil)
+	out := stripANSI(nv.view(140, 40))
+	if !strings.Contains(out, "[supported]") {
+		t.Fatalf("dashboard frontier missing supported marker:\n%s", out)
+	}
+	if strings.Contains(out, "[dead]") {
+		t.Fatalf("dashboard frontier should not show dead marker for supported hypotheses:\n%s", out)
 	}
 }
 

--- a/internal/cli/tui_view_dashboard.go
+++ b/internal/cli/tui_view_dashboard.go
@@ -503,8 +503,8 @@ func (v *dashboardView) renderFrontierPanel(width, height int) string {
 			tuiCyan.Render(r.Hypothesis),
 			snap.Goal.Objective.Instrument,
 			r.Value)
-		if r.Classification == experimentClassificationDead {
-			line += "  " + tuiDim.Render(experimentClassificationMarker(r.Classification))
+		if marker := frontierClassificationMarker(r.Classification, r.HypothesisStatus); marker != "" {
+			line += "  " + tuiDim.Render(marker)
 		}
 		lines = append(lines, line)
 	}

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -311,8 +311,8 @@ func (v *frontierView) view(width, height int) string {
 			v.goal.Objective.Instrument,
 			r.Value,
 			r.DeltaFrac)
-		if r.Classification == experimentClassificationDead {
-			rows[i] += "  " + tuiDim.Render(experimentClassificationMarker(r.Classification))
+		if marker := frontierClassificationMarker(r.Classification, r.HypothesisStatus); marker != "" {
+			rows[i] += "  " + tuiDim.Render(marker)
 		}
 	}
 	return renderFilteredListBody(header, rows, v.cursor, width, height)


### PR DESCRIPTION
## Summary
- add a frontier-only status-aware badge helper so dead-but-accepted rows render as the underlying hypothesis state
- update the frontier CLI, one-shot dashboard, dashboard TUI panel, and full-screen frontier TUI view to use that helper
- add regression coverage for the helper plus the CLI and TUI frontier renderers

## Testing
- make test

Fixes #38