### PR TITLE
Fix conclude baseline auto-resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The core nouns are:
 | **Experiment** | One concrete implementation attempt for a hypothesis, executed in its own git worktree. | Separates "what we changed" from "what we learned" and makes attempts reproducible. |
 | **Baseline** | A special experiment representing the reference code for a goal. | Gives every later comparison a stable "better than what?" anchor. |
 | **Observation** | The recorded result of running one instrument on one experiment: value, samples, CI, pass/fail, command, artifacts, and metadata. | This is the evidence layer. Conclusions may cite observations, not anecdotes. |
-| **Conclusion** | A verdict over a hypothesis, derived from observations and compared against the goal baseline. | Records whether the evidence actually supports, refutes, or fails to decide the claim. |
+| **Conclusion** | A verdict over a hypothesis, derived from observations and compared against the resolved absolute baseline. | Records whether the evidence actually supports, refutes, or fails to decide the claim. |
 | **Lesson** | A reusable takeaway extracted from prior work, either tied to a hypothesis chain or scoped to the system as a whole. | Prevents later cycles from rediscovering the same dead ends or overestimating future gains. |
 | **Frontier** | A derived view of the best supported conclusions for the current goal, annotated for current loop actionability. | Shows whether the search is still improving or has stalled without hiding historically important wins. |
 | **Instrument** | A command plus parser that turns program behavior into a number or pass/fail result. | Makes optimization targets measurable and repeatable. |

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -15,6 +15,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	concludeCandidateSourceObservations = "observations"
+	concludeBaselineSourceNone          = "none"
+)
+
+type concludeIgnoredObservation struct {
+	ID         string `json:"id"`
+	Instrument string `json:"instrument,omitempty"`
+	Reason     string `json:"reason"`
+}
+
+type concludeResolution struct {
+	RequestedObservations []string                     `json:"requested_observations"`
+	UsedObservations      []string                     `json:"used_observations"`
+	IgnoredObservations   []concludeIgnoredObservation `json:"ignored_observations,omitempty"`
+	CandidateExperiment   string                       `json:"candidate_experiment"`
+	CandidateSource       string                       `json:"candidate_source"`
+	BaselineExperiment    string                       `json:"baseline_experiment,omitempty"`
+	BaselineSource        string                       `json:"baseline_source"`
+	BaselineNote          string                       `json:"baseline_note,omitempty"`
+	AncestorHypothesis    string                       `json:"ancestor_hypothesis,omitempty"`
+	AncestorConclusion    string                       `json:"ancestor_conclusion,omitempty"`
+	IncrementalExperiment string                       `json:"incremental_experiment,omitempty"`
+}
+
 func concludeCommands() []*cobra.Command {
 	return []*cobra.Command{concludeCmd()}
 }
@@ -41,10 +66,18 @@ downgrade is recorded in the conclusion's strict_check block and in
 events.jsonl.
 
 Observations are concatenated by instrument. The candidate experiment is
-inferred from the observations; the baseline experiment is taken from
---baseline-experiment, or from the candidate's recorded baseline if set,
-or omitted entirely (in which case "supported" is automatically
-downgraded since there is no comparator).`,
+inferred from the observations. Requested observation ids on other
+instruments are ignored and reported in the CLI output; the remaining
+predicted-instrument observations must all belong to the same candidate
+experiment.
+
+The absolute baseline is resolved in this order: explicit
+--baseline-experiment (strict; no fallback), the candidate's recorded
+baseline if it has matching instrument data, the nearest accepted
+supported ancestor conclusion candidate, then the current goal's mapped
+baseline. If no usable comparator can be inferred, "supported" is
+automatically downgraded since there is no comparison. CLI and JSON
+output report which baseline source was used and any fallback note.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
@@ -67,79 +100,72 @@ downgraded since there is no comparator).`,
 				return fmt.Errorf("hypothesis %s is killed; reopen before concluding", hypID)
 			}
 
-			// Load observations, enforce they target the hypothesis's predicted instrument
-			// and all belong to the same candidate experiment.
-			var candObs []*entity.Observation
-			candExp := ""
-			for _, oid := range obsList {
-				o, err := s.ReadObservation(strings.TrimSpace(oid))
-				if err != nil {
-					return err
-				}
-				if o.Instrument != hyp.Predicts.Instrument {
-					return fmt.Errorf("observation %s uses instrument %q but hypothesis predicts on %q", o.ID, o.Instrument, hyp.Predicts.Instrument)
-				}
-				if candExp == "" {
-					candExp = o.Experiment
-				} else if candExp != o.Experiment {
-					return fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candExp, o.Experiment)
-				}
-				candObs = append(candObs, o)
-			}
-
-			// Resolve absolute baseline: prefer --baseline-experiment flag,
-			// then the candidate's recorded baseline, then the goal's
-			// IsBaseline experiment.
-			if baselineExp == "" {
-				candExpRec, err := s.ReadExperiment(candExp)
-				if err != nil {
-					return err
-				}
-				if candExpRec.Baseline.Experiment != "" {
-					baselineExp = candExpRec.Baseline.Experiment
-				}
-			}
-			if baselineExp == "" {
-				// Fall back to goal's baseline experiment.
-				exps, err := s.ListExperiments()
-				if err != nil {
-					return err
-				}
-				for _, e := range exps {
-					if e.IsBaseline {
-						baselineExp = e.ID
-						break
-					}
-				}
-			}
-
-			var baseObs []*entity.Observation
-			if baselineExp != "" {
-				all, err := s.ListObservationsForExperiment(baselineExp)
-				if err != nil {
-					return err
-				}
-				for _, o := range all {
-					if o.Instrument == hyp.Predicts.Instrument {
-						baseObs = append(baseObs, o)
-					}
-				}
-				if len(baseObs) == 0 {
-					return fmt.Errorf("baseline experiment %s has no observations on instrument %q", baselineExp, hyp.Predicts.Instrument)
-				}
-			}
-
-			// Resolve incremental baseline: the frontier best experiment.
-			var incrementalExp string
-			var incrObs []*entity.Observation
-			cfg, err := s.Config()
+			goal, err := goalForHypothesis(s, hyp)
 			if err != nil {
 				return err
 			}
