### PR TITLE
Persist experiment goal provenance

### DIFF
--- a/internal/cli/conclude_test.go
+++ b/internal/cli/conclude_test.go
@@ -80,6 +80,7 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 
 	goalBaseline := &entity.Experiment{
 		ID:         "E-0001",
+		GoalID:     goal.ID,
 		IsBaseline: true,
 		Status:     entity.ExpMeasured,
 		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
@@ -120,6 +121,7 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 	}
 	ancestorExp := &entity.Experiment{
 		ID:         "E-0002",
+		GoalID:     goal.ID,
 		Hypothesis: ancestorHyp.ID,
 		Status:     entity.ExpMeasured,
 		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
@@ -131,6 +133,7 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 	}
 	candidateExp := &entity.Experiment{
 		ID:         "E-0003",
+		GoalID:     goal.ID,
 		Hypothesis: currentHyp.ID,
 		Status:     entity.ExpMeasured,
 		Baseline: entity.Baseline{

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -80,6 +80,7 @@ func experimentDesignCmd() *cobra.Command {
 			}
 
 			e := &entity.Experiment{
+				GoalID:      h.GoalID,
 				Hypothesis:  hypID,
 				Status:      entity.ExpDesigned,
 				Baseline:    entity.Baseline{Ref: baseline},
@@ -346,6 +347,7 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 			}
 
 			e := &entity.Experiment{
+				GoalID:      goal.ID,
 				IsBaseline:  true,
 				Status:      entity.ExpDesigned,
 				Baseline:    entity.Baseline{Ref: baseline, SHA: sha},
@@ -549,6 +551,9 @@ func experimentShowCmd() *cobra.Command {
 				return w.JSON(view)
 			}
 			w.Textf("id:             %s\n", view.ID)
+			if view.GoalID != "" {
+				w.Textf("goal:           %s\n", view.GoalID)
+			}
 			w.Textf("hypothesis:     %s\n", view.Hypothesis)
 			w.Textf("status:         %s\n", view.Status)
 			w.Textf("classification: %s\n", experimentClassificationSummary(view.Classification, view.HypothesisStatus))

--- a/internal/cli/log.go
+++ b/internal/cli/log.go
@@ -170,9 +170,9 @@ func writeEventLine(w io.Writer, e store.Event) {
 	)
 }
 
-// newFollowEventFilter recreates the scope resolver per streamed event so
-// baseline ownership picks up experiment.baseline events appended after
-// `log --follow` starts.
+// newFollowEventFilter recreates the scope resolver per streamed event so it
+// always scopes against the latest on-disk entity provenance for newly-added
+// experiments, observations, and conclusions.
 func newFollowEventFilter(s *store.Store, scope goalScope, keep func(store.Event) bool) func(store.Event) bool {
 	if scope.All {
 		return keep

--- a/internal/cli/log_test.go
+++ b/internal/cli/log_test.go
@@ -21,6 +21,7 @@ func TestNewFollowEventFilter_RefreshesBaselineGoalScope(t *testing.T) {
 	now := time.Now().UTC()
 	baseline := &entity.Experiment{
 		ID:          "E-0004",
+		GoalID:      "G-0001",
 		IsBaseline:  true,
 		Status:      entity.ExpMeasured,
 		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "ghi789"},
@@ -37,7 +38,7 @@ func TestNewFollowEventFilter_RefreshesBaselineGoalScope(t *testing.T) {
 		Kind:    "experiment.baseline",
 		Actor:   "system",
 		Subject: baseline.ID,
-		Data:    jsonRaw(map[string]any{"goal": "G-0001"}),
+		Data:    jsonRaw(map[string]any{"note": "goal provenance now lives on the experiment entity"}),
 	}
 	if err := s.AppendEvent(baselineEvent); err != nil {
 		t.Fatal(err)

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -201,6 +201,9 @@ func renderReportMarkdown(r *reportData) string {
 		for _, blk := range r.Experiments {
 			e := blk.Experiment
 			fmt.Fprintf(&sb, "### %s — %s\n\n", e.ID, e.Status)
+			if e.GoalID != "" {
+				fmt.Fprintf(&sb, "- **Goal**: %s\n", e.GoalID)
+			}
 			fmt.Fprintf(&sb, "- **Baseline**: `%s`", e.Baseline.Ref)
 			if e.Baseline.SHA != "" {
 				fmt.Fprintf(&sb, " at `%s`", shortSHA(e.Baseline.SHA))

--- a/internal/cli/scope.go
+++ b/internal/cli/scope.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -84,12 +83,6 @@ type goalScopeResolver struct {
 	expGoals       map[string]string
 	conclusionMap  map[string]string
 	observationMap map[string]string
-
-	eventsLoaded bool
-	events       []store.Event
-
-	baselineLoaded bool
-	baselineGoals  map[string]string
 }
 
 func newGoalScopeResolver(s *store.Store, scope goalScope) *goalScopeResolver {
@@ -100,7 +93,6 @@ func newGoalScopeResolver(s *store.Store, scope goalScope) *goalScopeResolver {
 		expGoals:       map[string]string{},
 		conclusionMap:  map[string]string{},
 		observationMap: map[string]string{},
-		baselineGoals:  map[string]string{},
 	}
 }
 
@@ -130,45 +122,6 @@ func (r *goalScopeResolver) hypothesisGoal(id string) (string, error) {
 	return h.GoalID, nil
 }
 
-func (r *goalScopeResolver) ensureEvents() error {
-	if r.eventsLoaded {
-		return nil
-	}
-	all, err := r.store.Events(0)
-	if err != nil {
-		return err
-	}
-	r.events = all
-	r.eventsLoaded = true
-	return nil
-}
-
-func (r *goalScopeResolver) ensureBaselineGoals() error {
-	if r.baselineLoaded {
-		return nil
-	}
-	if err := r.ensureEvents(); err != nil {
-		return err
-	}
-	type baselinePayload struct {
-		Goal string `json:"goal"`
-	}
-	for _, ev := range r.events {
-		if ev.Kind != "experiment.baseline" || ev.Subject == "" {
-			continue
-		}
-		var payload baselinePayload
-		if err := json.Unmarshal(ev.Data, &payload); err != nil {
-			continue
-		}
-		if payload.Goal != "" {
-			r.baselineGoals[ev.Subject] = payload.Goal
-		}
-	}
-	r.baselineLoaded = true
-	return nil
-}
-
 func (r *goalScopeResolver) experimentGoal(id string) (string, error) {
 	if id == "" {
 		return "", nil
@@ -184,6 +137,10 @@ func (r *goalScopeResolver) experimentGoal(id string) (string, error) {
 		}
 		return "", err
 	}
+	if e.GoalID != "" {
+		r.expGoals[id] = e.GoalID
+		return e.GoalID, nil
+	}
 	if e.Hypothesis != "" {
 		gid, err := r.hypothesisGoal(e.Hypothesis)
 		if err != nil {
@@ -192,12 +149,8 @@ func (r *goalScopeResolver) experimentGoal(id string) (string, error) {
 		r.expGoals[id] = gid
 		return gid, nil
 	}
-	if err := r.ensureBaselineGoals(); err != nil {
-		return "", err
-	}
-	gid := r.baselineGoals[id]
-	r.expGoals[id] = gid
-	return gid, nil
+	r.expGoals[id] = ""
+	return "", nil
 }
 
 func (r *goalScopeResolver) conclusionGoal(id string) (string, error) {

--- a/internal/cli/scope_test.go
+++ b/internal/cli/scope_test.go
@@ -65,19 +65,19 @@ func scopedFixtureStore(t *testing.T) *store.Store {
 	}
 
 	base := &entity.Experiment{
-		ID: "E-0001", IsBaseline: true, Status: entity.ExpMeasured,
+		ID: "E-0001", GoalID: g1.ID, IsBaseline: true, Status: entity.ExpMeasured,
 		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
 		Instruments: []string{"host_timing"},
 		Author:      "system", CreatedAt: now,
 	}
 	e1 := &entity.Experiment{
-		ID: "E-0002", Hypothesis: h1.ID, Status: entity.ExpMeasured,
+		ID: "E-0002", GoalID: g1.ID, Hypothesis: h1.ID, Status: entity.ExpMeasured,
 		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
 		Instruments: []string{"host_timing"},
 		Author:      "system", CreatedAt: now,
 	}
 	e2 := &entity.Experiment{
-		ID: "E-0003", Hypothesis: h2.ID, Status: entity.ExpMeasured,
+		ID: "E-0003", GoalID: g2.ID, Hypothesis: h2.ID, Status: entity.ExpMeasured,
 		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "def456"},
 		Instruments: []string{"qemu_cycles"},
 		Author:      "system", CreatedAt: now,
@@ -138,7 +138,7 @@ func scopedFixtureStore(t *testing.T) *store.Store {
 		{Ts: now, Kind: "goal.new", Actor: "human", Subject: g2.ID},
 		{Ts: now, Kind: "hypothesis.add", Actor: "human", Subject: h1.ID},
 		{Ts: now, Kind: "hypothesis.add", Actor: "human", Subject: h2.ID},
-		{Ts: now, Kind: "experiment.baseline", Actor: "system", Subject: base.ID, Data: jsonRaw(map[string]any{"goal": g1.ID})},
+		{Ts: now, Kind: "experiment.baseline", Actor: "system", Subject: base.ID, Data: jsonRaw(map[string]any{"note": "legacy payload ignored once experiment.goal_id is present"})},
 		{Ts: now, Kind: "observation.record", Actor: "system", Subject: "O-0001"},
 		{Ts: now, Kind: "lesson.add", Actor: "agent:analyst", Subject: l1.ID},
 		{Ts: now, Kind: "lesson.add", Actor: "agent:analyst", Subject: l2.ID},

--- a/internal/entity/experiment.go
+++ b/internal/entity/experiment.go
@@ -16,17 +16,23 @@ const (
 )
 
 type Experiment struct {
-	ID                    string    `yaml:"id"                                  json:"id"`
-	Hypothesis            string    `yaml:"hypothesis"                          json:"hypothesis"`
-	IsBaseline            bool      `yaml:"is_baseline,omitempty"               json:"is_baseline,omitempty"`
-	Status                string    `yaml:"status"                              json:"status"`
-	Baseline              Baseline  `yaml:"baseline"                            json:"baseline"`
-	Instruments           []string  `yaml:"instruments"                         json:"instruments"`
-	Worktree              string    `yaml:"worktree,omitempty"                  json:"worktree,omitempty"`
-	Branch                string    `yaml:"branch,omitempty"                    json:"branch,omitempty"`
-	Budget                Budget    `yaml:"budget,omitempty"                    json:"budget,omitempty"`
-	Author                string    `yaml:"author"                              json:"author"`
-	CreatedAt             time.Time `yaml:"created_at"                          json:"created_at"`
+	ID string `yaml:"id"                                  json:"id"`
+	// GoalID is durable goal provenance for the experiment. For baseline
+	// experiments it is the only ownership link; for hypothesis-backed
+	// experiments it denormalizes the parent hypothesis's GoalID so read
+	// surfaces can scope experiments without replaying history or joining
+	// through hypotheses on every path.
+	GoalID      string    `yaml:"goal_id,omitempty"                   json:"goal_id,omitempty"`
+	Hypothesis  string    `yaml:"hypothesis"                          json:"hypothesis"`
+	IsBaseline  bool      `yaml:"is_baseline,omitempty"               json:"is_baseline,omitempty"`
+	Status      string    `yaml:"status"                              json:"status"`
+	Baseline    Baseline  `yaml:"baseline"                            json:"baseline"`
+	Instruments []string  `yaml:"instruments"                         json:"instruments"`
+	Worktree    string    `yaml:"worktree,omitempty"                  json:"worktree,omitempty"`
+	Branch      string    `yaml:"branch,omitempty"                    json:"branch,omitempty"`
+	Budget      Budget    `yaml:"budget,omitempty"                    json:"budget,omitempty"`
+	Author      string    `yaml:"author"                              json:"author"`
+	CreatedAt   time.Time `yaml:"created_at"                          json:"created_at"`
 	// ReferencedAsBaselineBy lists conclusion IDs that used this experiment
 	// as a baseline. Populated by `conclude` when it writes a new
 	// conclusion. Non-empty → this experiment has finished its job as a

--- a/internal/entity/experiment_test.go
+++ b/internal/entity/experiment_test.go
@@ -10,6 +10,7 @@ import (
 func TestExperimentRoundTrip(t *testing.T) {
 	e := &entity.Experiment{
 		ID:         "E-0001",
+		GoalID:     "G-0001",
 		Hypothesis: "H-0001",
 		Status:     entity.ExpDesigned,
 		Baseline: entity.Baseline{
@@ -36,6 +37,9 @@ func TestExperimentRoundTrip(t *testing.T) {
 	}
 	if back.ID != "E-0001" || back.Hypothesis != "H-0001" {
 		t.Errorf("round trip mismatch: %+v", back)
+	}
+	if back.GoalID != "G-0001" {
+		t.Errorf("goal_id round-trip: got %q, want G-0001", back.GoalID)
 	}
 	if len(back.Instruments) != 3 {
 		t.Errorf("instruments: got %d, want 3", len(back.Instruments))

--- a/internal/firewall/validators.go
+++ b/internal/firewall/validators.go
@@ -135,6 +135,9 @@ func validateGoalRescuers(g *entity.Goal, cfg *store.Config) error {
 }
 
 func ValidateExperiment(e *entity.Experiment, cfg *store.Config) error {
+	if strings.TrimSpace(e.GoalID) == "" {
+		return errors.New("experiment must record goal_id provenance")
+	}
 	if !e.IsBaseline && strings.TrimSpace(e.Hypothesis) == "" {
 		return errors.New("experiment must reference a hypothesis")
 	}

--- a/internal/firewall/validators_test.go
+++ b/internal/firewall/validators_test.go
@@ -162,6 +162,7 @@ func TestValidateHypothesis_NoKillIf(t *testing.T) {
 
 func TestValidateExperiment_Happy(t *testing.T) {
 	e := &entity.Experiment{
+		GoalID:      "G-0001",
 		Hypothesis:  "H-0001",
 		Instruments: []string{"qemu_cycles"},
 		Baseline:    entity.Baseline{Ref: "HEAD"},
@@ -173,6 +174,7 @@ func TestValidateExperiment_Happy(t *testing.T) {
 
 func TestValidateExperiment_UnregisteredInstrument(t *testing.T) {
 	e := &entity.Experiment{
+		GoalID:      "G-0001",
 		Hypothesis:  "H-0001",
 		Instruments: []string{"ghost_instrument"},
 		Baseline:    entity.Baseline{Ref: "HEAD"},

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -1,7 +1,6 @@
 package readmodel
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
@@ -203,31 +202,24 @@ func resolveGoalBaseline(s *store.Store, goalID, instrument string, obsByExp map
 }
 
 func goalBaselineExperimentIDs(s *store.Store, goalID string) ([]string, error) {
-	events, err := s.Events(0)
+	exps, err := s.ListExperiments()
 	if err != nil {
 		return nil, err
 	}
-	type baselinePayload struct {
-		Goal string `json:"goal"`
-	}
 	var ids []string
 	seen := map[string]struct{}{}
-	for _, ev := range events {
-		if ev.Kind != "experiment.baseline" || strings.TrimSpace(ev.Subject) == "" {
+	for _, e := range exps {
+		if e == nil || !e.IsBaseline || strings.TrimSpace(e.GoalID) == "" {
 			continue
 		}
-		var payload baselinePayload
-		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+		if e.GoalID != goalID {
 			continue
 		}
-		if payload.Goal != goalID {
+		if _, dup := seen[e.ID]; dup {
 			continue
 		}
-		if _, dup := seen[ev.Subject]; dup {
-			continue
-		}
-		seen[ev.Subject] = struct{}{}
-		ids = append(ids, ev.Subject)
+		seen[e.ID] = struct{}{}
+		ids = append(ids, e.ID)
 	}
 	return ids, nil
 }

--- a/internal/readmodel/baseline_test.go
+++ b/internal/readmodel/baseline_test.go
@@ -69,10 +69,18 @@ func (f *baselineFixture) writeHypothesis(t *testing.T, id, goalID, parent strin
 	return h
 }
 
-func (f *baselineFixture) writeExperiment(t *testing.T, id, hypID, baselineExp string, isBaseline bool) *entity.Experiment {
+func (f *baselineFixture) writeExperiment(t *testing.T, id, hypID, goalID, baselineExp string, isBaseline bool) *entity.Experiment {
 	t.Helper()
+	if goalID == "" && hypID != "" {
+		h, err := f.s.ReadHypothesis(hypID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		goalID = h.GoalID
+	}
 	e := &entity.Experiment{
 		ID:         id,
+		GoalID:     goalID,
 		Hypothesis: hypID,
 		IsBaseline: isBaseline,
 		Status:     entity.ExpMeasured,
@@ -153,18 +161,17 @@ func TestResolveInferredBaseline_UsesCandidateRecordedWhenUsable(t *testing.T) {
 	parent := f.writeHypothesis(t, "H-0001", "G-0001", "")
 	current := f.writeHypothesis(t, "H-0002", "G-0001", parent.ID)
 
-	goalBaseline := f.writeExperiment(t, "E-0001", "", "", true)
+	goalBaseline := f.writeExperiment(t, "E-0001", "", "G-0001", "", true)
 	f.writeObservation(t, "O-0001", goalBaseline.ID, "timing")
-	f.appendBaselineEvent(t, goalBaseline.ID, "G-0001")
 
-	ancestorExp := f.writeExperiment(t, "E-0002", parent.ID, "", false)
+	ancestorExp := f.writeExperiment(t, "E-0002", parent.ID, "", "", false)
 	f.writeObservation(t, "O-0002", ancestorExp.ID, "timing")
 	f.writeConclusion(t, "C-0001", parent.ID, ancestorExp.ID, true)
 
-	recorded := f.writeExperiment(t, "E-0003", "", "", true)
+	recorded := f.writeExperiment(t, "E-0003", "", "G-0001", "", true)
 	f.writeObservation(t, "O-0003", recorded.ID, "timing")
 
-	candidate := f.writeExperiment(t, "E-0004", current.ID, recorded.ID, false)
+	candidate := f.writeExperiment(t, "E-0004", current.ID, "", recorded.ID, false)
 
 	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
 	if err != nil {
@@ -189,14 +196,14 @@ func TestResolveInferredBaseline_PrefersNearestAcceptedSupportedAncestor(t *test
 	mid := f.writeHypothesis(t, "H-0002", "G-0001", root.ID)
 	current := f.writeHypothesis(t, "H-0003", "G-0001", mid.ID)
 
-	rootExp := f.writeExperiment(t, "E-0001", root.ID, "", false)
-	midExp := f.writeExperiment(t, "E-0002", mid.ID, "", false)
+	rootExp := f.writeExperiment(t, "E-0001", root.ID, "", "", false)
+	midExp := f.writeExperiment(t, "E-0002", mid.ID, "", "", false)
 	f.writeObservation(t, "O-0001", rootExp.ID, "timing")
 	f.writeObservation(t, "O-0002", midExp.ID, "timing")
 	f.writeConclusion(t, "C-0001", root.ID, rootExp.ID, true)
 	f.writeConclusion(t, "C-0002", mid.ID, midExp.ID, true)
 
-	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", "", false)
 
 	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
 	if err != nil {
@@ -226,13 +233,13 @@ func TestResolveInferredBaseline_DedupesSupportedConclusionsOnSameAncestorExperi
 	parent := f.writeHypothesis(t, "H-0001", "G-0001", "")
 	current := f.writeHypothesis(t, "H-0002", "G-0001", parent.ID)
 
-	ancestorExp := f.writeExperiment(t, "E-0001", parent.ID, "", false)
+	ancestorExp := f.writeExperiment(t, "E-0001", parent.ID, "", "", false)
 	f.writeObservation(t, "O-0001", ancestorExp.ID, "timing")
 	f.writeConclusion(t, "C-0001", parent.ID, ancestorExp.ID, true)
 	f.now = f.now.Add(time.Minute)
 	f.writeConclusion(t, "C-0002", parent.ID, ancestorExp.ID, true)
 
-	candidate := f.writeExperiment(t, "E-0002", current.ID, "", false)
+	candidate := f.writeExperiment(t, "E-0002", current.ID, "", "", false)
 
 	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
 	if err != nil {
@@ -257,15 +264,13 @@ func TestResolveInferredBaseline_UsesGoalScopedBaselineMapping(t *testing.T) {
 	f.writeGoal(t, "G-0001")
 	f.writeGoal(t, "G-0002")
 
-	otherBase := f.writeExperiment(t, "E-0001", "", "", true)
-	wantBase := f.writeExperiment(t, "E-0002", "", "", true)
+	otherBase := f.writeExperiment(t, "E-0001", "", "G-0001", "", true)
+	wantBase := f.writeExperiment(t, "E-0002", "", "G-0002", "", true)
 	f.writeObservation(t, "O-0001", otherBase.ID, "timing")
 	f.writeObservation(t, "O-0002", wantBase.ID, "timing")
-	f.appendBaselineEvent(t, otherBase.ID, "G-0001")
-	f.appendBaselineEvent(t, wantBase.ID, "G-0002")
 
 	current := f.writeHypothesis(t, "H-0001", "G-0002", "")
-	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", "", false)
 
 	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
 	if err != nil {
@@ -286,15 +291,13 @@ func TestResolveInferredBaseline_ErrorsOnAmbiguousGoalBaseline(t *testing.T) {
 	f := newBaselineFixture(t)
 	f.writeGoal(t, "G-0001")
 
-	baseA := f.writeExperiment(t, "E-0001", "", "", true)
-	baseB := f.writeExperiment(t, "E-0002", "", "", true)
+	baseA := f.writeExperiment(t, "E-0001", "", "G-0001", "", true)
+	baseB := f.writeExperiment(t, "E-0002", "", "G-0001", "", true)
 	f.writeObservation(t, "O-0001", baseA.ID, "timing")
 	f.writeObservation(t, "O-0002", baseB.ID, "timing")
-	f.appendBaselineEvent(t, baseA.ID, "G-0001")
-	f.appendBaselineEvent(t, baseB.ID, "G-0001")
 
 	current := f.writeHypothesis(t, "H-0001", "G-0001", "")
-	candidate := f.writeExperiment(t, "E-0003", current.ID, "", false)
+	candidate := f.writeExperiment(t, "E-0003", current.ID, "", "", false)
 
 	_, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
 	if err == nil {
@@ -309,7 +312,7 @@ func TestResolveInferredBaseline_PropagatesObservationReadErrors(t *testing.T) {
 	f := newBaselineFixture(t)
 	f.writeGoal(t, "G-0001")
 	current := f.writeHypothesis(t, "H-0001", "G-0001", "")
-	candidate := f.writeExperiment(t, "E-0001", current.ID, "", false)
+	candidate := f.writeExperiment(t, "E-0001", current.ID, "", "", false)
 
 	badPath := filepath.Join(f.s.ObservationsDir(), "O-9999.json")
 	if err := os.WriteFile(badPath, []byte("{not json"), 0o644); err != nil {

--- a/internal/store/migrate.go
+++ b/internal/store/migrate.go
@@ -27,8 +27,8 @@ func (s *Store) migrateV1ToV2() error {
 	if errors.Is(err, os.ErrNotExist) {
 		// No legacy goal. Still make sure schema_version is recorded.
 		return s.UpdateState(func(st *State) error {
-			if st.SchemaVersion < StateSchemaVersion {
-				st.SchemaVersion = StateSchemaVersion
+			if st.SchemaVersion < 2 {
+				st.SchemaVersion = 2
 			}
 			return nil
 		})
@@ -76,7 +76,7 @@ func (s *Store) migrateV1ToV2() error {
 
 	if err := s.UpdateState(func(st *State) error {
 		st.CurrentGoalID = newID
-		st.SchemaVersion = StateSchemaVersion
+		st.SchemaVersion = 2
 		if st.Counters == nil {
 			st.Counters = map[string]int{}
 		}
@@ -104,6 +104,147 @@ func (s *Store) migrateV1ToV2() error {
 	})
 }
 
+// migrateV2ToV3 backfills durable experiment.goal_id provenance:
+// hypothesis-backed experiments inherit it from their hypothesis, and legacy
+// baseline experiments get it from their historical experiment.baseline event.
+func (s *Store) migrateV2ToV3() error {
+	exps, err := s.ListExperiments()
+	if err != nil {
+		return fmt.Errorf("list experiments for migration: %w", err)
+	}
+	hyps, err := s.ListHypotheses()
+	if err != nil {
+		return fmt.Errorf("list hypotheses for migration: %w", err)
+	}
+
+	hypGoal := make(map[string]string, len(hyps))
+	for _, h := range hyps {
+		if h == nil {
+			continue
+		}
+		hypGoal[h.ID] = h.GoalID
+	}
+
+	needBaselineBackfill := map[string]struct{}{}
+	type goalBackfill struct {
+		ID     string
+		GoalID string
+		Source string
+	}
+	var backfilled []goalBackfill
+	var (
+		stampedHypothesis int
+		stampedBaseline   int
+	)
+	for _, e := range exps {
+		if e == nil || e.GoalID != "" {
+			continue
+		}
+		switch {
+		case e.Hypothesis != "":
+			gid := hypGoal[e.Hypothesis]
+			if gid == "" {
+				return fmt.Errorf("backfill experiment %s goal_id: hypothesis %s has no goal_id", e.ID, e.Hypothesis)
+			}
+			e.GoalID = gid
+			if err := s.WriteExperiment(e); err != nil {
+				return fmt.Errorf("write experiment %s during migration: %w", e.ID, err)
+			}
+			backfilled = append(backfilled, goalBackfill{ID: e.ID, GoalID: gid, Source: "hypothesis"})
+			stampedHypothesis++
+		case e.IsBaseline:
+			needBaselineBackfill[e.ID] = struct{}{}
+		}
+	}
+
+	if len(needBaselineBackfill) > 0 {
+		legacyGoals, err := s.legacyBaselineGoalMap(needBaselineBackfill)
+		if err != nil {
+			return fmt.Errorf("backfill baseline goal ownership: %w", err)
+		}
+		for _, e := range exps {
+			if e == nil {
+				continue
+			}
+			if _, ok := needBaselineBackfill[e.ID]; !ok {
+				continue
+			}
+			gid := legacyGoals[e.ID]
+			if gid == "" {
+				return fmt.Errorf("backfill experiment %s goal_id: no experiment.baseline ownership event found", e.ID)
+			}
+			e.GoalID = gid
+			if err := s.WriteExperiment(e); err != nil {
+				return fmt.Errorf("write baseline experiment %s during migration: %w", e.ID, err)
+			}
+			backfilled = append(backfilled, goalBackfill{ID: e.ID, GoalID: gid, Source: "legacy_baseline_event"})
+			stampedBaseline++
+		}
+	}
+
+	if err := s.UpdateState(func(st *State) error {
+		if st.SchemaVersion < 3 {
+			st.SchemaVersion = 3
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("update state for experiment goal_id migration: %w", err)
+	}
+
+	if stampedHypothesis == 0 && stampedBaseline == 0 {
+		return nil
+	}
+	for _, bf := range backfilled {
+		payload, _ := json.Marshal(map[string]any{
+			"goal_id": bf.GoalID,
+			"source":  bf.Source,
+		})
+		if err := s.AppendEvent(Event{
+			Kind:    "experiment.goal_backfilled",
+			Actor:   "system",
+			Subject: bf.ID,
+			Data:    payload,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) legacyBaselineGoalMap(needed map[string]struct{}) (map[string]string, error) {
+	out := map[string]string{}
+	if len(needed) == 0 {
+		return out, nil
+	}
+	events, err := s.Events(0)
+	if err != nil {
+		return nil, err
+	}
+	type baselinePayload struct {
+		Goal string `json:"goal"`
+	}
+	for _, ev := range events {
+		if ev.Kind != "experiment.baseline" {
+			continue
+		}
+		if _, ok := needed[ev.Subject]; !ok {
+			continue
+		}
+		var payload baselinePayload
+		if err := json.Unmarshal(ev.Data, &payload); err != nil {
+			return nil, fmt.Errorf("decode experiment.baseline payload for %s: %w", ev.Subject, err)
+		}
+		if payload.Goal == "" {
+			return nil, fmt.Errorf("experiment.baseline event for %s is missing goal ownership", ev.Subject)
+		}
+		if prev, dup := out[ev.Subject]; dup && prev != payload.Goal {
+			return nil, fmt.Errorf("conflicting experiment.baseline goal ownership for %s: %s vs %s", ev.Subject, prev, payload.Goal)
+		}
+		out[ev.Subject] = payload.Goal
+	}
+	return out, nil
+}
+
 // maybeMigrate runs schema upgrades on a freshly-opened store. Callers use
 // it from Open(); Create() skips it because a new store is born at the
 // current schema version.
@@ -118,6 +259,12 @@ func (s *Store) maybeMigrate() error {
 	if st.SchemaVersion < 2 {
 		if err := s.migrateV1ToV2(); err != nil {
 			return fmt.Errorf("migrate v1->v2: %w", err)
+		}
+		st.SchemaVersion = 2
+	}
+	if st.SchemaVersion < 3 {
+		if err := s.migrateV2ToV3(); err != nil {
+			return fmt.Errorf("migrate v2->v3: %w", err)
 		}
 	}
 	return nil

--- a/internal/store/migrate_test.go
+++ b/internal/store/migrate_test.go
@@ -1,0 +1,280 @@
+package store_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func TestOpenMigratesExperimentGoalIDProvenance(t *testing.T) {
+	s, dir := mustCreate(t)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	goal := &entity.Goal{
+		ID:        "G-0001",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "qemu_cycles", Target: "dsp_fir", Direction: "decrease"},
+	}
+	if err := s.WriteGoal(goal); err != nil {
+		t.Fatal(err)
+	}
+
+	h := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    goal.ID,
+		Claim:     "unroll dsp_fir",
+		Status:    entity.StatusOpen,
+		Author:    "human:alice",
+		CreatedAt: now,
+		Predicts: entity.Predicts{
+			Instrument: "qemu_cycles",
+			Target:     "dsp_fir",
+			Direction:  "decrease",
+			MinEffect:  0.1,
+		},
+		KillIf: []string{"flash grows"},
+	}
+	if err := s.WriteHypothesis(h); err != nil {
+		t.Fatal(err)
+	}
+
+	hypExp := &entity.Experiment{
+		ID:         "E-0001",
+		Hypothesis: h.ID,
+		Status:     entity.ExpDesigned,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Author:     "agent:designer",
+		CreatedAt:  now,
+	}
+	if err := s.WriteExperiment(hypExp); err != nil {
+		t.Fatal(err)
+	}
+
+	baseExp := &entity.Experiment{
+		ID:         "E-0002",
+		IsBaseline: true,
+		Status:     entity.ExpMeasured,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Author:     "system",
+		CreatedAt:  now,
+	}
+	if err := s.WriteExperiment(baseExp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AppendEvent(store.Event{
+		Ts:      now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: baseExp.ID,
+		Data:    mustJSONRaw(t, map[string]any{"goal": goal.ID}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateState(func(st *store.State) error {
+		st.SchemaVersion = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("Open after schema downgrade: %v", err)
+	}
+
+	st, err := s2.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.SchemaVersion != store.StateSchemaVersion {
+		t.Fatalf("schema_version after migrate: got %d, want %d", st.SchemaVersion, store.StateSchemaVersion)
+	}
+
+	hypBack, err := s2.ReadExperiment(hypExp.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hypBack.GoalID != goal.ID {
+		t.Fatalf("hypothesis-backed experiment goal_id: got %q, want %q", hypBack.GoalID, goal.ID)
+	}
+
+	baseBack, err := s2.ReadExperiment(baseExp.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if baseBack.GoalID != goal.ID {
+		t.Fatalf("baseline experiment goal_id: got %q, want %q", baseBack.GoalID, goal.ID)
+	}
+
+	events := eventsByKind(t, s2, "experiment.goal_backfilled")
+	if len(events) != 2 {
+		t.Fatalf("goal backfill events: got %d, want 2", len(events))
+	}
+
+	got := map[string]map[string]any{}
+	for _, ev := range events {
+		got[ev.Subject] = decodeEventPayload(t, &ev)
+	}
+	if payload := got[hypExp.ID]; payload == nil {
+		t.Fatalf("missing backfill event for %s", hypExp.ID)
+	} else {
+		if payload["goal_id"] != goal.ID {
+			t.Fatalf("hypothesis event goal_id = %v, want %q", payload["goal_id"], goal.ID)
+		}
+		if payload["source"] != "hypothesis" {
+			t.Fatalf("hypothesis event source = %v, want %q", payload["source"], "hypothesis")
+		}
+	}
+	if payload := got[baseExp.ID]; payload == nil {
+		t.Fatalf("missing backfill event for %s", baseExp.ID)
+	} else {
+		if payload["goal_id"] != goal.ID {
+			t.Fatalf("baseline event goal_id = %v, want %q", payload["goal_id"], goal.ID)
+		}
+		if payload["source"] != "legacy_baseline_event" {
+			t.Fatalf("baseline event source = %v, want %q", payload["source"], "legacy_baseline_event")
+		}
+	}
+}
+
+func TestOpenV2ToV3FailsOnMissingLegacyBaselineGoal(t *testing.T) {
+	s, dir := mustCreate(t)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	baseExp := &entity.Experiment{
+		ID:         "E-0001",
+		IsBaseline: true,
+		Status:     entity.ExpMeasured,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Author:     "system",
+		CreatedAt:  now,
+	}
+	if err := s.WriteExperiment(baseExp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AppendEvent(store.Event{
+		Ts:      now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: baseExp.ID,
+		Data:    mustJSONRaw(t, map[string]any{"baseline": "abc123"}),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateState(func(st *store.State) error {
+		st.SchemaVersion = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := store.Open(dir)
+	if err == nil {
+		t.Fatal("Open should fail when legacy baseline ownership is malformed")
+	}
+	if !strings.Contains(err.Error(), "missing goal ownership") {
+		t.Fatalf("Open error = %v, want missing goal ownership", err)
+	}
+}
+
+func TestOpenV2ToV3IgnoresMalformedLegacyBaselinePayloadWhenGoalIDPresent(t *testing.T) {
+	s, dir := mustCreate(t)
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	baseExp := &entity.Experiment{
+		ID:         "E-0001",
+		GoalID:     "G-0001",
+		IsBaseline: true,
+		Status:     entity.ExpMeasured,
+		Baseline:   entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Author:     "system",
+		CreatedAt:  now,
+	}
+	if err := s.WriteExperiment(baseExp); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AppendEvent(store.Event{
+		Ts:      now,
+		Kind:    "experiment.baseline",
+		Actor:   "system",
+		Subject: baseExp.ID,
+		Data:    json.RawMessage(`123`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateState(func(st *store.State) error {
+		st.SchemaVersion = 2
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s2, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("Open should succeed when durable goal_id makes legacy replay unnecessary: %v", err)
+	}
+
+	st, err := s2.State()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.SchemaVersion != store.StateSchemaVersion {
+		t.Fatalf("schema_version after migrate: got %d, want %d", st.SchemaVersion, store.StateSchemaVersion)
+	}
+
+	back, err := s2.ReadExperiment(baseExp.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if back.GoalID != baseExp.GoalID {
+		t.Fatalf("goal_id after migrate: got %q, want %q", back.GoalID, baseExp.GoalID)
+	}
+
+	if events := eventsByKind(t, s2, "experiment.goal_backfilled"); len(events) != 0 {
+		t.Fatalf("unexpected experiment.goal_backfilled events: %+v", events)
+	}
+}
+
+func mustJSONRaw(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	return data
+}
+
+func eventsByKind(t *testing.T, s *store.Store, kind string) []store.Event {
+	t.Helper()
+	events, err := s.Events(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []store.Event
+	for _, ev := range events {
+		if ev.Kind == kind {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func decodeEventPayload(t *testing.T, e *store.Event) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(e.Data, &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return payload
+}

--- a/internal/store/state.go
+++ b/internal/store/state.go
@@ -10,7 +10,10 @@ import (
 // StateSchemaVersion is the current state.json schema version.
 // v1: single-goal store (.research/goal.md).
 // v2: multi-goal store (.research/goals/G-NNNN.md) + current_goal_id pointer.
-const StateSchemaVersion = 2
+// v3: experiments persist durable goal_id provenance for read-side scoping
+//
+//	and baseline ownership (backfilled for older stores).
+const StateSchemaVersion = 3
 
 type State struct {
 	SchemaVersion     int            `json:"schema_version"`


### PR DESCRIPTION
## Summary
- persist durable experiment goal provenance in the schema via experiment.goal_id
- migrate older stores from schema v2 to v3, backfilling hypothesis-backed and baseline experiments while failing loudly on malformed legacy ownership payloads
- scope baselines from experiment entities instead of replaying baseline events, and surface the goal in experiment/report CLI output

## Testing
- make test

Closes #53