-			goal, goalErr := s.ActiveGoal()
-			if goalErr == nil {
-				concls, _ := s.ListConclusions()
-				frontierRows, _ := readmodel.ComputeFrontier(s, goal, concls)
+
+			requestedObsIDs, candObs, ignoredObs, candExp, err := resolveConcludeObservations(s, hyp, obsList)
+			if err != nil {
+				return err
+			}
+			candExpRec, err := s.ReadExperiment(candExp)
+			if err != nil {
+				return err
+			}
+
+			resolution := concludeResolution{
+				RequestedObservations: requestedObsIDs,
+				UsedObservations:      observationIDs(candObs),
+				IgnoredObservations:   ignoredObs,
+				CandidateExperiment:   candExp,
+				CandidateSource:       concludeCandidateSourceObservations,
+				BaselineSource:        concludeBaselineSourceNone,
+			}
+
+			var (
+				baseObs     []*entity.Observation
+				baselineRes *readmodel.BaselineResolution
+			)
+			if baselineExp = strings.TrimSpace(baselineExp); baselineExp != "" {
+				baseObs, err = baselineObservationsForExperiment(s, baselineExp, hyp.Predicts.Instrument)
+				if err != nil {
+					return err
+				}
+				baselineRes = &readmodel.BaselineResolution{
+					ExperimentID: baselineExp,
+					Source:       readmodel.BaselineSourceExplicit,
+				}
+			} else {
+				baselineRes, err = readmodel.ResolveInferredBaseline(s, hyp, candExpRec, hyp.Predicts.Instrument)
+				if err != nil {
+					return err
+				}
+				if baselineRes != nil {
+					baselineExp = baselineRes.ExperimentID
+				}
+				if baselineExp != "" {
+					baseObs, err = baselineObservationsForExperiment(s, baselineExp, hyp.Predicts.Instrument)
+					if err != nil {
+						return err
+					}
+				}
+			}
+			applyBaselineResolution(&resolution, baselineRes, hyp.Predicts.Instrument)
+
+			// Resolve incremental baseline: the frontier best within the same goal.
+			var incrementalExp string
+			var incrObs []*entity.Observation
+			if goal != nil {
+				concls, err := s.ListConclusions()
+				if err != nil {
+					return err
+				}
+				scopedConcls, err := conclusionsForGoal(s, hyp.GoalID, concls)
+				if err != nil {
+					return err
+				}
+				frontierRows, _ := readmodel.ComputeFrontier(s, goal, scopedConcls)
 				if len(frontierRows) > 0 {
 					best := frontierRows[0].Candidate
 					// Only compute incremental if it differs from the absolute baseline.
@@ -156,7 +182,9 @@ downgraded since there is no comparator).`,
 					}
 				}
 			}
-			_ = cfg // used for future extensions
+			if incrementalExp != "" {
+				resolution.IncrementalExperiment = incrementalExp
+			}
 
 			// Compute comparison against absolute baseline.
 			cSamples := flattenSamples(candObs)
@@ -223,7 +251,7 @@ downgraded since there is no comparator).`,
 			concl := &entity.Conclusion{
 				Hypothesis:      hypID,
 				Verdict:         decision.FinalVerdict,
-				Observations:    obsList,
+				Observations:    resolution.UsedObservations,
 				CandidateExp:    candExp,
 				BaselineExp:     baselineExp,
 				Effect:          effect,
@@ -241,7 +269,10 @@ downgraded since there is no comparator).`,
 				concl.IncrementalEffect = &incrEffect
 			}
 
-			if err := dryRun(w, fmt.Sprintf("%sconclude %s with verdict=%s", downgradeLabel(decision), hypID, decision.FinalVerdict), map[string]any{"conclusion": concl}); err != nil {
+			if err := dryRun(w, fmt.Sprintf("%sconclude %s with verdict=%s", downgradeLabel(decision), hypID, decision.FinalVerdict), map[string]any{
+				"conclusion": concl,
+				"resolution": resolution,
+			}); err != nil {
 				return err
 			}
 
@@ -291,16 +322,33 @@ downgraded since there is no comparator).`,
 
 			// Event.
 			eventData := map[string]any{
-				"verdict":      decision.FinalVerdict,
-				"requested":    verdict,
-				"downgraded":   decision.Downgraded,
-				"reasons":      decision.Reasons,
-				"candidate":    candExp,
-				"baseline":     baselineExp,
-				"observations": obsList,
-				"delta_frac":   effect.DeltaFrac,
-				"ci_low_frac":  effect.CILowFrac,
-				"ci_high_frac": effect.CIHighFrac,
+				"verdict":          decision.FinalVerdict,
+				"requested":        verdict,
+				"downgraded":       decision.Downgraded,
+				"reasons":          decision.Reasons,
+				"candidate":        candExp,
+				"candidate_source": resolution.CandidateSource,
+				"baseline":         baselineExp,
+				"baseline_source":  resolution.BaselineSource,
+				"observations":     resolution.UsedObservations,
+				"delta_frac":       effect.DeltaFrac,
+				"ci_low_frac":      effect.CILowFrac,
+				"ci_high_frac":     effect.CIHighFrac,
+			}
+			if !slices.Equal(resolution.RequestedObservations, resolution.UsedObservations) {
+				eventData["requested_observations"] = resolution.RequestedObservations
+			}
+			if len(resolution.IgnoredObservations) > 0 {
+				eventData["ignored_observations"] = resolution.IgnoredObservations
+			}
+			if resolution.BaselineNote != "" {
+				eventData["baseline_note"] = resolution.BaselineNote
+			}
+			if resolution.AncestorHypothesis != "" {
+				eventData["ancestor_hypothesis"] = resolution.AncestorHypothesis
+			}
+			if resolution.AncestorConclusion != "" {
+				eventData["ancestor_conclusion"] = resolution.AncestorConclusion
 			}
 			if incrementalExp != "" {
 				eventData["incremental_experiment"] = incrementalExp
@@ -329,6 +377,7 @@ downgraded since there is no comparator).`,
 					"id":         id,
 					"conclusion": concl,
 					"decision":   decision,
+					"resolution": resolution,
 				})
 			}
 			if decision.Downgraded {
@@ -346,9 +395,25 @@ downgraded since there is no comparator).`,
 			}
 			w.Textf("wrote %s\n", id)
 			w.Textf("  hypothesis:  %s (now %s)\n", hypID, hyp.Status)
-			w.Textf("  candidate:   %s  (n=%d)\n", candExp, effect.NCandidate)
+			w.Textf("  candidate:   %s  (source=%s, n=%d)\n", candExp, resolution.CandidateSource, effect.NCandidate)
+			w.Textf("  observations: %s\n", strings.Join(resolution.UsedObservations, ", "))
+			if !slices.Equal(resolution.RequestedObservations, resolution.UsedObservations) {
+				w.Textf("  requested:   %s\n", strings.Join(resolution.RequestedObservations, ", "))
+			}
+			for i, ignored := range resolution.IgnoredObservations {
+				label := "  ignored:     "
+				if i > 0 {
+					label = "               "
+				}
+				w.Textf("%s%s (%s)\n", label, ignored.ID, ignored.Reason)
+			}
 			if baselineExp != "" {
-				w.Textf("  baseline:    %s  (n=%d)\n", baselineExp, effect.NBaseline)
+				w.Textf("  baseline:    %s  (n=%d, source=%s)\n", baselineExp, effect.NBaseline, formatBaselineSource(resolution))
+			} else {
+				w.Textf("  baseline:    none  (source=%s)\n", resolution.BaselineSource)
+			}
+			if resolution.BaselineNote != "" {
+				w.Textf("  baseline note: %s\n", resolution.BaselineNote)
 			}
 			if cmp != nil {
 				w.Textf("  delta_frac:  %+.4f  95%% CI [%+.4f, %+.4f]  (vs absolute baseline)\n", effect.DeltaFrac, effect.CILowFrac, effect.CIHighFrac)
@@ -370,7 +435,7 @@ downgraded since there is no comparator).`,
 	}
 	c.Flags().StringVar(&verdict, "verdict", "", "supported | refuted | inconclusive (required)")
 	c.Flags().StringSliceVar(&obsList, "observations", nil, "comma-separated observation ids (required)")
-	c.Flags().StringVar(&baselineExp, "baseline-experiment", "", "baseline experiment id (overrides candidate.baseline.experiment)")
+	c.Flags().StringVar(&baselineExp, "baseline-experiment", "", "baseline experiment id (strict override; no fallback if it lacks the predicted instrument)")
 	c.Flags().StringVar(&interpretation, "interpretation", "", "optional prose interpretation")
 	addAuthorFlag(c, &author, "")
 	c.Flags().StringVar(&reviewedBy, "reviewed-by", "", "critic or human who reviewed")
@@ -407,6 +472,160 @@ func downgradeLabel(d firewall.VerdictDecision) string {
 		return "(rescued) "
 	}
 	return ""
+}
+
+func goalForHypothesis(s *store.Store, hyp *entity.Hypothesis) (*entity.Goal, error) {
+	if s == nil || hyp == nil || strings.TrimSpace(hyp.GoalID) == "" {
+		return nil, nil
+	}
+	goal, err := s.ReadGoal(hyp.GoalID)
+	if errors.Is(err, store.ErrGoalNotFound) {
+		return nil, nil
+	}
+	return goal, err
+}
+
+func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs []string) ([]string, []*entity.Observation, []concludeIgnoredObservation, string, error) {
+	requested := normalizeObservationIDs(rawIDs)
+	if len(requested) == 0 {
+		return nil, nil, nil, "", errors.New("--observations is required (at least one observation id)")
+	}
+
+	var (
+		used    []*entity.Observation
+		ignored []concludeIgnoredObservation
+		candExp string
+	)
+	for _, oid := range requested {
+		o, err := s.ReadObservation(oid)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+		if o.Instrument != hyp.Predicts.Instrument {
+			ignored = append(ignored, concludeIgnoredObservation{
+				ID:         o.ID,
+				Instrument: o.Instrument,
+				Reason:     fmt.Sprintf("instrument %q does not match predicted instrument %q", o.Instrument, hyp.Predicts.Instrument),
+			})
+			continue
+		}
+		if candExp == "" {
+			candExp = o.Experiment
+		} else if candExp != o.Experiment {
+			return nil, nil, nil, "", fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candExp, o.Experiment)
+		}
+		used = append(used, o)
+	}
+	if len(used) == 0 {
+		var ignoredIDs []string
+		for _, ignoredObs := range ignored {
+			ignoredIDs = append(ignoredIDs, ignoredObs.ID)
+		}
+		if len(ignoredIDs) > 0 {
+			return nil, nil, nil, "", fmt.Errorf("none of the requested observations use predicted instrument %q; ignored: %s", hyp.Predicts.Instrument, strings.Join(ignoredIDs, ", "))
+		}
+		return nil, nil, nil, "", fmt.Errorf("none of the requested observations use predicted instrument %q", hyp.Predicts.Instrument)
+	}
+	return requested, used, ignored, candExp, nil
+}
+
+func normalizeObservationIDs(rawIDs []string) []string {
+	var ids []string
+	for _, raw := range rawIDs {
+		if id := strings.TrimSpace(raw); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func observationIDs(obs []*entity.Observation) []string {
+	ids := make([]string, 0, len(obs))
+	for _, o := range obs {
+		if o != nil {
+			ids = append(ids, o.ID)
+		}
+	}
+	return ids
+}
+
+func baselineObservationsForExperiment(s *store.Store, expID, instrument string) ([]*entity.Observation, error) {
+	if expID == "" {
+		return nil, nil
+	}
+	if _, err := s.ReadExperiment(expID); err != nil {
+		return nil, fmt.Errorf("baseline experiment %s: %w", expID, err)
+	}
+	all, err := s.ListObservationsForExperiment(expID)
+	if err != nil {
+		return nil, err
+	}
+	var filtered []*entity.Observation
+	for _, o := range all {
+		if o.Instrument == instrument {
+			filtered = append(filtered, o)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("baseline experiment %s has no observations on instrument %q", expID, instrument)
+	}
+	return filtered, nil
+}
+
+func applyBaselineResolution(res *concludeResolution, baseline *readmodel.BaselineResolution, instrument string) {
+	if res == nil {
+		return
+	}
+	res.BaselineSource = concludeBaselineSourceNone
+	if baseline == nil {
+		res.BaselineNote = fmt.Sprintf("no usable baseline could be inferred for instrument %q", instrument)
+		return
+	}
+	res.BaselineExperiment = baseline.ExperimentID
+	if baseline.Source != "" {
+		res.BaselineSource = baseline.Source
+	}
+	res.BaselineNote = baseline.Note
+	res.AncestorHypothesis = baseline.AncestorHypothesis
+	res.AncestorConclusion = baseline.AncestorConclusion
+	if res.BaselineExperiment == "" && res.BaselineNote == "" {
+		res.BaselineNote = fmt.Sprintf("no usable baseline could be inferred for instrument %q", instrument)
+	}
+}
+
+func formatBaselineSource(res concludeResolution) string {
+	if res.BaselineSource == readmodel.BaselineSourceAncestorSupported &&
+		res.AncestorHypothesis != "" &&
+		res.AncestorConclusion != "" {
+		return fmt.Sprintf("%s via %s/%s", res.BaselineSource, res.AncestorHypothesis, res.AncestorConclusion)
+	}
+	return res.BaselineSource
+}
+
+func conclusionsForGoal(s *store.Store, goalID string, concls []*entity.Conclusion) ([]*entity.Conclusion, error) {
+	if goalID == "" {
+		return nil, nil
+	}
+	goalByHypothesis := map[string]string{}
+	out := make([]*entity.Conclusion, 0, len(concls))
+	for _, c := range concls {
+		if c == nil || c.Hypothesis == "" {
+			continue
+		}
+		gid, ok := goalByHypothesis[c.Hypothesis]
+		if !ok {
+			h, err := s.ReadHypothesis(c.Hypothesis)
+			if err != nil {
+				return nil, err
+			}
+			gid = h.GoalID
+			goalByHypothesis[c.Hypothesis] = gid
+		}
+		if gid == goalID {
+			out = append(out, c)
+		}
+	}
+	return out, nil
 }
 
 // samplesForInstrument flattens every per-sample slice across observations

--- a/internal/cli/conclude_test.go
+++ b/internal/cli/conclude_test.go
@@ -1,0 +1,416 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type concludeResolutionJSON struct {
+	RequestedObservations []string `json:"requested_observations"`
+	UsedObservations      []string `json:"used_observations"`
+	IgnoredObservations   []struct {
+		ID     string `json:"id"`
+		Reason string `json:"reason"`
+	} `json:"ignored_observations"`
+	CandidateExperiment string `json:"candidate_experiment"`
+	CandidateSource     string `json:"candidate_source"`
+	BaselineExperiment  string `json:"baseline_experiment,omitempty"`
+	BaselineSource      string `json:"baseline_source"`
+	BaselineNote        string `json:"baseline_note,omitempty"`
+	AncestorHypothesis  string `json:"ancestor_hypothesis,omitempty"`
+	AncestorConclusion  string `json:"ancestor_conclusion,omitempty"`
+}
+
+type concludeJSONResponse struct {
+	ID         string                 `json:"id"`
+	Conclusion entity.Conclusion      `json:"conclusion"`
+	Resolution concludeResolutionJSON `json:"resolution"`
+}
+
+type concludeFixture struct {
+	dir                 string
+	goalID              string
+	goalBaseline        string
+	ancestorHypothesis  string
+	ancestorExperiment  string
+	ancestorConclusion  string
+	currentHypothesis   string
+	candidateExperiment string
+	timingObservation   string
+	sizeObservation     string
+}
+
+func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
+	t.Helper()
+
+	dir := t.TempDir()
+	s, err := store.Create(dir, store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	goal := &entity.Goal{
+		ID:        "G-0001",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+	}
+	otherGoal := &entity.Goal{
+		ID:        "G-0002",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+	}
+	for _, g := range []*entity.Goal{goal, otherGoal} {
+		if err := s.WriteGoal(g); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	goalBaseline := &entity.Experiment{
+		ID:         "E-0001",
+		IsBaseline: true,
+		Status:     entity.ExpMeasured,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{
+			"binary_size",
+		},
+		Author:    "system",
+		CreatedAt: now,
+	}
+	ancestorHyp := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    goal.ID,
+		Claim:     "ancestor",
+		Status:    entity.StatusSupported,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+		Predicts: entity.Predicts{
+			Instrument: "timing",
+			Target:     "kernel",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+	}
+	currentHyp := &entity.Hypothesis{
+		ID:        "H-0002",
+		GoalID:    goal.ID,
+		Parent:    ancestorHyp.ID,
+		Claim:     "descendant",
+		Status:    entity.StatusOpen,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+		Predicts: entity.Predicts{
+			Instrument: "timing",
+			Target:     "kernel",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+	}
+	ancestorExp := &entity.Experiment{
+		ID:         "E-0002",
+		Hypothesis: ancestorHyp.ID,
+		Status:     entity.ExpMeasured,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{
+			"timing",
+		},
+		Author:    "agent:observer",
+		CreatedAt: now,
+	}
+	candidateExp := &entity.Experiment{
+		ID:         "E-0003",
+		Hypothesis: currentHyp.ID,
+		Status:     entity.ExpMeasured,
+		Baseline: entity.Baseline{
+			Ref:        "HEAD",
+			SHA:        "def456",
+			Experiment: goalBaseline.ID,
+		},
+		Instruments: []string{"timing", "binary_size"},
+		Author:      "agent:observer",
+		CreatedAt:   now,
+	}
+	for _, h := range []*entity.Hypothesis{ancestorHyp, currentHyp} {
+		if err := s.WriteHypothesis(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, e := range []*entity.Experiment{goalBaseline, ancestorExp, candidateExp} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeObservation := func(id, expID, instrument string, value float64, perSample []float64) {
+		t.Helper()
+		o := &entity.Observation{
+			ID:         id,
+			Experiment: expID,
+			Instrument: instrument,
+			MeasuredAt: now,
+			Value:      value,
+			Samples:    len(perSample),
+			PerSample:  perSample,
+			Unit:       "ns",
+			Author:     "agent:observer",
+		}
+		if instrument == "binary_size" {
+			o.Unit = "bytes"
+		}
+		if err := s.WriteObservation(o); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeObservation("O-0001", goalBaseline.ID, "binary_size", 900, []float64{900, 900, 900, 900, 900})
+	writeObservation("O-0002", ancestorExp.ID, "timing", 100.4, []float64{100, 101, 99, 100, 102})
+	writeObservation("O-0003", candidateExp.ID, "timing", 70.4, []float64{70, 71, 69, 72, 70})
+	writeObservation("O-0004", candidateExp.ID, "binary_size", 860, []float64{860, 860, 860, 860, 860})
+
+	ancestorConcl := &entity.Conclusion{
+		ID:           "C-0001",
+		Hypothesis:   ancestorHyp.ID,
+		Verdict:      entity.VerdictSupported,
+		Observations: []string{"O-0002"},
+		CandidateExp: ancestorExp.ID,
+		BaselineExp:  goalBaseline.ID,
+		Effect: entity.Effect{
+			Instrument: "timing",
+			DeltaFrac:  -0.15,
+			NCandidate: 5,
+			NBaseline:  5,
+		},
+		StatTest:   "mann_whitney_u",
+		Strict:     entity.Strict{Passed: true},
+		Author:     "agent:analyst",
+		ReviewedBy: "human:gate",
+		CreatedAt:  now,
+	}
+	if err := s.WriteConclusion(ancestorConcl); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AppendEvent(store.Event{
+		Ts:      now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: goalBaseline.ID,
+		Data:    jsonRaw(map[string]any{"goal": goal.ID}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateState(func(st *store.State) error {
+		st.CurrentGoalID = otherGoal.ID
+		st.Counters["G"] = 2
+		st.Counters["H"] = 2
+		st.Counters["E"] = 3
+		st.Counters["O"] = 4
+		st.Counters["C"] = 1
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	return concludeFixture{
+		dir:                 dir,
+		goalID:              goal.ID,
+		goalBaseline:        goalBaseline.ID,
+		ancestorHypothesis:  ancestorHyp.ID,
+		ancestorExperiment:  ancestorExp.ID,
+		ancestorConclusion:  ancestorConcl.ID,
+		currentHypothesis:   currentHyp.ID,
+		candidateExperiment: candidateExp.ID,
+		timingObservation:   "O-0003",
+		sizeObservation:     "O-0004",
+	}
+}
+
+func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
+	saveGlobals(t)
+	fx := setupConcludeFallbackFixture(t)
+
+	resp := runCLIJSON[concludeJSONResponse](t, fx.dir,
+		"conclude", fx.currentHypothesis,
+		"--verdict", "supported",
+		"--observations", strings.Join([]string{fx.timingObservation, fx.sizeObservation}, ","),
+	)
+
+	if resp.Conclusion.CandidateExp != fx.candidateExperiment {
+		t.Fatalf("candidate_experiment = %q, want %q", resp.Conclusion.CandidateExp, fx.candidateExperiment)
+	}
+	if got, want := resp.Conclusion.Observations, []string{fx.timingObservation}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("stored observations = %v, want %v", got, want)
+	}
+	if resp.Resolution.CandidateSource != concludeCandidateSourceObservations {
+		t.Fatalf("candidate_source = %q, want %q", resp.Resolution.CandidateSource, concludeCandidateSourceObservations)
+	}
+	if got, want := resp.Resolution.UsedObservations, []string{fx.timingObservation}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("used_observations = %v, want %v", got, want)
+	}
+	if got, want := resp.Resolution.RequestedObservations, []string{fx.timingObservation, fx.sizeObservation}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("requested_observations = %v, want %v", got, want)
+	}
+	if got, want := len(resp.Resolution.IgnoredObservations), 1; got != want {
+		t.Fatalf("ignored_observations len = %d, want %d", got, want)
+	}
+	if resp.Resolution.IgnoredObservations[0].ID != fx.sizeObservation {
+		t.Fatalf("ignored observation id = %q, want %q", resp.Resolution.IgnoredObservations[0].ID, fx.sizeObservation)
+	}
+	if resp.Resolution.BaselineExperiment != fx.ancestorExperiment {
+		t.Fatalf("baseline_experiment = %q, want %q", resp.Resolution.BaselineExperiment, fx.ancestorExperiment)
+	}
+	if resp.Resolution.BaselineSource != readmodel.BaselineSourceAncestorSupported {
+		t.Fatalf("baseline_source = %q, want %q", resp.Resolution.BaselineSource, readmodel.BaselineSourceAncestorSupported)
+	}
+	if resp.Resolution.AncestorHypothesis != fx.ancestorHypothesis {
+		t.Fatalf("ancestor_hypothesis = %q, want %q", resp.Resolution.AncestorHypothesis, fx.ancestorHypothesis)
+	}
+	if resp.Resolution.AncestorConclusion != fx.ancestorConclusion {
+		t.Fatalf("ancestor_conclusion = %q, want %q", resp.Resolution.AncestorConclusion, fx.ancestorConclusion)
+	}
+	if !strings.Contains(resp.Resolution.BaselineNote, fx.goalBaseline) {
+		t.Fatalf("baseline_note = %q, want to mention %s", resp.Resolution.BaselineNote, fx.goalBaseline)
+	}
+
+	s, err := store.Open(fx.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	written, err := s.ReadConclusion(resp.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := written.Observations, []string{fx.timingObservation}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("written conclusion observations = %v, want %v", got, want)
+	}
+
+	e := findLastEvent(t, s, "conclusion.write")
+	if e == nil {
+		t.Fatal("conclusion.write event not found")
+	}
+	payload := decodePayload(t, e)
+	if got := payload["candidate_source"]; got != concludeCandidateSourceObservations {
+		t.Fatalf("payload candidate_source = %v, want %q", got, concludeCandidateSourceObservations)
+	}
+	if got := payload["baseline_source"]; got != readmodel.BaselineSourceAncestorSupported {
+		t.Fatalf("payload baseline_source = %v, want %q", got, readmodel.BaselineSourceAncestorSupported)
+	}
+	if got := payload["ancestor_hypothesis"]; got != fx.ancestorHypothesis {
+		t.Fatalf("payload ancestor_hypothesis = %v, want %q", got, fx.ancestorHypothesis)
+	}
+	if got := payload["ancestor_conclusion"]; got != fx.ancestorConclusion {
+		t.Fatalf("payload ancestor_conclusion = %v, want %q", got, fx.ancestorConclusion)
+	}
+	if got, ok := payload["observations"].([]any); !ok || len(got) != 1 || got[0] != fx.timingObservation {
+		t.Fatalf("payload observations = %#v, want [%s]", payload["observations"], fx.timingObservation)
+	}
+	if got, ok := payload["requested_observations"].([]any); !ok || len(got) != 2 || got[0] != fx.timingObservation || got[1] != fx.sizeObservation {
+		t.Fatalf("payload requested_observations = %#v, want [%s %s]", payload["requested_observations"], fx.timingObservation, fx.sizeObservation)
+	}
+	ignored, ok := payload["ignored_observations"].([]any)
+	if !ok || len(ignored) != 1 {
+		t.Fatalf("payload ignored_observations = %#v", payload["ignored_observations"])
+	}
+	ignoredMap, ok := ignored[0].(map[string]any)
+	if !ok {
+		t.Fatalf("ignored_observations[0] type = %T", ignored[0])
+	}
+	if ignoredMap["id"] != fx.sizeObservation {
+		t.Fatalf("ignored observation id = %v, want %q", ignoredMap["id"], fx.sizeObservation)
+	}
+}
+
+func TestConclude_TextOutputSurfacesFallback(t *testing.T) {
+	saveGlobals(t)
+	fx := setupConcludeFallbackFixture(t)
+
+	out := runCLI(t, fx.dir,
+		"conclude", fx.currentHypothesis,
+		"--verdict", "supported",
+		"--observations", strings.Join([]string{fx.timingObservation, fx.sizeObservation}, ","),
+	)
+
+	if !strings.Contains(out, "candidate:   "+fx.candidateExperiment+"  (source=observations") {
+		t.Fatalf("output missing candidate source:\n%s", out)
+	}
+	if !strings.Contains(out, "ignored:     "+fx.sizeObservation+" (instrument \"binary_size\" does not match predicted instrument \"timing\")") {
+		t.Fatalf("output missing ignored observation audit:\n%s", out)
+	}
+	if !strings.Contains(out, "baseline:    "+fx.ancestorExperiment+"  (n=5, source=ancestor_supported via "+fx.ancestorHypothesis+"/"+fx.ancestorConclusion+")") {
+		t.Fatalf("output missing baseline source path:\n%s", out)
+	}
+	if !strings.Contains(out, "baseline note: candidate recorded baseline "+fx.goalBaseline+" has no observations on instrument \"timing\"") {
+		t.Fatalf("output missing baseline fallback note:\n%s", out)
+	}
+}
+
+func TestConclude_ExplicitBaselineRemainsStrict(t *testing.T) {
+	saveGlobals(t)
+	fx := setupConcludeFallbackFixture(t)
+
+	_, _, err := runCLIResult(t, fx.dir,
+		"conclude", fx.currentHypothesis,
+		"--verdict", "supported",
+		"--baseline-experiment", fx.goalBaseline,
+		"--observations", strings.Join([]string{fx.timingObservation, fx.sizeObservation}, ","),
+	)
+	if err == nil {
+		t.Fatal("conclude unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "baseline experiment "+fx.goalBaseline+" has no observations on instrument \"timing\"") {
+		t.Fatalf("error = %q, want missing instrument failure", err)
+	}
+}
+
+func runCLIResult(t *testing.T, dir string, args ...string) (string, string, error) {
+	t.Helper()
+
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("stderr pipe: %v", err)
+	}
+	outCh := make(chan string, 1)
+	errCh := make(chan string, 1)
+	go func() {
+		data, _ := io.ReadAll(rOut)
+		outCh <- string(data)
+	}()
+	go func() {
+		data, _ := io.ReadAll(rErr)
+		errCh <- string(data)
+	}()
+
+	os.Stdout = wOut
+	os.Stderr = wErr
+	defer func() {
+		os.Stdout = oldStdout
+		os.Stderr = oldStderr
+	}()
+
+	root := Root()
+	root.SetArgs(append([]string{"-C", dir}, args...))
+	execErr := root.Execute()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+	stdout := <-outCh
+	stderr := <-errCh
+	return stdout, stderr, execErr
+}

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -116,8 +116,11 @@ If the list is empty, create one:
 
     autoresearch experiment baseline --json
 
-The `conclude` command auto-derives the baseline — you do not need to
-pass `--baseline-experiment` manually.
+The `conclude` command auto-derives the baseline when you omit
+`--baseline-experiment`: candidate-recorded baseline if usable, else the
+nearest accepted supported ancestor, else the goal baseline. Its output
+spells out which source it used and any ignored off-instrument
+observations.
 
 ### Command spine
 
@@ -346,11 +349,15 @@ autoresearch conclude <hyp-id> \
     --author agent:orchestrator --json
 ```
 
-The CLI auto-derives two baselines: absolute (the goal's baseline
-experiment) and incremental (the current frontier best). The JSON
-response includes both `effect` (vs absolute) and `incremental_effect`
-(vs frontier best). The strict firewall always evaluates against the
-absolute baseline.
+The CLI auto-derives two baselines. Absolute resolution prefers the
+candidate's recorded baseline when it has matching instrument data, then
+the nearest accepted supported ancestor candidate, then the goal
+baseline. Incremental resolution uses the current frontier best within
+the same goal. JSON and text output report the chosen absolute-baseline
+source, any ignored off-instrument observations, and both `effect`
+(vs absolute) and `incremental_effect` (vs frontier best, when
+available). The strict firewall always evaluates against the absolute
+baseline.
 
 If the firewall downgrades your verdict, **the downgrade is
 authoritative**. Report it in the yield summary.

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -264,10 +264,12 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
     autoresearch conclude <hyp-id> \
         --verdict {supported|refuted|inconclusive} \
         --observations O-XXXX,O-YYYY \
-        [--baseline-experiment E-XXXX] \   # override; auto-derived from goal baseline if omitted
+        [--baseline-experiment E-XXXX] \   # strict override; otherwise auto-derive baseline
         [--interpretation "..."]
-        # Dual baseline: auto-derives absolute (goal baseline) and incremental
-        # (frontier best). JSON output includes both effect and incremental_effect.
+        # Dual baseline: absolute prefers candidate-recorded baseline, then the
+        # nearest accepted supported ancestor, then the goal baseline; incremental
+        # uses the same goal's frontier best. Output reports the chosen source,
+        # ignored off-instrument observations, and both effect + incremental_effect.
 
 ### Conclusions (review and gate reviewer)
     autoresearch conclusion list       [--goal G-NNNN|all] [--hypothesis H-XXXX] [--verdict X]

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -42,7 +42,10 @@ func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *
 		return nil, nil
 	}
 
-	obsByExp := LoadObservationsByExperiment(s)
+	obsByExp, err := loadObservationsByExperimentStrict(s)
+	if err != nil {
+		return nil, err
+	}
 	var notes []string
 
 	if expID := strings.TrimSpace(candidate.Baseline.Experiment); expID != "" {
@@ -116,36 +119,37 @@ func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, in
 		}
 
 		accepted := acceptedByHyp[parentID]
-		var usable []*entity.Conclusion
+		usableByExp := map[string]*entity.Conclusion{}
 		for _, c := range accepted {
 			ok, _, err := experimentHasInstrumentData(s, obsByExp, c.CandidateExp, instrument, "accepted supported ancestor candidate")
 			if err != nil {
 				return nil, "", err
 			}
 			if ok {
-				usable = append(usable, c)
+				usableByExp[c.CandidateExp] = preferAncestorConclusion(usableByExp[c.CandidateExp], c)
 			}
 		}
 
-		switch len(usable) {
+		switch len(usableByExp) {
 		case 0:
 			if len(accepted) > 0 {
 				notes = appendNote(notes, fmt.Sprintf("accepted supported ancestor %s has no candidate with observations on instrument %q", parentID, instrument))
 			}
 		case 1:
+			chosen := onlyAncestorConclusion(usableByExp)
 			return &BaselineResolution{
-				ExperimentID:       usable[0].CandidateExp,
+				ExperimentID:       chosen.CandidateExp,
 				Source:             BaselineSourceAncestorSupported,
 				AncestorHypothesis: parentID,
-				AncestorConclusion: usable[0].ID,
+				AncestorConclusion: chosen.ID,
 			}, joinNotes(notes...), nil
 		default:
-			ids := make([]string, 0, len(usable))
-			for _, c := range usable {
-				ids = append(ids, c.ID)
+			expIDs := make([]string, 0, len(usableByExp))
+			for expID := range usableByExp {
+				expIDs = append(expIDs, expID)
 			}
-			sort.Strings(ids)
-			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported conclusions with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(ids, ", "))
+			sort.Strings(expIDs)
+			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported candidate experiments with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(expIDs, ", "))
 		}
 
 		parentID = strings.TrimSpace(parent.Parent)
@@ -228,6 +232,14 @@ func goalBaselineExperimentIDs(s *store.Store, goalID string) ([]string, error) 
 	return ids, nil
 }
 
+func loadObservationsByExperimentStrict(s *store.Store) (map[string][]*entity.Observation, error) {
+	all, err := s.ListObservations()
+	if err != nil {
+		return nil, err
+	}
+	return GroupObservationsByExperiment(all), nil
+}
+
 func experimentHasInstrumentData(s *store.Store, obsByExp map[string][]*entity.Observation, expID, instrument, label string) (bool, string, error) {
 	if _, err := s.ReadExperiment(expID); err != nil {
 		if errors.Is(err, store.ErrExperimentNotFound) {
@@ -241,6 +253,29 @@ func experimentHasInstrumentData(s *store.Store, obsByExp map[string][]*entity.O
 		}
 	}
 	return false, fmt.Sprintf("%s %s has no observations on instrument %q", label, expID, instrument), nil
+}
+
+func preferAncestorConclusion(cur, next *entity.Conclusion) *entity.Conclusion {
+	if cur == nil {
+		return next
+	}
+	if next == nil {
+		return cur
+	}
+	if next.CreatedAt.After(cur.CreatedAt) {
+		return next
+	}
+	if next.CreatedAt.Equal(cur.CreatedAt) && next.ID > cur.ID {
+		return next
+	}
+	return cur
+}
+
+func onlyAncestorConclusion(m map[string]*entity.Conclusion) *entity.Conclusion {
+	for _, c := range m {
+		return c
+	}
+	return nil
 }
 
 func appendNote(notes []string, note string) []string {

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -1,0 +1,265 @@
+package readmodel
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const (
+	BaselineSourceExplicit          = "explicit"
+	BaselineSourceCandidateRecorded = "candidate_recorded"
+	BaselineSourceAncestorSupported = "ancestor_supported"
+	BaselineSourceGoalBaseline      = "goal_baseline"
+)
+
+// BaselineResolution describes how conclude resolved its absolute baseline.
+// When ExperimentID is empty, Note explains why no usable baseline could be
+// inferred.
+type BaselineResolution struct {
+	ExperimentID       string `json:"experiment,omitempty"`
+	Source             string `json:"source,omitempty"`
+	AncestorHypothesis string `json:"ancestor_hypothesis,omitempty"`
+	AncestorConclusion string `json:"ancestor_conclusion,omitempty"`
+	Note               string `json:"note,omitempty"`
+}
+
+// ResolveInferredBaseline resolves conclude's default absolute baseline order:
+// candidate-recorded baseline, nearest accepted supported ancestor, then the
+// current goal's mapped baseline. It never applies the explicit
+// --baseline-experiment override; callers handle that strictly at the CLI.
+func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *entity.Experiment, instrument string) (*BaselineResolution, error) {
+	if s == nil || hyp == nil || candidate == nil {
+		return nil, nil
+	}
+	instrument = strings.TrimSpace(instrument)
+	if instrument == "" {
+		return nil, nil
+	}
+
+	obsByExp := LoadObservationsByExperiment(s)
+	var notes []string
+
+	if expID := strings.TrimSpace(candidate.Baseline.Experiment); expID != "" {
+		ok, note, err := experimentHasInstrumentData(s, obsByExp, expID, instrument, "candidate recorded baseline")
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			return &BaselineResolution{
+				ExperimentID: expID,
+				Source:       BaselineSourceCandidateRecorded,
+			}, nil
+		}
+		notes = appendNote(notes, note)
+	}
+
+	concls, err := s.ListConclusions()
+	if err != nil {
+		return nil, err
+	}
+	ancestor, note, err := resolveAncestorSupportedBaseline(s, hyp, instrument, concls, obsByExp)
+	if err != nil {
+		return nil, err
+	}
+	notes = appendNote(notes, note)
+	if ancestor != nil {
+		ancestor.Note = joinNotes(append(notes, ancestor.Note)...)
+		return ancestor, nil
+	}
+
+	goalBase, note, err := resolveGoalBaseline(s, hyp.GoalID, instrument, obsByExp)
+	if err != nil {
+		return nil, err
+	}
+	notes = appendNote(notes, note)
+	if goalBase != nil {
+		goalBase.Note = joinNotes(append(notes, goalBase.Note)...)
+		return goalBase, nil
+	}
+
+	if len(notes) == 0 {
+		notes = append(notes, fmt.Sprintf("no usable baseline could be inferred for instrument %q", instrument))
+	}
+	return &BaselineResolution{Note: joinNotes(notes...)}, nil
+}
+
+func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, instrument string, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation) (*BaselineResolution, string, error) {
+	if hyp == nil || strings.TrimSpace(hyp.Parent) == "" {
+		return nil, "", nil
+	}
+
+	acceptedByHyp := map[string][]*entity.Conclusion{}
+	for _, c := range concls {
+		if c == nil || c.ReviewedBy == "" || c.Verdict != entity.VerdictSupported || strings.TrimSpace(c.CandidateExp) == "" {
+			continue
+		}
+		acceptedByHyp[c.Hypothesis] = append(acceptedByHyp[c.Hypothesis], c)
+	}
+
+	seen := map[string]struct{}{}
+	var notes []string
+	for parentID := strings.TrimSpace(hyp.Parent); parentID != ""; {
+		if _, dup := seen[parentID]; dup {
+			return nil, "", fmt.Errorf("hypothesis parent chain cycles at %s", parentID)
+		}
+		seen[parentID] = struct{}{}
+
+		parent, err := s.ReadHypothesis(parentID)
+		if err != nil {
+			return nil, "", fmt.Errorf("read parent hypothesis %s: %w", parentID, err)
+		}
+
+		accepted := acceptedByHyp[parentID]
+		var usable []*entity.Conclusion
+		for _, c := range accepted {
+			ok, _, err := experimentHasInstrumentData(s, obsByExp, c.CandidateExp, instrument, "accepted supported ancestor candidate")
+			if err != nil {
+				return nil, "", err
+			}
+			if ok {
+				usable = append(usable, c)
+			}
+		}
+
+		switch len(usable) {
+		case 0:
+			if len(accepted) > 0 {
+				notes = appendNote(notes, fmt.Sprintf("accepted supported ancestor %s has no candidate with observations on instrument %q", parentID, instrument))
+			}
+		case 1:
+			return &BaselineResolution{
+				ExperimentID:       usable[0].CandidateExp,
+				Source:             BaselineSourceAncestorSupported,
+				AncestorHypothesis: parentID,
+				AncestorConclusion: usable[0].ID,
+			}, joinNotes(notes...), nil
+		default:
+			ids := make([]string, 0, len(usable))
+			for _, c := range usable {
+				ids = append(ids, c.ID)
+			}
+			sort.Strings(ids)
+			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported conclusions with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(ids, ", "))
+		}
+
+		parentID = strings.TrimSpace(parent.Parent)
+	}
+
+	return nil, joinNotes(notes...), nil
+}
+
+func resolveGoalBaseline(s *store.Store, goalID, instrument string, obsByExp map[string][]*entity.Observation) (*BaselineResolution, string, error) {
+	goalID = strings.TrimSpace(goalID)
+	if goalID == "" {
+		return nil, "", nil
+	}
+
+	ids, err := goalBaselineExperimentIDs(s, goalID)
+	if err != nil {
+		return nil, "", err
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Sprintf("goal %s has no recorded baseline experiment", goalID), nil
+	}
+
+	var (
+		usable []string
+		notes  []string
+	)
+	for _, expID := range ids {
+		ok, note, err := experimentHasInstrumentData(s, obsByExp, expID, instrument, "goal baseline")
+		if err != nil {
+			return nil, "", err
+		}
+		if ok {
+			usable = append(usable, expID)
+			continue
+		}
+		notes = appendNote(notes, note)
+	}
+
+	switch len(usable) {
+	case 0:
+		return nil, joinNotes(notes...), nil
+	case 1:
+		return &BaselineResolution{
+			ExperimentID: usable[0],
+			Source:       BaselineSourceGoalBaseline,
+		}, joinNotes(notes...), nil
+	default:
+		sort.Strings(usable)
+		return nil, "", fmt.Errorf("goal %s has multiple baseline experiments with observations on instrument %q: %s; pass --baseline-experiment explicitly", goalID, instrument, strings.Join(usable, ", "))
+	}
+}
+
+func goalBaselineExperimentIDs(s *store.Store, goalID string) ([]string, error) {
+	events, err := s.Events(0)
+	if err != nil {
+		return nil, err
+	}
+	type baselinePayload struct {
+		Goal string `json:"goal"`
+	}
+	var ids []string
+	seen := map[string]struct{}{}
+	for _, ev := range events {
+		if ev.Kind != "experiment.baseline" || strings.TrimSpace(ev.Subject) == "" {
+			continue
+		}
+		var payload baselinePayload
+		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+			continue
+		}
+		if payload.Goal != goalID {
+			continue
+		}
+		if _, dup := seen[ev.Subject]; dup {
+			continue
+		}
+		seen[ev.Subject] = struct{}{}
+		ids = append(ids, ev.Subject)
+	}
+	return ids, nil
+}
+
+func experimentHasInstrumentData(s *store.Store, obsByExp map[string][]*entity.Observation, expID, instrument, label string) (bool, string, error) {
+	if _, err := s.ReadExperiment(expID); err != nil {
+		if errors.Is(err, store.ErrExperimentNotFound) {
+			return false, fmt.Sprintf("%s %s does not exist", label, expID), nil
+		}
+		return false, "", err
+	}
+	for _, o := range obsByExp[expID] {
+		if o != nil && o.Instrument == instrument {
+			return true, "", nil
+		}
+	}
+	return false, fmt.Sprintf("%s %s has no observations on instrument %q", label, expID, instrument), nil
+}
+
+func appendNote(notes []string, note string) []string {
+	note = strings.TrimSpace(note)
+	if note == "" {
+		return notes
+	}
+	for _, existing := range notes {
+		if existing == note {
+			return notes
+		}
+	}
+	return append(notes, note)
+}
+
+func joinNotes(notes ...string) string {
+	var cleaned []string
+	for _, note := range notes {
+		cleaned = appendNote(cleaned, note)
+	}
+	return strings.Join(cleaned, "; ")
+}

--- a/internal/readmodel/baseline_test.go
+++ b/internal/readmodel/baseline_test.go
@@ -2,6 +2,8 @@ package readmodel
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -217,6 +219,39 @@ func TestResolveInferredBaseline_PrefersNearestAcceptedSupportedAncestor(t *test
 	}
 }
 
+func TestResolveInferredBaseline_DedupesSupportedConclusionsOnSameAncestorExperiment(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+
+	parent := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	current := f.writeHypothesis(t, "H-0002", "G-0001", parent.ID)
+
+	ancestorExp := f.writeExperiment(t, "E-0001", parent.ID, "", false)
+	f.writeObservation(t, "O-0001", ancestorExp.ID, "timing")
+	f.writeConclusion(t, "C-0001", parent.ID, ancestorExp.ID, true)
+	f.now = f.now.Add(time.Minute)
+	f.writeConclusion(t, "C-0002", parent.ID, ancestorExp.ID, true)
+
+	candidate := f.writeExperiment(t, "E-0002", current.ID, "", false)
+
+	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ResolveInferredBaseline returned nil result")
+	}
+	if got.ExperimentID != ancestorExp.ID {
+		t.Fatalf("experiment = %q, want %q", got.ExperimentID, ancestorExp.ID)
+	}
+	if got.Source != BaselineSourceAncestorSupported {
+		t.Fatalf("source = %q, want %q", got.Source, BaselineSourceAncestorSupported)
+	}
+	if got.AncestorConclusion != "C-0002" {
+		t.Fatalf("ancestor conclusion = %q, want %q", got.AncestorConclusion, "C-0002")
+	}
+}
+
 func TestResolveInferredBaseline_UsesGoalScopedBaselineMapping(t *testing.T) {
 	f := newBaselineFixture(t)
 	f.writeGoal(t, "G-0001")
@@ -267,5 +302,25 @@ func TestResolveInferredBaseline_ErrorsOnAmbiguousGoalBaseline(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "multiple baseline experiments") {
 		t.Fatalf("error = %q, want multiple baseline experiments", err)
+	}
+}
+
+func TestResolveInferredBaseline_PropagatesObservationReadErrors(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+	current := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	candidate := f.writeExperiment(t, "E-0001", current.ID, "", false)
+
+	badPath := filepath.Join(f.s.ObservationsDir(), "O-9999.json")
+	if err := os.WriteFile(badPath, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err == nil {
+		t.Fatal("ResolveInferredBaseline unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "parse observation") {
+		t.Fatalf("error = %q, want parse observation", err)
 	}
 }

--- a/internal/readmodel/baseline_test.go
+++ b/internal/readmodel/baseline_test.go
@@ -1,0 +1,271 @@
+package readmodel
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type baselineFixture struct {
+	s   *store.Store
+	now time.Time
+}
+
+func newBaselineFixture(t *testing.T) *baselineFixture {
+	t.Helper()
+	s, err := store.Create(t.TempDir(), store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &baselineFixture{
+		s:   s,
+		now: time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func (f *baselineFixture) writeGoal(t *testing.T, id string) *entity.Goal {
+	t.Helper()
+	g := &entity.Goal{
+		ID:        id,
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &f.now,
+		Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+	}
+	if err := f.s.WriteGoal(g); err != nil {
+		t.Fatal(err)
+	}
+	return g
+}
+
+func (f *baselineFixture) writeHypothesis(t *testing.T, id, goalID, parent string) *entity.Hypothesis {
+	t.Helper()
+	h := &entity.Hypothesis{
+		ID:        id,
+		GoalID:    goalID,
+		Parent:    parent,
+		Claim:     id,
+		Status:    entity.StatusOpen,
+		Author:    "agent:analyst",
+		CreatedAt: f.now,
+		Predicts: entity.Predicts{
+			Instrument: "timing",
+			Target:     "kernel",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+	}
+	if err := f.s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func (f *baselineFixture) writeExperiment(t *testing.T, id, hypID, baselineExp string, isBaseline bool) *entity.Experiment {
+	t.Helper()
+	e := &entity.Experiment{
+		ID:         id,
+		Hypothesis: hypID,
+		IsBaseline: isBaseline,
+		Status:     entity.ExpMeasured,
+		Baseline: entity.Baseline{
+			Ref:        "HEAD",
+			SHA:        "abc123",
+			Experiment: baselineExp,
+		},
+		Instruments: []string{"timing"},
+		Author:      "agent:observer",
+		CreatedAt:   f.now,
+	}
+	if err := f.s.WriteExperiment(e); err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func (f *baselineFixture) writeObservation(t *testing.T, id, expID, instrument string) {
+	t.Helper()
+	o := &entity.Observation{
+		ID:         id,
+		Experiment: expID,
+		Instrument: instrument,
+		MeasuredAt: f.now,
+		Value:      100,
+		Samples:    3,
+		PerSample:  []float64{100, 101, 99},
+		Unit:       "ns",
+		Author:     "agent:observer",
+	}
+	if err := f.s.WriteObservation(o); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *baselineFixture) writeConclusion(t *testing.T, id, hypID, candidateExp string, reviewed bool) {
+	t.Helper()
+	c := &entity.Conclusion{
+		ID:           id,
+		Hypothesis:   hypID,
+		Verdict:      entity.VerdictSupported,
+		Observations: []string{"O-" + id},
+		CandidateExp: candidateExp,
+		Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.1},
+		StatTest:     "mann_whitney_u",
+		Author:       "agent:analyst",
+		CreatedAt:    f.now,
+	}
+	if reviewed {
+		c.ReviewedBy = "human:gate"
+	}
+	if err := f.s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *baselineFixture) appendBaselineEvent(t *testing.T, expID, goalID string) {
+	t.Helper()
+	data, err := json.Marshal(map[string]any{"goal": goalID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := f.s.AppendEvent(store.Event{
+		Ts:      f.now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: expID,
+		Data:    data,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestResolveInferredBaseline_UsesCandidateRecordedWhenUsable(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+	parent := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	current := f.writeHypothesis(t, "H-0002", "G-0001", parent.ID)
+
+	goalBaseline := f.writeExperiment(t, "E-0001", "", "", true)
+	f.writeObservation(t, "O-0001", goalBaseline.ID, "timing")
+	f.appendBaselineEvent(t, goalBaseline.ID, "G-0001")
+
+	ancestorExp := f.writeExperiment(t, "E-0002", parent.ID, "", false)
+	f.writeObservation(t, "O-0002", ancestorExp.ID, "timing")
+	f.writeConclusion(t, "C-0001", parent.ID, ancestorExp.ID, true)
+
+	recorded := f.writeExperiment(t, "E-0003", "", "", true)
+	f.writeObservation(t, "O-0003", recorded.ID, "timing")
+
+	candidate := f.writeExperiment(t, "E-0004", current.ID, recorded.ID, false)
+
+	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ResolveInferredBaseline returned nil result")
+	}
+	if got.ExperimentID != recorded.ID {
+		t.Fatalf("experiment = %q, want %q", got.ExperimentID, recorded.ID)
+	}
+	if got.Source != BaselineSourceCandidateRecorded {
+		t.Fatalf("source = %q, want %q", got.Source, BaselineSourceCandidateRecorded)
+	}
+}
+
+func TestResolveInferredBaseline_PrefersNearestAcceptedSupportedAncestor(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+
+	root := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	mid := f.writeHypothesis(t, "H-0002", "G-0001", root.ID)
+	current := f.writeHypothesis(t, "H-0003", "G-0001", mid.ID)
+
+	rootExp := f.writeExperiment(t, "E-0001", root.ID, "", false)
+	midExp := f.writeExperiment(t, "E-0002", mid.ID, "", false)
+	f.writeObservation(t, "O-0001", rootExp.ID, "timing")
+	f.writeObservation(t, "O-0002", midExp.ID, "timing")
+	f.writeConclusion(t, "C-0001", root.ID, rootExp.ID, true)
+	f.writeConclusion(t, "C-0002", mid.ID, midExp.ID, true)
+
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+
+	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ResolveInferredBaseline returned nil result")
+	}
+	if got.ExperimentID != midExp.ID {
+		t.Fatalf("experiment = %q, want %q", got.ExperimentID, midExp.ID)
+	}
+	if got.Source != BaselineSourceAncestorSupported {
+		t.Fatalf("source = %q, want %q", got.Source, BaselineSourceAncestorSupported)
+	}
+	if got.AncestorHypothesis != mid.ID {
+		t.Fatalf("ancestor hypothesis = %q, want %q", got.AncestorHypothesis, mid.ID)
+	}
+	if got.AncestorConclusion != "C-0002" {
+		t.Fatalf("ancestor conclusion = %q, want %q", got.AncestorConclusion, "C-0002")
+	}
+}
+
+func TestResolveInferredBaseline_UsesGoalScopedBaselineMapping(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+	f.writeGoal(t, "G-0002")
+
+	otherBase := f.writeExperiment(t, "E-0001", "", "", true)
+	wantBase := f.writeExperiment(t, "E-0002", "", "", true)
+	f.writeObservation(t, "O-0001", otherBase.ID, "timing")
+	f.writeObservation(t, "O-0002", wantBase.ID, "timing")
+	f.appendBaselineEvent(t, otherBase.ID, "G-0001")
+	f.appendBaselineEvent(t, wantBase.ID, "G-0002")
+
+	current := f.writeHypothesis(t, "H-0001", "G-0002", "")
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+
+	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ResolveInferredBaseline returned nil result")
+	}
+	if got.ExperimentID != wantBase.ID {
+		t.Fatalf("experiment = %q, want %q", got.ExperimentID, wantBase.ID)
+	}
+	if got.Source != BaselineSourceGoalBaseline {
+		t.Fatalf("source = %q, want %q", got.Source, BaselineSourceGoalBaseline)
+	}
+}
+
+func TestResolveInferredBaseline_ErrorsOnAmbiguousGoalBaseline(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+
+	baseA := f.writeExperiment(t, "E-0001", "", "", true)
+	baseB := f.writeExperiment(t, "E-0002", "", "", true)
+	f.writeObservation(t, "O-0001", baseA.ID, "timing")
+	f.writeObservation(t, "O-0002", baseB.ID, "timing")
+	f.appendBaselineEvent(t, baseA.ID, "G-0001")
+	f.appendBaselineEvent(t, baseB.ID, "G-0001")
+
+	current := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+
+	_, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err == nil {
+		t.Fatal("ResolveInferredBaseline unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "multiple baseline experiments") {
+		t.Fatalf("error = %q, want multiple baseline experiments", err)
+	}
+}


### PR DESCRIPTION
## Summary
- resolve inferred conclude baselines by preferring a usable recorded baseline, then the nearest accepted supported ancestor, then the goal-scoped baseline
- ignore and surface off-instrument observation ids in conclude output, store only the actual used observations, and audit the candidate/baseline resolution path in text, JSON, and events
- keep explicit --baseline-experiment strict, add regressions for ambiguity and fallback behavior, and update the agent-facing docs

## Testing
- make test

Fixes #39