### PR TITLE
observe: add idempotent sampling and check probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ get a new file plus an entry in the `groups` slice in `Root()`.
 - **Read vs. write verbs.** Mutating verbs must check the pause flag via the
   store and return `ErrPaused` (exit 3) when paused. Read-only verbs
   (`status`, `log`, `tree`, `frontier`, `report`, `artifact <read>`,
-  `conclusion show`, `dashboard`, `*-list`, `*-show`) work even when paused.
+  `conclusion show`, `dashboard`, `observe check`, `*-list`, `*-show`) work
+  even when paused.
 - **Read models live in `internal/readmodel/`.** `experiment list/show`,
   `frontier`, `status`, `dashboard`, and the TUI consume shared read-side
   projections from there. Don't re-encode "live/dead", frontier, or

--- a/README.md
+++ b/README.md
@@ -243,9 +243,10 @@ All commands accept `--json` (machine-readable output), `-C/--project-dir`
 is paused.
 
 `observe` is idempotent by default for the current implementation attempt and
-candidate commit: existing samples on that scope satisfy or top up the target
-rather than re-running blindly. Use `observe check` for the cheap probe, and
-`--append` when you intentionally want another fresh run.
+candidate snapshot: existing samples on that scope satisfy or top up the
+target rather than re-running blindly. Dirty worktrees disable reuse until the
+candidate is clean or committed again. Use `observe check` for the cheap
+probe, and `--append` when you intentionally want another fresh run.
 
 | Group | Verbs |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -242,10 +242,10 @@ All commands accept `--json` (machine-readable output), `-C/--project-dir`
 (target project), and `--dry-run`. Read-only verbs work even when the project
 is paused.
 
-`observe` is idempotent by default: existing samples on an
-`(experiment, instrument)` pair satisfy or top up the target rather than
-re-running blindly. Use `observe check` for the cheap probe, and `--append`
-when you intentionally want another fresh run.
+`observe` is idempotent by default for the current implementation attempt and
+candidate commit: existing samples on that scope satisfy or top up the target
+rather than re-running blindly. Use `observe check` for the cheap probe, and
+`--append` when you intentionally want another fresh run.
 
 | Group | Verbs |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -242,6 +242,11 @@ All commands accept `--json` (machine-readable output), `-C/--project-dir`
 (target project), and `--dry-run`. Read-only verbs work even when the project
 is paused.
 
+`observe` is idempotent by default: existing samples on an
+`(experiment, instrument)` pair satisfy or top up the target rather than
+re-running blindly. Use `observe check` for the cheap probe, and `--append`
+when you intentionally want another fresh run.
+
 | Group | Verbs |
 | --- | --- |
 | **lifecycle** | `init`, `status`, `pause`, `resume` |
@@ -249,7 +254,7 @@ is paused.
 | **steering** | `steering show`, `steering append` |
 | **hypothesis** | `add`, `list`, `show`, `promote`, `kill`, `reopen`, `worktree`, `diff`, `apply` |
 | **experiment** | `baseline`, `design`, `implement`, `reset`, `worktree`, `list`, `show` |
-| **observe** | `observe <exp> --instrument <name>`, `observe <exp> --all` |
+| **observe** | `observe check <exp> --instrument <name>`, `observe <exp> --instrument <name> [--append]`, `observe <exp> --all [--append]` |
 | **analyze** | `analyze <exp> [--baseline <exp>]` |
 | **conclude** | `conclude <hyp> --verdict ... --observations ...` |
 | **conclusion** | `list`, `show`, `accept`, `downgrade`, `appeal` |

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -8,7 +8,6 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
 	"github.com/bytter/autoresearch/internal/stats"
-	"github.com/bytter/autoresearch/internal/worktree"
 	"github.com/spf13/cobra"
 )
 
@@ -61,18 +60,14 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 			}
 			if !exp.IsBaseline {
 				if strings.TrimSpace(candidateRef) != "" {
-					ref, err := normalizeAnalyzeCandidateRef(exp, candidateRef)
-					if err != nil {
-						return err
-					}
-					candObs, err = filterAnalyzeObservationsByCandidateRef(candObs, ref)
+					candObs, err = filterAnalyzeObservationsByCandidateRef(candObs, strings.TrimSpace(candidateRef))
 					if err != nil {
 						return fmt.Errorf("experiment %s: %w", expID, err)
 					}
 				} else {
 					if provs := distinctObservationProvenances(candObs); len(provs) > 1 {
 						return fmt.Errorf(
-							"experiment %s has observations for multiple candidate refs/shas (%s); rerun analyze with --candidate-ref <ref>",
+							"experiment %s has observations for multiple candidate scopes (%s); rerun analyze with --candidate-ref <stored-ref>",
 							expID, formatObservationProvenances(provs),
 						)
 					}
@@ -175,30 +170,40 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 }
 
 type observationProvenance struct {
-	Ref string
-	SHA string
-}
-
-func normalizeAnalyzeCandidateRef(exp *entity.Experiment, candidateRef string) (string, error) {
-	ref := strings.TrimSpace(candidateRef)
-	if ref == "" {
-		return "", fmt.Errorf("--candidate-ref is required")
-	}
-	repoDir := exp.Worktree
-	if strings.TrimSpace(repoDir) == "" {
-		repoDir = globalProjectDir
-	}
-	sym, err := worktree.SymbolicFullName(repoDir, ref)
-	if err != nil {
-		return "", fmt.Errorf("resolve candidate ref %q for %s: %w", ref, exp.ID, err)
-	}
-	if !strings.HasPrefix(sym, "refs/") {
-		return "", fmt.Errorf("candidate ref %q is not a named git ref", ref)
-	}
-	return sym, nil
+	Attempt int
+	Ref     string
+	SHA     string
 }
 
 func filterAnalyzeObservationsByCandidateRef(obs []*entity.Observation, candidateRef string) ([]*entity.Observation, error) {
+	if candidateRef == "" {
+		return nil, fmt.Errorf("--candidate-ref is required")
+	}
+	filterRef := candidateRef
+	filtered := filterAnalyzeObservationsByStoredRef(obs, filterRef)
+	if len(filtered) == 0 {
+		resolvedRef, ok, err := resolveAnalyzeCandidateRefFromStoredObservations(obs, candidateRef)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			filterRef = resolvedRef
+			filtered = filterAnalyzeObservationsByStoredRef(obs, filterRef)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("no observations recorded for candidate ref %s (candidate_ref matching is literal; use the stored full ref value)", candidateRef)
+	}
+	if provs := distinctObservationProvenances(filtered); len(provs) > 1 {
+		return nil, fmt.Errorf(
+			"candidate ref %s maps to multiple recorded candidate scopes (%s); use a unique candidate ref per measured candidate",
+			candidateRef, formatObservationProvenances(provs),
+		)
+	}
+	return filtered, nil
+}
+
+func filterAnalyzeObservationsByStoredRef(obs []*entity.Observation, candidateRef string) []*entity.Observation {
 	filtered := make([]*entity.Observation, 0, len(obs))
 	for _, o := range obs {
 		if o == nil {
@@ -208,16 +213,53 @@ func filterAnalyzeObservationsByCandidateRef(obs []*entity.Observation, candidat
 			filtered = append(filtered, o)
 		}
 	}
-	if len(filtered) == 0 {
-		return nil, fmt.Errorf("no observations recorded for candidate ref %s", candidateRef)
+	return filtered
+}
+
+func resolveAnalyzeCandidateRefFromStoredObservations(obs []*entity.Observation, candidateRef string) (string, bool, error) {
+	if strings.HasPrefix(candidateRef, "refs/") {
+		return "", false, nil
 	}
-	if provs := distinctObservationProvenances(filtered); len(provs) > 1 {
-		return nil, fmt.Errorf(
-			"candidate ref %s maps to multiple recorded SHAs (%s); use a unique candidate ref per measured candidate",
-			candidateRef, formatObservationProvenances(provs),
-		)
+	matches := map[string]struct{}{}
+	for _, o := range obs {
+		if o == nil {
+			continue
+		}
+		stored := strings.TrimSpace(o.CandidateRef)
+		if stored == "" || !storedAnalyzeCandidateRefMatches(stored, candidateRef) {
+			continue
+		}
+		matches[stored] = struct{}{}
 	}
-	return filtered, nil
+	switch len(matches) {
+	case 0:
+		return "", false, nil
+	case 1:
+		for stored := range matches {
+			return stored, true, nil
+		}
+	default:
+		var refs []string
+		for stored := range matches {
+			refs = append(refs, stored)
+		}
+		sort.Strings(refs)
+		return "", false, fmt.Errorf("candidate ref %s matches multiple stored refs (%s); use the stored full ref value", candidateRef, strings.Join(refs, ", "))
+	}
+	return "", false, nil
+}
+
+func storedAnalyzeCandidateRefMatches(stored, candidateRef string) bool {
+	if stored == candidateRef {
+		return true
+	}
+	if strings.TrimPrefix(stored, "refs/heads/") == candidateRef {
+		return true
+	}
+	if strings.TrimPrefix(stored, "refs/tags/") == candidateRef {
+		return true
+	}
+	return false
 }
 
 func distinctObservationProvenances(obs []*entity.Observation) []observationProvenance {
@@ -228,8 +270,9 @@ func distinctObservationProvenances(obs []*entity.Observation) []observationProv
 			continue
 		}
 		p := observationProvenance{
-			Ref: strings.TrimSpace(o.CandidateRef),
-			SHA: strings.TrimSpace(o.CandidateSHA),
+			Attempt: o.Attempt,
+			Ref:     strings.TrimSpace(o.CandidateRef),
+			SHA:     strings.TrimSpace(o.CandidateSHA),
 		}
 		if _, ok := seen[p]; ok {
 			continue
@@ -238,6 +281,9 @@ func distinctObservationProvenances(obs []*entity.Observation) []observationProv
 		out = append(out, p)
 	}
 	sort.Slice(out, func(i, j int) bool {
+		if out[i].Attempt != out[j].Attempt {
+			return out[i].Attempt < out[j].Attempt
+		}
 		if out[i].Ref == out[j].Ref {
 			return out[i].SHA < out[j].SHA
 		}
@@ -249,13 +295,19 @@ func distinctObservationProvenances(obs []*entity.Observation) []observationProv
 func formatObservationProvenances(provs []observationProvenance) string {
 	parts := make([]string, 0, len(provs))
 	for _, p := range provs {
+		prefix := ""
+		if p.Attempt > 0 {
+			prefix = fmt.Sprintf("attempt=%d ", p.Attempt)
+		}
 		switch {
 		case p.Ref != "" && p.SHA != "":
-			parts = append(parts, fmt.Sprintf("%s@%s", p.Ref, shortSHA(p.SHA)))
+			parts = append(parts, fmt.Sprintf("%s%s@%s", prefix, p.Ref, shortSHA(p.SHA)))
 		case p.Ref != "":
-			parts = append(parts, p.Ref)
+			parts = append(parts, prefix+p.Ref)
 		case p.SHA != "":
-			parts = append(parts, shortSHA(p.SHA))
+			parts = append(parts, prefix+shortSHA(p.SHA))
+		case prefix != "":
+			parts = append(parts, strings.TrimSpace(prefix))
 		default:
 			parts = append(parts, "(legacy)")
 		}

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
 	"github.com/bytter/autoresearch/internal/stats"
+	"github.com/bytter/autoresearch/internal/worktree"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +18,10 @@ func analyzeCommands() []*cobra.Command {
 
 func analyzeCmd() *cobra.Command {
 	var (
-		baselineExp string
-		instName    string
-		iters       int
+		baselineExp  string
+		instName     string
+		iters        int
+		candidateRef string
 	)
 	c := &cobra.Command{
 		Use:   "analyze <exp-id>",
@@ -31,13 +34,20 @@ the baseline experiment's samples for the same instrument using percentile
 bootstrap (for the delta CI) and Mann–Whitney U (for p-value).
 
 analyze is read-only: no store writes, no state transitions. Use conclude
-to persist a verdict.`,
+to persist a verdict.
+
+For non-baseline experiments that have observations on multiple candidate
+refs, pass --candidate-ref to analyze the specific measured candidate.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
 			expID := args[0]
 
 			s, err := openStore()
+			if err != nil {
+				return err
+			}
+			exp, err := s.ReadExperiment(expID)
 			if err != nil {
 				return err
 			}
@@ -48,6 +58,25 @@ to persist a verdict.`,
 			}
 			if len(candObs) == 0 {
 				return fmt.Errorf("experiment %s has no observations", expID)
+			}
+			if !exp.IsBaseline {
+				if strings.TrimSpace(candidateRef) != "" {
+					ref, err := normalizeAnalyzeCandidateRef(exp, candidateRef)
+					if err != nil {
+						return err
+					}
+					candObs, err = filterAnalyzeObservationsByCandidateRef(candObs, ref)
+					if err != nil {
+						return fmt.Errorf("experiment %s: %w", expID, err)
+					}
+				} else {
+					if provs := distinctObservationProvenances(candObs); len(provs) > 1 {
+						return fmt.Errorf(
+							"experiment %s has observations for multiple candidate refs/shas (%s); rerun analyze with --candidate-ref <ref>",
+							expID, formatObservationProvenances(provs),
+						)
+					}
+				}
 			}
 
 			// Optional baseline.
@@ -141,7 +170,97 @@ to persist a verdict.`,
 	c.Flags().StringVar(&baselineExp, "baseline", "", "baseline experiment id to compare against")
 	c.Flags().StringVar(&instName, "instrument", "", "only analyze this instrument")
 	c.Flags().IntVar(&iters, "iters", 0, "bootstrap iterations (0 uses default 2000)")
+	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "for non-baseline experiments, restrict analysis to observations recorded on this candidate ref")
 	return c
+}
+
+type observationProvenance struct {
+	Ref string
+	SHA string
+}
+
+func normalizeAnalyzeCandidateRef(exp *entity.Experiment, candidateRef string) (string, error) {
+	ref := strings.TrimSpace(candidateRef)
+	if ref == "" {
+		return "", fmt.Errorf("--candidate-ref is required")
+	}
+	repoDir := exp.Worktree
+	if strings.TrimSpace(repoDir) == "" {
+		repoDir = globalProjectDir
+	}
+	sym, err := worktree.SymbolicFullName(repoDir, ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve candidate ref %q for %s: %w", ref, exp.ID, err)
+	}
+	if !strings.HasPrefix(sym, "refs/") {
+		return "", fmt.Errorf("candidate ref %q is not a named git ref", ref)
+	}
+	return sym, nil
+}
+
+func filterAnalyzeObservationsByCandidateRef(obs []*entity.Observation, candidateRef string) ([]*entity.Observation, error) {
+	filtered := make([]*entity.Observation, 0, len(obs))
+	for _, o := range obs {
+		if o == nil {
+			continue
+		}
+		if strings.TrimSpace(o.CandidateRef) == candidateRef {
+			filtered = append(filtered, o)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil, fmt.Errorf("no observations recorded for candidate ref %s", candidateRef)
+	}
+	if provs := distinctObservationProvenances(filtered); len(provs) > 1 {
+		return nil, fmt.Errorf(
+			"candidate ref %s maps to multiple recorded SHAs (%s); use a unique candidate ref per measured candidate",
+			candidateRef, formatObservationProvenances(provs),
+		)
+	}
+	return filtered, nil
+}
+
+func distinctObservationProvenances(obs []*entity.Observation) []observationProvenance {
+	seen := map[observationProvenance]struct{}{}
+	out := make([]observationProvenance, 0)
+	for _, o := range obs {
+		if o == nil {
+			continue
+		}
+		p := observationProvenance{
+			Ref: strings.TrimSpace(o.CandidateRef),
+			SHA: strings.TrimSpace(o.CandidateSHA),
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Ref == out[j].Ref {
+			return out[i].SHA < out[j].SHA
+		}
+		return out[i].Ref < out[j].Ref
+	})
+	return out
+}
+
+func formatObservationProvenances(provs []observationProvenance) string {
+	parts := make([]string, 0, len(provs))
+	for _, p := range provs {
+		switch {
+		case p.Ref != "" && p.SHA != "":
+			parts = append(parts, fmt.Sprintf("%s@%s", p.Ref, shortSHA(p.SHA)))
+		case p.Ref != "":
+			parts = append(parts, p.Ref)
+		case p.SHA != "":
+			parts = append(parts, shortSHA(p.SHA))
+		default:
+			parts = append(parts, "(legacy)")
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 func groupByInstrument(obs []*entity.Observation) map[string][]*entity.Observation {
@@ -173,4 +292,3 @@ func sortedKeys(m map[string][]*entity.Observation) []string {
 	sort.Strings(out)
 	return out
 }
-

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -41,6 +41,7 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
 			expID := args[0]
+			candidateRef = strings.TrimSpace(candidateRef)
 
 			s, err := openStore()
 			if err != nil {
@@ -58,19 +59,23 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 			if len(candObs) == 0 {
 				return fmt.Errorf("experiment %s has no observations", expID)
 			}
-			if !exp.IsBaseline {
-				if strings.TrimSpace(candidateRef) != "" {
-					candObs, err = filterAnalyzeObservationsByCandidateRef(candObs, strings.TrimSpace(candidateRef))
-					if err != nil {
-						return fmt.Errorf("experiment %s: %w", expID, err)
-					}
-				} else {
-					if provs := distinctObservationProvenances(candObs); len(provs) > 1 {
-						return fmt.Errorf(
-							"experiment %s has observations for multiple candidate scopes (%s); rerun analyze with --candidate-ref <stored-ref>",
-							expID, formatObservationProvenances(provs),
-						)
-					}
+			if candidateRef != "" {
+				if exp.IsBaseline {
+					return fmt.Errorf("--candidate-ref is only valid for non-baseline experiments")
+				}
+				candObs, err = filterAnalyzeObservationsByCandidateRef(candObs, candidateRef)
+				if err != nil {
+					return fmt.Errorf("experiment %s: %w", expID, err)
+				}
+			} else {
+				scopeLabel := "recorded scopes"
+				hint := "analyze requires a single recorded scope"
+				if !exp.IsBaseline {
+					scopeLabel = "candidate scopes"
+					hint = "rerun analyze with --candidate-ref <stored-ref>"
+				}
+				if err := ensureAnalyzeObservationsSingleScope("experiment", expID, scopeLabel, candObs, hint); err != nil {
+					return err
 				}
 			}
 
@@ -83,6 +88,15 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 				}
 				if len(baseObs) == 0 {
 					return fmt.Errorf("baseline experiment %s has no observations", baselineExp)
+				}
+				if err := ensureAnalyzeObservationsSingleScope(
+					"baseline experiment",
+					baselineExp,
+					"recorded scopes",
+					baseObs,
+					"analyze requires a baseline experiment with a single recorded scope",
+				); err != nil {
+					return err
 				}
 			}
 
@@ -167,6 +181,16 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 	c.Flags().IntVar(&iters, "iters", 0, "bootstrap iterations (0 uses default 2000)")
 	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "for non-baseline experiments, restrict analysis to observations recorded on this candidate ref")
 	return c
+}
+
+func ensureAnalyzeObservationsSingleScope(subject, expID, scopeLabel string, obs []*entity.Observation, hint string) error {
+	if provs := distinctObservationProvenances(obs); len(provs) > 1 {
+		return fmt.Errorf(
+			"%s %s has observations for multiple %s (%s); %s",
+			subject, expID, scopeLabel, formatObservationProvenances(provs), hint,
+		)
+	}
+	return nil
 }
 
 type observationProvenance struct {

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -1,0 +1,64 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+func TestAnalyzeCandidateRefUsesStoredRefAfterDeletion(t *testing.T) {
+	saveGlobals(t)
+
+	dir := setupObserveScenarioStore(t)
+	registerScenarioInstruments(t, dir)
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+
+	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate a")
+	candidateRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/analyze-deleted-ref")
+	runCLIJSON[observeRecordJSON](t, dir,
+		"observe", scenario.ExpID,
+		"--instrument", "timing",
+		"--candidate-ref", candidateRef,
+	)
+
+	fullRef := "refs/heads/" + candidateRef
+	gitRun(t, scenario.Worktree, "branch", "-D", candidateRef)
+
+	resp := runCLIJSON[cliAnalyzeResponse](t, dir,
+		"analyze", scenario.ExpID,
+		"--candidate-ref", fullRef,
+	)
+	if got, want := len(resp.Rows), 1; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := resp.Rows[0].Instrument, "timing"; got != want {
+		t.Fatalf("instrument = %q, want %q", got, want)
+	}
+}
+
+func TestFilterAnalyzeObservationsByCandidateRef_RejectsMixedAttempts(t *testing.T) {
+	obs := []*entity.Observation{
+		{
+			ID:           "O-0001",
+			Attempt:      1,
+			CandidateRef: "refs/heads/candidate/E-0001-a1",
+			CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
+		},
+		{
+			ID:           "O-0002",
+			Attempt:      2,
+			CandidateRef: "refs/heads/candidate/E-0001-a1",
+			CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
+		},
+	}
+
+	_, err := filterAnalyzeObservationsByCandidateRef(obs, "refs/heads/candidate/E-0001-a1")
+	if err == nil {
+		t.Fatal("filterAnalyzeObservationsByCandidateRef unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "multiple recorded candidate scopes") {
+		t.Fatalf("error = %q, want multiple recorded candidate scopes", err)
+	}
+}

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -3,8 +3,10 @@ package cli
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
 )
 
 func TestAnalyzeCandidateRefUsesStoredRefAfterDeletion(t *testing.T) {
@@ -38,6 +40,62 @@ func TestAnalyzeCandidateRefUsesStoredRefAfterDeletion(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRejectsBaselineExperimentWithMultipleScopes(t *testing.T) {
+	saveGlobals(t)
+
+	dir, baselineID := setupAnalyzeAmbiguousBaseline(t)
+
+	_, _, err := runCLIResult(t, dir, "analyze", baselineID)
+	if err == nil {
+		t.Fatal("analyze baseline unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "experiment "+baselineID+" has observations for multiple recorded scopes") {
+		t.Fatalf("error = %q, want multiple recorded scopes for %s", err, baselineID)
+	}
+}
+
+func TestAnalyzeRejectsAmbiguousBaselineArgument(t *testing.T) {
+	saveGlobals(t)
+
+	dir, baselineID := setupAnalyzeAmbiguousBaseline(t)
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+
+	writeScenarioMetrics(t, impl.Worktree, "90\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "candidate a")
+	candidateRef := gitCreateCandidateRef(t, impl.Worktree, "candidate/analyze-ambiguous-baseline")
+	runCLIJSON[observeRecordJSON](t, dir,
+		"observe", exp.ID,
+		"--instrument", "timing",
+		"--candidate-ref", candidateRef,
+	)
+
+	_, _, err := runCLIResult(t, dir,
+		"analyze", exp.ID,
+		"--candidate-ref", candidateRef,
+		"--baseline", baselineID,
+	)
+	if err == nil {
+		t.Fatal("analyze with ambiguous baseline unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "baseline experiment "+baselineID+" has observations for multiple recorded scopes") {
+		t.Fatalf("error = %q, want ambiguous baseline scope for %s", err, baselineID)
+	}
+}
+
 func TestFilterAnalyzeObservationsByCandidateRef_RejectsMixedAttempts(t *testing.T) {
 	obs := []*entity.Observation{
 		{
@@ -60,5 +118,55 @@ func TestFilterAnalyzeObservationsByCandidateRef_RejectsMixedAttempts(t *testing
 	}
 	if !strings.Contains(err.Error(), "multiple recorded candidate scopes") {
 		t.Fatalf("error = %q, want multiple recorded candidate scopes", err)
+	}
+}
+
+func setupAnalyzeAmbiguousBaseline(t *testing.T) (string, string) {
+	t.Helper()
+
+	dir := setupObserveScenarioStore(t)
+	registerScenarioInstruments(t, dir)
+	runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-max", "binary_size=1000",
+	)
+	baseline := runCLIJSON[cliIDResponse](t, dir, "experiment", "baseline")
+	addAnalyzeBaselineScope(t, dir, baseline.ID, 2, 95)
+	return dir, baseline.ID
+}
+
+func addAnalyzeBaselineScope(t *testing.T, dir, baselineID string, attempt int, value float64) {
+	t.Helper()
+
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	exp, err := s.ReadExperiment(baselineID)
+	if err != nil {
+		t.Fatalf("ReadExperiment: %v", err)
+	}
+	id, err := s.AllocID(store.KindObservation)
+	if err != nil {
+		t.Fatalf("AllocID: %v", err)
+	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID:           id,
+		Experiment:   baselineID,
+		Instrument:   "timing",
+		MeasuredAt:   time.Now().UTC(),
+		Value:        value,
+		Unit:         "ns",
+		Samples:      1,
+		Command:      "sh -c cat timing.txt",
+		ExitCode:     0,
+		Attempt:      attempt,
+		CandidateSHA: exp.Baseline.SHA,
+		Author:       "test",
+	}); err != nil {
+		t.Fatalf("WriteObservation: %v", err)
 	}
 }

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -31,6 +31,8 @@ type concludeResolution struct {
 	UsedObservations      []string                     `json:"used_observations"`
 	IgnoredObservations   []concludeIgnoredObservation `json:"ignored_observations,omitempty"`
 	CandidateExperiment   string                       `json:"candidate_experiment"`
+	CandidateRef          string                       `json:"candidate_ref,omitempty"`
+	CandidateSHA          string                       `json:"candidate_sha,omitempty"`
 	CandidateSource       string                       `json:"candidate_source"`
 	BaselineExperiment    string                       `json:"baseline_experiment,omitempty"`
 	BaselineSource        string                       `json:"baseline_source"`
@@ -105,7 +107,7 @@ output report which baseline source was used and any fallback note.`,
 				return err
 			}
 
-			requestedObsIDs, candObs, ignoredObs, candExp, err := resolveConcludeObservations(s, hyp, obsList)
+			requestedObsIDs, candObs, ignoredObs, candExp, candProv, err := resolveConcludeObservations(s, hyp, obsList)
 			if err != nil {
 				return err
 			}
@@ -119,6 +121,8 @@ output report which baseline source was used and any fallback note.`,
 				UsedObservations:      observationIDs(candObs),
 				IgnoredObservations:   ignoredObs,
 				CandidateExperiment:   candExp,
+				CandidateRef:          candProv.Ref,
+				CandidateSHA:          candProv.SHA,
 				CandidateSource:       concludeCandidateSourceObservations,
 				BaselineSource:        concludeBaselineSourceNone,
 			}
@@ -253,6 +257,8 @@ output report which baseline source was used and any fallback note.`,
 				Verdict:         decision.FinalVerdict,
 				Observations:    resolution.UsedObservations,
 				CandidateExp:    candExp,
+				CandidateRef:    candProv.Ref,
+				CandidateSHA:    candProv.SHA,
 				BaselineExp:     baselineExp,
 				Effect:          effect,
 				IncrementalExp:  incrementalExp,
@@ -327,6 +333,8 @@ output report which baseline source was used and any fallback note.`,
 				"downgraded":       decision.Downgraded,
 				"reasons":          decision.Reasons,
 				"candidate":        candExp,
+				"candidate_ref":    candProv.Ref,
+				"candidate_sha":    candProv.SHA,
 				"candidate_source": resolution.CandidateSource,
 				"baseline":         baselineExp,
 				"baseline_source":  resolution.BaselineSource,
@@ -396,6 +404,12 @@ output report which baseline source was used and any fallback note.`,
 			w.Textf("wrote %s\n", id)
 			w.Textf("  hypothesis:  %s (now %s)\n", hypID, hyp.Status)
 			w.Textf("  candidate:   %s  (source=%s, n=%d)\n", candExp, resolution.CandidateSource, effect.NCandidate)
+			if resolution.CandidateRef != "" {
+				w.Textf("  candidate ref: %s\n", resolution.CandidateRef)
+			}
+			if resolution.CandidateSHA != "" {
+				w.Textf("  candidate sha: %s\n", resolution.CandidateSHA)
+			}
 			w.Textf("  observations: %s\n", strings.Join(resolution.UsedObservations, ", "))
 			if !slices.Equal(resolution.RequestedObservations, resolution.UsedObservations) {
 				w.Textf("  requested:   %s\n", strings.Join(resolution.RequestedObservations, ", "))
@@ -485,21 +499,22 @@ func goalForHypothesis(s *store.Store, hyp *entity.Hypothesis) (*entity.Goal, er
 	return goal, err
 }
 
-func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs []string) ([]string, []*entity.Observation, []concludeIgnoredObservation, string, error) {
+func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs []string) ([]string, []*entity.Observation, []concludeIgnoredObservation, string, observationProvenance, error) {
 	requested := normalizeObservationIDs(rawIDs)
 	if len(requested) == 0 {
-		return nil, nil, nil, "", errors.New("--observations is required (at least one observation id)")
+		return nil, nil, nil, "", observationProvenance{}, errors.New("--observations is required (at least one observation id)")
 	}
 
 	var (
-		used    []*entity.Observation
-		ignored []concludeIgnoredObservation
-		candExp string
+		used     []*entity.Observation
+		ignored  []concludeIgnoredObservation
+		candExp  string
+		candProv observationProvenance
 	)
 	for _, oid := range requested {
 		o, err := s.ReadObservation(oid)
 		if err != nil {
-			return nil, nil, nil, "", err
+			return nil, nil, nil, "", observationProvenance{}, err
 		}
 		if o.Instrument != hyp.Predicts.Instrument {
 			ignored = append(ignored, concludeIgnoredObservation{
@@ -511,8 +526,12 @@ func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs 
 		}
 		if candExp == "" {
 			candExp = o.Experiment
+			candProv = observationProvenanceFromObservation(o)
 		} else if candExp != o.Experiment {
-			return nil, nil, nil, "", fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candExp, o.Experiment)
+			return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candExp, o.Experiment)
+		}
+		if err := validateObservationProvenance(candProv, o); err != nil {
+			return nil, nil, nil, "", observationProvenance{}, err
 		}
 		used = append(used, o)
 	}
@@ -522,11 +541,47 @@ func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs 
 			ignoredIDs = append(ignoredIDs, ignoredObs.ID)
 		}
 		if len(ignoredIDs) > 0 {
-			return nil, nil, nil, "", fmt.Errorf("none of the requested observations use predicted instrument %q; ignored: %s", hyp.Predicts.Instrument, strings.Join(ignoredIDs, ", "))
+			return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("none of the requested observations use predicted instrument %q; ignored: %s", hyp.Predicts.Instrument, strings.Join(ignoredIDs, ", "))
 		}
-		return nil, nil, nil, "", fmt.Errorf("none of the requested observations use predicted instrument %q", hyp.Predicts.Instrument)
+		return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("none of the requested observations use predicted instrument %q", hyp.Predicts.Instrument)
 	}
-	return requested, used, ignored, candExp, nil
+	return requested, used, ignored, candExp, candProv, nil
+}
+
+func observationProvenanceFromObservation(o *entity.Observation) observationProvenance {
+	if o == nil {
+		return observationProvenance{}
+	}
+	return observationProvenance{
+		Ref: strings.TrimSpace(o.CandidateRef),
+		SHA: strings.TrimSpace(o.CandidateSHA),
+	}
+}
+
+func validateObservationProvenance(expected observationProvenance, o *entity.Observation) error {
+	actual := observationProvenanceFromObservation(o)
+	if actual == expected {
+		return nil
+	}
+	return fmt.Errorf(
+		"observations mix candidate provenance: expected %s, got %s on %s",
+		formatSingleObservationProvenance(expected),
+		formatSingleObservationProvenance(actual),
+		o.ID,
+	)
+}
+
+func formatSingleObservationProvenance(p observationProvenance) string {
+	switch {
+	case p.Ref != "" && p.SHA != "":
+		return fmt.Sprintf("%s@%s", p.Ref, shortSHA(p.SHA))
+	case p.Ref != "":
+		return p.Ref
+	case p.SHA != "":
+		return shortSHA(p.SHA)
+	default:
+		return "(legacy)"
+	}
 }
 
 func normalizeObservationIDs(rawIDs []string) []string {

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -31,10 +31,14 @@ type concludeResolution struct {
 	UsedObservations      []string                     `json:"used_observations"`
 	IgnoredObservations   []concludeIgnoredObservation `json:"ignored_observations,omitempty"`
 	CandidateExperiment   string                       `json:"candidate_experiment"`
+	CandidateAttempt      int                          `json:"candidate_attempt,omitempty"`
 	CandidateRef          string                       `json:"candidate_ref,omitempty"`
 	CandidateSHA          string                       `json:"candidate_sha,omitempty"`
 	CandidateSource       string                       `json:"candidate_source"`
 	BaselineExperiment    string                       `json:"baseline_experiment,omitempty"`
+	BaselineAttempt       int                          `json:"baseline_attempt,omitempty"`
+	BaselineRef           string                       `json:"baseline_ref,omitempty"`
+	BaselineSHA           string                       `json:"baseline_sha,omitempty"`
 	BaselineSource        string                       `json:"baseline_source"`
 	BaselineNote          string                       `json:"baseline_note,omitempty"`
 	AncestorHypothesis    string                       `json:"ancestor_hypothesis,omitempty"`
@@ -107,11 +111,16 @@ output report which baseline source was used and any fallback note.`,
 				return err
 			}
 
-			requestedObsIDs, candObs, ignoredObs, candExp, candProv, err := resolveConcludeObservations(s, hyp, obsList)
+			requestedObsIDs, candObs, ignoredObs, candScope, err := resolveConcludeObservations(s, hyp, obsList)
 			if err != nil {
 				return err
 			}
+			candExp := candScope.Experiment
 			candExpRec, err := s.ReadExperiment(candExp)
+			if err != nil {
+				return err
+			}
+			obsIdx, err := readmodel.LoadObservationIndexStrict(s)
 			if err != nil {
 				return err
 			}
@@ -121,8 +130,9 @@ output report which baseline source was used and any fallback note.`,
 				UsedObservations:      observationIDs(candObs),
 				IgnoredObservations:   ignoredObs,
 				CandidateExperiment:   candExp,
-				CandidateRef:          candProv.Ref,
-				CandidateSHA:          candProv.SHA,
+				CandidateAttempt:      candScope.Attempt,
+				CandidateRef:          candScope.Ref,
+				CandidateSHA:          candScope.SHA,
 				CandidateSource:       concludeCandidateSourceObservations,
 				BaselineSource:        concludeBaselineSourceNone,
 			}
@@ -132,16 +142,12 @@ output report which baseline source was used and any fallback note.`,
 				baselineRes *readmodel.BaselineResolution
 			)
 			if baselineExp = strings.TrimSpace(baselineExp); baselineExp != "" {
-				baseObs, err = baselineObservationsForExperiment(s, baselineExp, hyp.Predicts.Instrument)
+				baseObs, baselineRes, err = baselineObservationsForExperiment(s, obsIdx, baselineExp, hyp.Predicts.Instrument)
 				if err != nil {
 					return err
 				}
-				baselineRes = &readmodel.BaselineResolution{
-					ExperimentID: baselineExp,
-					Source:       readmodel.BaselineSourceExplicit,
-				}
 			} else {
-				baselineRes, err = readmodel.ResolveInferredBaseline(s, hyp, candExpRec, hyp.Predicts.Instrument)
+				baselineRes, err = readmodel.ResolveInferredBaselineWithIndex(s, obsIdx, hyp, candExpRec, hyp.Predicts.Instrument)
 				if err != nil {
 					return err
 				}
@@ -149,10 +155,7 @@ output report which baseline source was used and any fallback note.`,
 					baselineExp = baselineRes.ExperimentID
 				}
 				if baselineExp != "" {
-					baseObs, err = baselineObservationsForExperiment(s, baselineExp, hyp.Predicts.Instrument)
-					if err != nil {
-						return err
-					}
+					baseObs = filterObservationsByInstrument(obsIdx.ObservationsForScope(baselineRes.Scope()), hyp.Predicts.Instrument)
 				}
 			}
 			applyBaselineResolution(&resolution, baselineRes, hyp.Predicts.Instrument)
@@ -171,18 +174,12 @@ output report which baseline source was used and any fallback note.`,
 				}
 				frontierRows, _ := readmodel.ComputeFrontier(s, goal, scopedConcls)
 				if len(frontierRows) > 0 {
-					best := frontierRows[0].Candidate
-					// Only compute incremental if it differs from the absolute baseline.
-					if best != baselineExp && best != candExp {
-						incrementalExp = best
-						all, err := s.ListObservationsForExperiment(best)
-						if err == nil {
-							for _, o := range all {
-								if o.Instrument == hyp.Predicts.Instrument {
-									incrObs = append(incrObs, o)
-								}
-							}
-						}
+					bestConcl := conclusionByID(scopedConcls, frontierRows[0].Conclusion)
+					bestObs, bestScope, ok := obsIdx.ObservationsForConclusionCandidate(bestConcl)
+					baseScope := baselineRes.Scope()
+					if ok && bestScope != candScope && bestScope != baseScope {
+						incrementalExp = bestScope.Experiment
+						incrObs = filterObservationsByInstrument(bestObs, hyp.Predicts.Instrument)
 					}
 				}
 			}
@@ -216,10 +213,10 @@ output report which baseline source was used and any fallback note.`,
 			// primary can be rescued by a goal-level secondary.
 			strictCtx := firewall.StrictContext{}
 			if goal != nil && len(goal.Rescuers) > 0 && goal.NeutralBandFrac > 0 {
-				candAll, _ := s.ListObservationsForExperiment(candExp)
+				candAll := obsIdx.ObservationsForScope(candScope)
 				var baseAll []*entity.Observation
-				if baselineExp != "" {
-					baseAll, _ = s.ListObservationsForExperiment(baselineExp)
+				if baselineRes != nil {
+					baseAll = obsIdx.ObservationsForScope(baselineRes.Scope())
 				}
 				strictCtx = firewall.StrictContext{
 					Goal: goal,
@@ -253,22 +250,26 @@ output report which baseline source was used and any fallback note.`,
 			}
 
 			concl := &entity.Conclusion{
-				Hypothesis:      hypID,
-				Verdict:         decision.FinalVerdict,
-				Observations:    resolution.UsedObservations,
-				CandidateExp:    candExp,
-				CandidateRef:    candProv.Ref,
-				CandidateSHA:    candProv.SHA,
-				BaselineExp:     baselineExp,
-				Effect:          effect,
-				IncrementalExp:  incrementalExp,
-				SecondaryChecks: decision.ClauseChecks,
-				StatTest:        "mann_whitney_u",
-				Strict:          strictRec,
-				Author:          or(author, "agent:analyst"),
-				ReviewedBy:      reviewedBy,
-				CreatedAt:       nowUTC(),
-				Body:            interpretationBody(interpretation, verdict, decision),
+				Hypothesis:       hypID,
+				Verdict:          decision.FinalVerdict,
+				Observations:     resolution.UsedObservations,
+				CandidateExp:     candExp,
+				CandidateAttempt: candScope.Attempt,
+				CandidateRef:     candScope.Ref,
+				CandidateSHA:     candScope.SHA,
+				BaselineExp:      baselineExp,
+				BaselineAttempt:  resolution.BaselineAttempt,
+				BaselineRef:      resolution.BaselineRef,
+				BaselineSHA:      resolution.BaselineSHA,
+				Effect:           effect,
+				IncrementalExp:   incrementalExp,
+				SecondaryChecks:  decision.ClauseChecks,
+				StatTest:         "mann_whitney_u",
+				Strict:           strictRec,
+				Author:           or(author, "agent:analyst"),
+				ReviewedBy:       reviewedBy,
+				CreatedAt:        nowUTC(),
+				Body:             interpretationBody(interpretation, verdict, decision),
 			}
 			if incrCmp != nil {
 				incrEffect := buildEffect(hyp.Predicts.Instrument, cSamples, flattenSamples(incrObs), incrCmp)
@@ -328,20 +329,21 @@ output report which baseline source was used and any fallback note.`,
 
 			// Event.
 			eventData := map[string]any{
-				"verdict":          decision.FinalVerdict,
-				"requested":        verdict,
-				"downgraded":       decision.Downgraded,
-				"reasons":          decision.Reasons,
-				"candidate":        candExp,
-				"candidate_ref":    candProv.Ref,
-				"candidate_sha":    candProv.SHA,
-				"candidate_source": resolution.CandidateSource,
-				"baseline":         baselineExp,
-				"baseline_source":  resolution.BaselineSource,
-				"observations":     resolution.UsedObservations,
-				"delta_frac":       effect.DeltaFrac,
-				"ci_low_frac":      effect.CILowFrac,
-				"ci_high_frac":     effect.CIHighFrac,
+				"verdict":           decision.FinalVerdict,
+				"requested":         verdict,
+				"downgraded":        decision.Downgraded,
+				"reasons":           decision.Reasons,
+				"candidate":         candExp,
+				"candidate_attempt": candScope.Attempt,
+				"candidate_ref":     candScope.Ref,
+				"candidate_sha":     candScope.SHA,
+				"candidate_source":  resolution.CandidateSource,
+				"baseline":          baselineExp,
+				"baseline_source":   resolution.BaselineSource,
+				"observations":      resolution.UsedObservations,
+				"delta_frac":        effect.DeltaFrac,
+				"ci_low_frac":       effect.CILowFrac,
+				"ci_high_frac":      effect.CIHighFrac,
 			}
 			if !slices.Equal(resolution.RequestedObservations, resolution.UsedObservations) {
 				eventData["requested_observations"] = resolution.RequestedObservations
@@ -351,6 +353,15 @@ output report which baseline source was used and any fallback note.`,
 			}
 			if resolution.BaselineNote != "" {
 				eventData["baseline_note"] = resolution.BaselineNote
+			}
+			if resolution.BaselineAttempt > 0 {
+				eventData["baseline_attempt"] = resolution.BaselineAttempt
+			}
+			if resolution.BaselineRef != "" {
+				eventData["baseline_ref"] = resolution.BaselineRef
+			}
+			if resolution.BaselineSHA != "" {
+				eventData["baseline_sha"] = resolution.BaselineSHA
 			}
 			if resolution.AncestorHypothesis != "" {
 				eventData["ancestor_hypothesis"] = resolution.AncestorHypothesis
@@ -404,6 +415,9 @@ output report which baseline source was used and any fallback note.`,
 			w.Textf("wrote %s\n", id)
 			w.Textf("  hypothesis:  %s (now %s)\n", hypID, hyp.Status)
 			w.Textf("  candidate:   %s  (source=%s, n=%d)\n", candExp, resolution.CandidateSource, effect.NCandidate)
+			if resolution.CandidateAttempt > 0 {
+				w.Textf("  candidate attempt: %d\n", resolution.CandidateAttempt)
+			}
 			if resolution.CandidateRef != "" {
 				w.Textf("  candidate ref: %s\n", resolution.CandidateRef)
 			}
@@ -423,6 +437,15 @@ output report which baseline source was used and any fallback note.`,
 			}
 			if baselineExp != "" {
 				w.Textf("  baseline:    %s  (n=%d, source=%s)\n", baselineExp, effect.NBaseline, formatBaselineSource(resolution))
+				if resolution.BaselineAttempt > 0 {
+					w.Textf("  baseline attempt: %d\n", resolution.BaselineAttempt)
+				}
+				if resolution.BaselineRef != "" {
+					w.Textf("  baseline ref: %s\n", resolution.BaselineRef)
+				}
+				if resolution.BaselineSHA != "" {
+					w.Textf("  baseline sha: %s\n", resolution.BaselineSHA)
+				}
 			} else {
 				w.Textf("  baseline:    none  (source=%s)\n", resolution.BaselineSource)
 			}
@@ -499,22 +522,21 @@ func goalForHypothesis(s *store.Store, hyp *entity.Hypothesis) (*entity.Goal, er
 	return goal, err
 }
 
-func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs []string) ([]string, []*entity.Observation, []concludeIgnoredObservation, string, observationProvenance, error) {
+func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs []string) ([]string, []*entity.Observation, []concludeIgnoredObservation, readmodel.ObservationScope, error) {
 	requested := normalizeObservationIDs(rawIDs)
 	if len(requested) == 0 {
-		return nil, nil, nil, "", observationProvenance{}, errors.New("--observations is required (at least one observation id)")
+		return nil, nil, nil, readmodel.ObservationScope{}, errors.New("--observations is required (at least one observation id)")
 	}
 
 	var (
-		used     []*entity.Observation
-		ignored  []concludeIgnoredObservation
-		candExp  string
-		candProv observationProvenance
+		used      []*entity.Observation
+		ignored   []concludeIgnoredObservation
+		candScope readmodel.ObservationScope
 	)
 	for _, oid := range requested {
 		o, err := s.ReadObservation(oid)
 		if err != nil {
-			return nil, nil, nil, "", observationProvenance{}, err
+			return nil, nil, nil, readmodel.ObservationScope{}, err
 		}
 		if o.Instrument != hyp.Predicts.Instrument {
 			ignored = append(ignored, concludeIgnoredObservation{
@@ -524,14 +546,14 @@ func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs 
 			})
 			continue
 		}
-		if candExp == "" {
-			candExp = o.Experiment
-			candProv = observationProvenanceFromObservation(o)
-		} else if candExp != o.Experiment {
-			return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candExp, o.Experiment)
+		scope := readmodel.ObservationScopeFromObservation(o)
+		if candScope.Experiment == "" {
+			candScope = scope
+		} else if candScope.Experiment != scope.Experiment {
+			return nil, nil, nil, readmodel.ObservationScope{}, fmt.Errorf("observations belong to different experiments (%s and %s); pass only observations from a single candidate", candScope.Experiment, scope.Experiment)
 		}
-		if err := validateObservationProvenance(candProv, o); err != nil {
-			return nil, nil, nil, "", observationProvenance{}, err
+		if err := validateObservationScope(candScope, o); err != nil {
+			return nil, nil, nil, readmodel.ObservationScope{}, err
 		}
 		used = append(used, o)
 	}
@@ -541,47 +563,24 @@ func resolveConcludeObservations(s *store.Store, hyp *entity.Hypothesis, rawIDs 
 			ignoredIDs = append(ignoredIDs, ignoredObs.ID)
 		}
 		if len(ignoredIDs) > 0 {
-			return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("none of the requested observations use predicted instrument %q; ignored: %s", hyp.Predicts.Instrument, strings.Join(ignoredIDs, ", "))
+			return nil, nil, nil, readmodel.ObservationScope{}, fmt.Errorf("none of the requested observations use predicted instrument %q; ignored: %s", hyp.Predicts.Instrument, strings.Join(ignoredIDs, ", "))
 		}
-		return nil, nil, nil, "", observationProvenance{}, fmt.Errorf("none of the requested observations use predicted instrument %q", hyp.Predicts.Instrument)
+		return nil, nil, nil, readmodel.ObservationScope{}, fmt.Errorf("none of the requested observations use predicted instrument %q", hyp.Predicts.Instrument)
 	}
-	return requested, used, ignored, candExp, candProv, nil
+	return requested, used, ignored, candScope, nil
 }
 
-func observationProvenanceFromObservation(o *entity.Observation) observationProvenance {
-	if o == nil {
-		return observationProvenance{}
-	}
-	return observationProvenance{
-		Ref: strings.TrimSpace(o.CandidateRef),
-		SHA: strings.TrimSpace(o.CandidateSHA),
-	}
-}
-
-func validateObservationProvenance(expected observationProvenance, o *entity.Observation) error {
-	actual := observationProvenanceFromObservation(o)
+func validateObservationScope(expected readmodel.ObservationScope, o *entity.Observation) error {
+	actual := readmodel.ObservationScopeFromObservation(o)
 	if actual == expected {
 		return nil
 	}
 	return fmt.Errorf(
-		"observations mix candidate provenance: expected %s, got %s on %s",
-		formatSingleObservationProvenance(expected),
-		formatSingleObservationProvenance(actual),
+		"observations mix candidate scope: expected %s, got %s on %s",
+		readmodel.FormatObservationScope(expected),
+		readmodel.FormatObservationScope(actual),
 		o.ID,
 	)
-}
-
-func formatSingleObservationProvenance(p observationProvenance) string {
-	switch {
-	case p.Ref != "" && p.SHA != "":
-		return fmt.Sprintf("%s@%s", p.Ref, shortSHA(p.SHA))
-	case p.Ref != "":
-		return p.Ref
-	case p.SHA != "":
-		return shortSHA(p.SHA)
-	default:
-		return "(legacy)"
-	}
 }
 
 func normalizeObservationIDs(rawIDs []string) []string {
@@ -604,27 +603,25 @@ func observationIDs(obs []*entity.Observation) []string {
 	return ids
 }
 
-func baselineObservationsForExperiment(s *store.Store, expID, instrument string) ([]*entity.Observation, error) {
+func baselineObservationsForExperiment(s *store.Store, obs *readmodel.ObservationIndex, expID, instrument string) ([]*entity.Observation, *readmodel.BaselineResolution, error) {
 	if expID == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
-	if _, err := s.ReadExperiment(expID); err != nil {
-		return nil, fmt.Errorf("baseline experiment %s: %w", expID, err)
-	}
-	all, err := s.ListObservationsForExperiment(expID)
+	scope, ok, note, err := readmodel.ResolveExperimentInstrumentScope(s, obs, expID, instrument, "baseline experiment")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var filtered []*entity.Observation
-	for _, o := range all {
-		if o.Instrument == instrument {
-			filtered = append(filtered, o)
-		}
+	if !ok {
+		return nil, nil, fmt.Errorf("%s", note)
 	}
-	if len(filtered) == 0 {
-		return nil, fmt.Errorf("baseline experiment %s has no observations on instrument %q", expID, instrument)
-	}
-	return filtered, nil
+	filtered := filterObservationsByInstrument(obs.ObservationsForScope(scope), instrument)
+	return filtered, &readmodel.BaselineResolution{
+		ExperimentID: expID,
+		Attempt:      scope.Attempt,
+		Ref:          scope.Ref,
+		SHA:          scope.SHA,
+		Source:       readmodel.BaselineSourceExplicit,
+	}, nil
 }
 
 func applyBaselineResolution(res *concludeResolution, baseline *readmodel.BaselineResolution, instrument string) {
@@ -637,6 +634,9 @@ func applyBaselineResolution(res *concludeResolution, baseline *readmodel.Baseli
 		return
 	}
 	res.BaselineExperiment = baseline.ExperimentID
+	res.BaselineAttempt = baseline.Attempt
+	res.BaselineRef = baseline.Ref
+	res.BaselineSHA = baseline.SHA
 	if baseline.Source != "" {
 		res.BaselineSource = baseline.Source
 	}
@@ -655,6 +655,25 @@ func formatBaselineSource(res concludeResolution) string {
 		return fmt.Sprintf("%s via %s/%s", res.BaselineSource, res.AncestorHypothesis, res.AncestorConclusion)
 	}
 	return res.BaselineSource
+}
+
+func conclusionByID(concls []*entity.Conclusion, id string) *entity.Conclusion {
+	for _, c := range concls {
+		if c != nil && c.ID == id {
+			return c
+		}
+	}
+	return nil
+}
+
+func filterObservationsByInstrument(obs []*entity.Observation, instrument string) []*entity.Observation {
+	var filtered []*entity.Observation
+	for _, o := range obs {
+		if o != nil && o.Instrument == instrument {
+			filtered = append(filtered, o)
+		}
+	}
+	return filtered
 }
 
 func conclusionsForGoal(s *store.Store, goalID string, concls []*entity.Conclusion) ([]*entity.Conclusion, error) {

--- a/internal/cli/conclude_test.go
+++ b/internal/cli/conclude_test.go
@@ -20,10 +20,14 @@ type concludeResolutionJSON struct {
 		Reason string `json:"reason"`
 	} `json:"ignored_observations"`
 	CandidateExperiment string `json:"candidate_experiment"`
+	CandidateAttempt    int    `json:"candidate_attempt,omitempty"`
 	CandidateRef        string `json:"candidate_ref,omitempty"`
 	CandidateSHA        string `json:"candidate_sha,omitempty"`
 	CandidateSource     string `json:"candidate_source"`
 	BaselineExperiment  string `json:"baseline_experiment,omitempty"`
+	BaselineAttempt     int    `json:"baseline_attempt,omitempty"`
+	BaselineRef         string `json:"baseline_ref,omitempty"`
+	BaselineSHA         string `json:"baseline_sha,omitempty"`
 	BaselineSource      string `json:"baseline_source"`
 	BaselineNote        string `json:"baseline_note,omitempty"`
 	AncestorHypothesis  string `json:"ancestor_hypothesis,omitempty"`
@@ -175,6 +179,9 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 			CandidateSHA: candidateSHA,
 			Author:       "agent:observer",
 		}
+		if candidateRef != "" || candidateSHA != "" {
+			o.Attempt = 1
+		}
 		if instrument == "binary_size" {
 			o.Unit = "bytes"
 		}
@@ -192,14 +199,15 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 	writeObservation("O-0004", candidateExp.ID, "binary_size", 860, []float64{860, 860, 860, 860, 860}, candidateRef, candidateSHA)
 
 	ancestorConcl := &entity.Conclusion{
-		ID:           "C-0001",
-		Hypothesis:   ancestorHyp.ID,
-		Verdict:      entity.VerdictSupported,
-		Observations: []string{"O-0002"},
-		CandidateExp: ancestorExp.ID,
-		CandidateRef: ancestorRef,
-		CandidateSHA: ancestorSHA,
-		BaselineExp:  goalBaseline.ID,
+		ID:               "C-0001",
+		Hypothesis:       ancestorHyp.ID,
+		Verdict:          entity.VerdictSupported,
+		Observations:     []string{"O-0002"},
+		CandidateExp:     ancestorExp.ID,
+		CandidateAttempt: 1,
+		CandidateRef:     ancestorRef,
+		CandidateSHA:     ancestorSHA,
+		BaselineExp:      goalBaseline.ID,
 		Effect: entity.Effect{
 			Instrument: "timing",
 			DeltaFrac:  -0.15,
@@ -273,6 +281,9 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	if resp.Conclusion.CandidateSHA != fx.candidateSHA {
 		t.Fatalf("candidate_sha = %q, want %q", resp.Conclusion.CandidateSHA, fx.candidateSHA)
 	}
+	if resp.Conclusion.CandidateAttempt != 1 {
+		t.Fatalf("candidate_attempt = %d, want 1", resp.Conclusion.CandidateAttempt)
+	}
 	if got, want := resp.Conclusion.Observations, []string{fx.timingObservation}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("stored observations = %v, want %v", got, want)
 	}
@@ -281,6 +292,9 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	}
 	if resp.Resolution.CandidateSHA != fx.candidateSHA {
 		t.Fatalf("resolution candidate_sha = %q, want %q", resp.Resolution.CandidateSHA, fx.candidateSHA)
+	}
+	if resp.Resolution.CandidateAttempt != 1 {
+		t.Fatalf("resolution candidate_attempt = %d, want 1", resp.Resolution.CandidateAttempt)
 	}
 	if resp.Resolution.CandidateSource != concludeCandidateSourceObservations {
 		t.Fatalf("candidate_source = %q, want %q", resp.Resolution.CandidateSource, concludeCandidateSourceObservations)
@@ -299,6 +313,9 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	}
 	if resp.Resolution.BaselineExperiment != fx.ancestorExperiment {
 		t.Fatalf("baseline_experiment = %q, want %q", resp.Resolution.BaselineExperiment, fx.ancestorExperiment)
+	}
+	if resp.Resolution.BaselineAttempt != 1 {
+		t.Fatalf("baseline_attempt = %d, want 1", resp.Resolution.BaselineAttempt)
 	}
 	if resp.Resolution.BaselineSource != readmodel.BaselineSourceAncestorSupported {
 		t.Fatalf("baseline_source = %q, want %q", resp.Resolution.BaselineSource, readmodel.BaselineSourceAncestorSupported)
@@ -339,8 +356,14 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	if got := payload["candidate_sha"]; got != fx.candidateSHA {
 		t.Fatalf("payload candidate_sha = %v, want %q", got, fx.candidateSHA)
 	}
+	if got := payload["candidate_attempt"]; got != float64(1) {
+		t.Fatalf("payload candidate_attempt = %v, want 1", got)
+	}
 	if got := payload["baseline_source"]; got != readmodel.BaselineSourceAncestorSupported {
 		t.Fatalf("payload baseline_source = %v, want %q", got, readmodel.BaselineSourceAncestorSupported)
+	}
+	if got := payload["baseline_attempt"]; got != float64(1) {
+		t.Fatalf("payload baseline_attempt = %v, want 1", got)
 	}
 	if got := payload["ancestor_hypothesis"]; got != fx.ancestorHypothesis {
 		t.Fatalf("payload ancestor_hypothesis = %v, want %q", got, fx.ancestorHypothesis)
@@ -447,8 +470,244 @@ func TestConclude_RefusesMixedCandidateProvenance(t *testing.T) {
 	if err == nil {
 		t.Fatal("conclude unexpectedly succeeded with mixed candidate provenance")
 	}
-	if !strings.Contains(err.Error(), "mix candidate provenance") {
+	if !strings.Contains(err.Error(), "mix candidate scope") {
 		t.Fatalf("unexpected mixed provenance error: %v", err)
+	}
+}
+
+func TestConclude_RefusesMixedCandidateScopeAcrossAttempts(t *testing.T) {
+	saveGlobals(t)
+	fx := setupConcludeFallbackFixture(t)
+
+	s, err := store.Open(fx.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID:           "O-0006",
+		Experiment:   fx.candidateExperiment,
+		Instrument:   "timing",
+		MeasuredAt:   time.Date(2026, 4, 19, 12, 2, 0, 0, time.UTC),
+		Value:        69.9,
+		Samples:      5,
+		PerSample:    []float64{70, 70, 69, 70, 70},
+		Unit:         "ns",
+		Attempt:      2,
+		CandidateRef: fx.candidateRef,
+		CandidateSHA: fx.candidateSHA,
+		Author:       "agent:observer",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = runCLIResult(t, fx.dir,
+		"conclude", fx.currentHypothesis,
+		"--verdict", "supported",
+		"--observations", strings.Join([]string{fx.timingObservation, "O-0006"}, ","),
+	)
+	if err == nil {
+		t.Fatal("conclude unexpectedly succeeded with mixed candidate attempts")
+	}
+	if !strings.Contains(err.Error(), "mix candidate scope") {
+		t.Fatalf("unexpected mixed scope error: %v", err)
+	}
+}
+
+func TestConclude_UsesScopedRescuerComparison(t *testing.T) {
+	saveGlobals(t)
+
+	dir := t.TempDir()
+	s, err := store.Create(dir, store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 4, 19, 12, 0, 0, 0, time.UTC)
+	goal := &entity.Goal{
+		ID:              "G-0001",
+		Status:          entity.GoalStatusActive,
+		CreatedAt:       &now,
+		Objective:       entity.Objective{Instrument: "timing", Direction: "decrease"},
+		NeutralBandFrac: 0.05,
+		Rescuers: []entity.Rescuer{
+			{Instrument: "binary_size", Direction: "decrease", MinEffect: 0.05},
+		},
+	}
+	parent := &entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    goal.ID,
+		Claim:     "ancestor",
+		Status:    entity.StatusSupported,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+		Predicts: entity.Predicts{
+			Instrument: "timing",
+			Target:     "kernel",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+	}
+	current := &entity.Hypothesis{
+		ID:        "H-0002",
+		GoalID:    goal.ID,
+		Parent:    parent.ID,
+		Claim:     "candidate",
+		Status:    entity.StatusOpen,
+		Author:    "agent:analyst",
+		CreatedAt: now,
+		Predicts: entity.Predicts{
+			Instrument: "timing",
+			Target:     "kernel",
+			Direction:  "decrease",
+			MinEffect:  0.05,
+		},
+	}
+	ancestorExp := &entity.Experiment{
+		ID:          "E-0001",
+		GoalID:      goal.ID,
+		Hypothesis:  parent.ID,
+		Status:      entity.ExpMeasured,
+		Attempt:     2,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{"timing", "binary_size"},
+		Author:      "agent:observer",
+		CreatedAt:   now,
+	}
+	candidateExp := &entity.Experiment{
+		ID:          "E-0002",
+		GoalID:      goal.ID,
+		Hypothesis:  current.ID,
+		Status:      entity.ExpMeasured,
+		Attempt:     2,
+		Baseline:    entity.Baseline{Ref: "HEAD", SHA: "abc123"},
+		Instruments: []string{"timing", "binary_size"},
+		Author:      "agent:observer",
+		CreatedAt:   now,
+	}
+	for _, g := range []*entity.Goal{goal} {
+		if err := s.WriteGoal(g); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, h := range []*entity.Hypothesis{parent, current} {
+		if err := s.WriteHypothesis(h); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, e := range []*entity.Experiment{ancestorExp, candidateExp} {
+		if err := s.WriteExperiment(e); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeObs := func(id, expID, instrument string, value float64, attempt int, ref, sha string) {
+		t.Helper()
+		perSample := []float64{value, value, value, value, value}
+		unit := "ns"
+		if instrument == "binary_size" {
+			unit = "bytes"
+		}
+		if err := s.WriteObservation(&entity.Observation{
+			ID:           id,
+			Experiment:   expID,
+			Instrument:   instrument,
+			MeasuredAt:   now,
+			Value:        value,
+			Samples:      len(perSample),
+			PerSample:    perSample,
+			Unit:         unit,
+			Attempt:      attempt,
+			CandidateRef: ref,
+			CandidateSHA: sha,
+			Author:       "agent:observer",
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ancestorScopeA := readmodel.ObservationScope{
+		Experiment: ancestorExp.ID,
+		Attempt:    1,
+		Ref:        "refs/heads/candidate/E-0001-a1",
+		SHA:        "1111111111111111111111111111111111111111",
+	}
+	ancestorScopeB := readmodel.ObservationScope{
+		Experiment: ancestorExp.ID,
+		Attempt:    2,
+		Ref:        "refs/heads/candidate/E-0001-a2",
+		SHA:        "2222222222222222222222222222222222222222",
+	}
+	currentScopeA := readmodel.ObservationScope{
+		Experiment: candidateExp.ID,
+		Attempt:    1,
+		Ref:        "refs/heads/candidate/E-0002-a1",
+		SHA:        "3333333333333333333333333333333333333333",
+	}
+	currentScopeB := readmodel.ObservationScope{
+		Experiment: candidateExp.ID,
+		Attempt:    2,
+		Ref:        "refs/heads/candidate/E-0002-a2",
+		SHA:        "4444444444444444444444444444444444444444",
+	}
+
+	writeObs("O-0001", ancestorExp.ID, "timing", 100, ancestorScopeA.Attempt, ancestorScopeA.Ref, ancestorScopeA.SHA)
+	writeObs("O-0002", ancestorExp.ID, "binary_size", 1000, ancestorScopeA.Attempt, ancestorScopeA.Ref, ancestorScopeA.SHA)
+	writeObs("O-0003", ancestorExp.ID, "timing", 95, ancestorScopeB.Attempt, ancestorScopeB.Ref, ancestorScopeB.SHA)
+	writeObs("O-0004", ancestorExp.ID, "binary_size", 800, ancestorScopeB.Attempt, ancestorScopeB.Ref, ancestorScopeB.SHA)
+	writeObs("O-0005", candidateExp.ID, "timing", 100, currentScopeA.Attempt, currentScopeA.Ref, currentScopeA.SHA)
+	writeObs("O-0006", candidateExp.ID, "binary_size", 900, currentScopeA.Attempt, currentScopeA.Ref, currentScopeA.SHA)
+	writeObs("O-0007", candidateExp.ID, "timing", 70, currentScopeB.Attempt, currentScopeB.Ref, currentScopeB.SHA)
+	writeObs("O-0008", candidateExp.ID, "binary_size", 1200, currentScopeB.Attempt, currentScopeB.Ref, currentScopeB.SHA)
+
+	if err := s.WriteConclusion(&entity.Conclusion{
+		ID:               "C-0001",
+		Hypothesis:       parent.ID,
+		Verdict:          entity.VerdictSupported,
+		ReviewedBy:       "human:gate",
+		Observations:     []string{"O-0001"},
+		CandidateExp:     ancestorExp.ID,
+		CandidateAttempt: ancestorScopeA.Attempt,
+		CandidateRef:     ancestorScopeA.Ref,
+		CandidateSHA:     ancestorScopeA.SHA,
+		Effect: entity.Effect{
+			Instrument: "timing",
+			DeltaFrac:  -0.10,
+			NCandidate: 5,
+			NBaseline:  5,
+		},
+		StatTest:  "mann_whitney_u",
+		Strict:    entity.Strict{Passed: true},
+		Author:    "agent:analyst",
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := runCLIJSON[concludeJSONResponse](t, dir,
+		"conclude", current.ID,
+		"--verdict", "supported",
+		"--observations", "O-0005",
+	)
+	if got, want := resp.Conclusion.Verdict, entity.VerdictSupported; got != want {
+		t.Fatalf("verdict = %q, want %q", got, want)
+	}
+	if got, want := resp.Conclusion.Strict.RescuedBy, "binary_size"; got != want {
+		t.Fatalf("rescued_by = %q, want %q", got, want)
+	}
+	if got, want := resp.Resolution.BaselineExperiment, ancestorExp.ID; got != want {
+		t.Fatalf("baseline_experiment = %q, want %q", got, want)
+	}
+	if got, want := resp.Resolution.BaselineAttempt, ancestorScopeA.Attempt; got != want {
+		t.Fatalf("baseline_attempt = %d, want %d", got, want)
+	}
+	if got, want := resp.Resolution.BaselineRef, ancestorScopeA.Ref; got != want {
+		t.Fatalf("baseline_ref = %q, want %q", got, want)
+	}
+	if got, want := resp.Resolution.BaselineSHA, ancestorScopeA.SHA; got != want {
+		t.Fatalf("baseline_sha = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cli/conclude_test.go
+++ b/internal/cli/conclude_test.go
@@ -20,6 +20,8 @@ type concludeResolutionJSON struct {
 		Reason string `json:"reason"`
 	} `json:"ignored_observations"`
 	CandidateExperiment string `json:"candidate_experiment"`
+	CandidateRef        string `json:"candidate_ref,omitempty"`
+	CandidateSHA        string `json:"candidate_sha,omitempty"`
 	CandidateSource     string `json:"candidate_source"`
 	BaselineExperiment  string `json:"baseline_experiment,omitempty"`
 	BaselineSource      string `json:"baseline_source"`
@@ -43,6 +45,8 @@ type concludeFixture struct {
 	ancestorConclusion  string
 	currentHypothesis   string
 	candidateExperiment string
+	candidateRef        string
+	candidateSHA        string
 	timingObservation   string
 	sizeObservation     string
 }
@@ -156,18 +160,20 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 		}
 	}
 
-	writeObservation := func(id, expID, instrument string, value float64, perSample []float64) {
+	writeObservation := func(id, expID, instrument string, value float64, perSample []float64, candidateRef, candidateSHA string) {
 		t.Helper()
 		o := &entity.Observation{
-			ID:         id,
-			Experiment: expID,
-			Instrument: instrument,
-			MeasuredAt: now,
-			Value:      value,
-			Samples:    len(perSample),
-			PerSample:  perSample,
-			Unit:       "ns",
-			Author:     "agent:observer",
+			ID:           id,
+			Experiment:   expID,
+			Instrument:   instrument,
+			MeasuredAt:   now,
+			Value:        value,
+			Samples:      len(perSample),
+			PerSample:    perSample,
+			Unit:         "ns",
+			CandidateRef: candidateRef,
+			CandidateSHA: candidateSHA,
+			Author:       "agent:observer",
 		}
 		if instrument == "binary_size" {
 			o.Unit = "bytes"
@@ -176,10 +182,14 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 			t.Fatal(err)
 		}
 	}
-	writeObservation("O-0001", goalBaseline.ID, "binary_size", 900, []float64{900, 900, 900, 900, 900})
-	writeObservation("O-0002", ancestorExp.ID, "timing", 100.4, []float64{100, 101, 99, 100, 102})
-	writeObservation("O-0003", candidateExp.ID, "timing", 70.4, []float64{70, 71, 69, 72, 70})
-	writeObservation("O-0004", candidateExp.ID, "binary_size", 860, []float64{860, 860, 860, 860, 860})
+	ancestorRef := "refs/heads/candidate/E-0002-a1"
+	ancestorSHA := "1111111111111111111111111111111111111111"
+	candidateRef := "refs/heads/candidate/E-0003-a1"
+	candidateSHA := "2222222222222222222222222222222222222222"
+	writeObservation("O-0001", goalBaseline.ID, "binary_size", 900, []float64{900, 900, 900, 900, 900}, "", "")
+	writeObservation("O-0002", ancestorExp.ID, "timing", 100.4, []float64{100, 101, 99, 100, 102}, ancestorRef, ancestorSHA)
+	writeObservation("O-0003", candidateExp.ID, "timing", 70.4, []float64{70, 71, 69, 72, 70}, candidateRef, candidateSHA)
+	writeObservation("O-0004", candidateExp.ID, "binary_size", 860, []float64{860, 860, 860, 860, 860}, candidateRef, candidateSHA)
 
 	ancestorConcl := &entity.Conclusion{
 		ID:           "C-0001",
@@ -187,6 +197,8 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 		Verdict:      entity.VerdictSupported,
 		Observations: []string{"O-0002"},
 		CandidateExp: ancestorExp.ID,
+		CandidateRef: ancestorRef,
+		CandidateSHA: ancestorSHA,
 		BaselineExp:  goalBaseline.ID,
 		Effect: entity.Effect{
 			Instrument: "timing",
@@ -235,6 +247,8 @@ func setupConcludeFallbackFixture(t *testing.T) concludeFixture {
 		ancestorConclusion:  ancestorConcl.ID,
 		currentHypothesis:   currentHyp.ID,
 		candidateExperiment: candidateExp.ID,
+		candidateRef:        candidateRef,
+		candidateSHA:        candidateSHA,
 		timingObservation:   "O-0003",
 		sizeObservation:     "O-0004",
 	}
@@ -253,8 +267,20 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	if resp.Conclusion.CandidateExp != fx.candidateExperiment {
 		t.Fatalf("candidate_experiment = %q, want %q", resp.Conclusion.CandidateExp, fx.candidateExperiment)
 	}
+	if resp.Conclusion.CandidateRef != fx.candidateRef {
+		t.Fatalf("candidate_ref = %q, want %q", resp.Conclusion.CandidateRef, fx.candidateRef)
+	}
+	if resp.Conclusion.CandidateSHA != fx.candidateSHA {
+		t.Fatalf("candidate_sha = %q, want %q", resp.Conclusion.CandidateSHA, fx.candidateSHA)
+	}
 	if got, want := resp.Conclusion.Observations, []string{fx.timingObservation}; len(got) != len(want) || got[0] != want[0] {
 		t.Fatalf("stored observations = %v, want %v", got, want)
+	}
+	if resp.Resolution.CandidateRef != fx.candidateRef {
+		t.Fatalf("resolution candidate_ref = %q, want %q", resp.Resolution.CandidateRef, fx.candidateRef)
+	}
+	if resp.Resolution.CandidateSHA != fx.candidateSHA {
+		t.Fatalf("resolution candidate_sha = %q, want %q", resp.Resolution.CandidateSHA, fx.candidateSHA)
 	}
 	if resp.Resolution.CandidateSource != concludeCandidateSourceObservations {
 		t.Fatalf("candidate_source = %q, want %q", resp.Resolution.CandidateSource, concludeCandidateSourceObservations)
@@ -307,6 +333,12 @@ func TestConclude_JSONSurfacesResolutionAndEventAudit(t *testing.T) {
 	if got := payload["candidate_source"]; got != concludeCandidateSourceObservations {
 		t.Fatalf("payload candidate_source = %v, want %q", got, concludeCandidateSourceObservations)
 	}
+	if got := payload["candidate_ref"]; got != fx.candidateRef {
+		t.Fatalf("payload candidate_ref = %v, want %q", got, fx.candidateRef)
+	}
+	if got := payload["candidate_sha"]; got != fx.candidateSHA {
+		t.Fatalf("payload candidate_sha = %v, want %q", got, fx.candidateSHA)
+	}
 	if got := payload["baseline_source"]; got != readmodel.BaselineSourceAncestorSupported {
 		t.Fatalf("payload baseline_source = %v, want %q", got, readmodel.BaselineSourceAncestorSupported)
 	}
@@ -348,6 +380,12 @@ func TestConclude_TextOutputSurfacesFallback(t *testing.T) {
 	if !strings.Contains(out, "candidate:   "+fx.candidateExperiment+"  (source=observations") {
 		t.Fatalf("output missing candidate source:\n%s", out)
 	}
+	if !strings.Contains(out, "candidate ref: "+fx.candidateRef) {
+		t.Fatalf("output missing candidate ref:\n%s", out)
+	}
+	if !strings.Contains(out, "candidate sha: "+fx.candidateSHA) {
+		t.Fatalf("output missing candidate sha:\n%s", out)
+	}
 	if !strings.Contains(out, "ignored:     "+fx.sizeObservation+" (instrument \"binary_size\" does not match predicted instrument \"timing\")") {
 		t.Fatalf("output missing ignored observation audit:\n%s", out)
 	}
@@ -374,6 +412,43 @@ func TestConclude_ExplicitBaselineRemainsStrict(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "baseline experiment "+fx.goalBaseline+" has no observations on instrument \"timing\"") {
 		t.Fatalf("error = %q, want missing instrument failure", err)
+	}
+}
+
+func TestConclude_RefusesMixedCandidateProvenance(t *testing.T) {
+	saveGlobals(t)
+	fx := setupConcludeFallbackFixture(t)
+
+	s, err := store.Open(fx.dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.WriteObservation(&entity.Observation{
+		ID:           "O-0005",
+		Experiment:   fx.candidateExperiment,
+		Instrument:   "timing",
+		MeasuredAt:   time.Date(2026, 4, 19, 12, 1, 0, 0, time.UTC),
+		Value:        69.8,
+		Samples:      5,
+		PerSample:    []float64{70, 70, 69, 70, 70},
+		Unit:         "ns",
+		CandidateRef: "refs/heads/candidate/E-0003-a2",
+		CandidateSHA: "3333333333333333333333333333333333333333",
+		Author:       "agent:observer",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = runCLIResult(t, fx.dir,
+		"conclude", fx.currentHypothesis,
+		"--verdict", "supported",
+		"--observations", strings.Join([]string{fx.timingObservation, "O-0005"}, ","),
+	)
+	if err == nil {
+		t.Fatal("conclude unexpectedly succeeded with mixed candidate provenance")
+	}
+	if !strings.Contains(err.Error(), "mix candidate provenance") {
+		t.Fatalf("unexpected mixed provenance error: %v", err)
 	}
 }
 

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -140,6 +140,12 @@ func conclusionShowCmd() *cobra.Command {
 				}
 			}
 			w.Textf("candidate:    %s  (n=%d)\n", c.CandidateExp, c.Effect.NCandidate)
+			if c.CandidateRef != "" {
+				w.Textf("candidate_ref: %s\n", c.CandidateRef)
+			}
+			if c.CandidateSHA != "" {
+				w.Textf("candidate_sha: %s\n", c.CandidateSHA)
+			}
 			if c.BaselineExp != "" {
 				w.Textf("baseline:     %s  (n=%d)\n", c.BaselineExp, c.Effect.NBaseline)
 			}

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -140,6 +140,9 @@ func conclusionShowCmd() *cobra.Command {
 				}
 			}
 			w.Textf("candidate:    %s  (n=%d)\n", c.CandidateExp, c.Effect.NCandidate)
+			if c.CandidateAttempt > 0 {
+				w.Textf("candidate_attempt: %d\n", c.CandidateAttempt)
+			}
 			if c.CandidateRef != "" {
 				w.Textf("candidate_ref: %s\n", c.CandidateRef)
 			}
@@ -148,6 +151,15 @@ func conclusionShowCmd() *cobra.Command {
 			}
 			if c.BaselineExp != "" {
 				w.Textf("baseline:     %s  (n=%d)\n", c.BaselineExp, c.Effect.NBaseline)
+				if c.BaselineAttempt > 0 {
+					w.Textf("baseline_attempt: %d\n", c.BaselineAttempt)
+				}
+				if c.BaselineRef != "" {
+					w.Textf("baseline_ref: %s\n", c.BaselineRef)
+				}
+				if c.BaselineSHA != "" {
+					w.Textf("baseline_sha: %s\n", c.BaselineSHA)
+				}
 			}
 			w.Textf("effect on %s:\n", c.Effect.Instrument)
 			w.Textf("  delta_frac: %+.4f  95%% CI [%+.4f, %+.4f]\n", c.Effect.DeltaFrac, c.Effect.CILowFrac, c.Effect.CIHighFrac)

--- a/internal/cli/conclusion_show_test.go
+++ b/internal/cli/conclusion_show_test.go
@@ -84,6 +84,8 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 		Verdict:      entity.VerdictSupported,
 		Observations: []string{"O-0001", "O-0002", "O-0003", "O-9999"},
 		CandidateExp: "E-0001",
+		CandidateRef: "refs/heads/candidate/E-0001-a1",
+		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
 		BaselineExp:  "E-0000",
 		Effect: entity.Effect{
 			Instrument: "timing",
@@ -112,6 +114,12 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	}
 	if got.ID != "C-0001" {
 		t.Fatalf("id = %q, want C-0001", got.ID)
+	}
+	if got.CandidateRef != "refs/heads/candidate/E-0001-a1" {
+		t.Fatalf("candidate_ref = %q", got.CandidateRef)
+	}
+	if got.CandidateSHA != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("candidate_sha = %q", got.CandidateSHA)
 	}
 	if len(got.Observations) != 4 {
 		t.Fatalf("observations len = %d, want 4", len(got.Observations))

--- a/internal/cli/conclusion_show_test.go
+++ b/internal/cli/conclusion_show_test.go
@@ -79,14 +79,18 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 		t.Fatal(err)
 	}
 	if err := s.WriteConclusion(&entity.Conclusion{
-		ID:           "C-0001",
-		Hypothesis:   "H-0001",
-		Verdict:      entity.VerdictSupported,
-		Observations: []string{"O-0001", "O-0002", "O-0003", "O-9999"},
-		CandidateExp: "E-0001",
-		CandidateRef: "refs/heads/candidate/E-0001-a1",
-		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
-		BaselineExp:  "E-0000",
+		ID:               "C-0001",
+		Hypothesis:       "H-0001",
+		Verdict:          entity.VerdictSupported,
+		Observations:     []string{"O-0001", "O-0002", "O-0003", "O-9999"},
+		CandidateExp:     "E-0001",
+		CandidateAttempt: 2,
+		CandidateRef:     "refs/heads/candidate/E-0001-a1",
+		CandidateSHA:     "0123456789abcdef0123456789abcdef01234567",
+		BaselineExp:      "E-0000",
+		BaselineAttempt:  1,
+		BaselineRef:      "refs/heads/baseline/E-0000-a1",
+		BaselineSHA:      "89abcdef0123456789abcdef0123456789abcdef",
 		Effect: entity.Effect{
 			Instrument: "timing",
 			DeltaAbs:   -20,
@@ -120,6 +124,18 @@ func TestConclusionShowJSON_JoinsObservationArtifacts(t *testing.T) {
 	}
 	if got.CandidateSHA != "0123456789abcdef0123456789abcdef01234567" {
 		t.Fatalf("candidate_sha = %q", got.CandidateSHA)
+	}
+	if got.CandidateAttempt != 2 {
+		t.Fatalf("candidate_attempt = %d", got.CandidateAttempt)
+	}
+	if got.BaselineAttempt != 1 {
+		t.Fatalf("baseline_attempt = %d", got.BaselineAttempt)
+	}
+	if got.BaselineRef != "refs/heads/baseline/E-0000-a1" {
+		t.Fatalf("baseline_ref = %q", got.BaselineRef)
+	}
+	if got.BaselineSHA != "89abcdef0123456789abcdef0123456789abcdef" {
+		t.Fatalf("baseline_sha = %q", got.BaselineSHA)
 	}
 	if len(got.Observations) != 4 {
 		t.Fatalf("observations len = %d, want 4", len(got.Observations))

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -257,7 +257,7 @@ func captureDashboardScoped(s *store.Store, scope goalScope) (*dashboardSnapshot
 	}
 
 	if snap.Goal != nil {
-		frontier := readmodel.BuildFrontierSnapshot(snap.Goal, concls, readmodel.GroupObservationsByExperiment(allObs), expClassByID)
+		frontier := readmodel.BuildFrontierSnapshot(snap.Goal, concls, readmodel.NewObservationIndex(allObs), expClassByID)
 		snap.Frontier = frontier.Rows
 		snap.StalledFor = frontier.StalledFor
 	}

--- a/internal/cli/event_payload_test.go
+++ b/internal/cli/event_payload_test.go
@@ -304,7 +304,8 @@ func TestEventPayload_ObservationRecordIncludesEvidenceFailures(t *testing.T) {
 	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
 	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
 	gitCommitAll(t, impl.Worktree, "improve timing")
-	runCLI(t, dir, "observe", exp.ID, "--instrument", "timing")
+	candidateRef := gitCreateCandidateRef(t, impl.Worktree, "candidate/event-timing")
+	runCLI(t, dir, "observe", exp.ID, "--instrument", "timing", "--candidate-ref", candidateRef)
 
 	s, err := store.Open(dir)
 	if err != nil {
@@ -334,6 +335,9 @@ func TestEventPayload_ObservationRecordIncludesEvidenceFailures(t *testing.T) {
 	}
 	if got := payload["attempt"]; got != float64(1) {
 		t.Fatalf("data.attempt = %v, want 1", got)
+	}
+	if got, ok := payload["candidate_ref"].(string); !ok || got == "" {
+		t.Fatalf("data.candidate_ref = %#v, want non-empty string", payload["candidate_ref"])
 	}
 	if got, ok := payload["candidate_sha"].(string); !ok || got == "" {
 		t.Fatalf("data.candidate_sha = %#v, want non-empty string", payload["candidate_sha"])

--- a/internal/cli/event_payload_test.go
+++ b/internal/cli/event_payload_test.go
@@ -332,4 +332,10 @@ func TestEventPayload_ObservationRecordIncludesEvidenceFailures(t *testing.T) {
 	if failure["exit_code"] != float64(7) {
 		t.Fatalf("failure exit_code = %v, want 7", failure["exit_code"])
 	}
+	if got := payload["attempt"]; got != float64(1) {
+		t.Fatalf("data.attempt = %v, want 1", got)
+	}
+	if got, ok := payload["candidate_sha"].(string); !ok || got == "" {
+		t.Fatalf("data.candidate_sha = %#v, want non-empty string", payload["candidate_sha"])
+	}
 }

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -416,7 +416,7 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 			}
 
 			// --- Phase 3: Observe all instruments ---
-			results, err := observeAll(s, cfg, e, instruments, 0, or(author, "system"))
+			results, err := observeAll(s, cfg, e, instruments, 0, false, or(author, "system"))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -35,6 +35,31 @@ func experimentCommands() []*cobra.Command {
 	return []*cobra.Command{e}
 }
 
+func persistImplementedExperiment(s *store.Store, e *entity.Experiment, wtPath, branch, implNotes string, appendImplNotes bool) error {
+	e.Worktree = wtPath
+	e.Branch = branch
+	e.Attempt++
+	e.Status = entity.ExpImplemented
+	if appendImplNotes {
+		e.Body = entity.AppendMarkdownSection(e.Body, "Implementation notes", implNotes)
+	}
+	return s.WriteExperiment(e)
+}
+
+func emitExperimentImplementEvent(s *store.Store, id, wtPath, branch string, attempt int, implNotes string) error {
+	eventData := map[string]any{
+		"from":     entity.ExpDesigned,
+		"to":       entity.ExpImplemented,
+		"worktree": wtPath,
+		"branch":   branch,
+		"attempt":  attempt,
+	}
+	if snippet := truncate(strings.TrimSpace(implNotes), 200); snippet != "" {
+		eventData["impl_notes"] = snippet
+	}
+	return emitEvent(s, "experiment.implement", "system", id, eventData)
+}
+
 func experimentDesignCmd() *cobra.Command {
 	var (
 		baseline    string
@@ -178,12 +203,7 @@ func experimentImplementCmd() *cobra.Command {
 				return fmt.Errorf("create worktree: %w", err)
 			}
 
-			e.Worktree = wtPath
-			e.Branch = branch
-			e.Attempt++
-			e.Status = entity.ExpImplemented
-			e.Body = entity.AppendMarkdownSection(e.Body, "Implementation notes", implNotes)
-			if err := s.WriteExperiment(e); err != nil {
+			if err := persistImplementedExperiment(s, e, wtPath, branch, implNotes, true); err != nil {
 				return err
 			}
 
@@ -191,17 +211,7 @@ func experimentImplementCmd() *cobra.Command {
 				return fmt.Errorf("write worktree brief: %w", err)
 			}
 
-			eventData := map[string]any{
-				"from":     entity.ExpDesigned,
-				"to":       entity.ExpImplemented,
-				"worktree": wtPath,
-				"branch":   branch,
-				"attempt":  e.Attempt,
-			}
-			if snippet := truncate(strings.TrimSpace(implNotes), 200); snippet != "" {
-				eventData["impl_notes"] = snippet
-			}
-			if err := emitEvent(s, "experiment.implement", "system", id, eventData); err != nil {
+			if err := emitExperimentImplementEvent(s, id, wtPath, branch, e.Attempt, implNotes); err != nil {
 				return err
 			}
 			return w.Emit(
@@ -398,24 +408,14 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 				return fmt.Errorf("create worktree: %w", err)
 			}
 
-			e.Worktree = wtPath
-			e.Branch = branch
-			e.Attempt++
-			e.Status = entity.ExpImplemented
-			if err := s.WriteExperiment(e); err != nil {
+			if err := persistImplementedExperiment(s, e, wtPath, branch, "", false); err != nil {
 				return err
 			}
 			if err := writeWorktreeBrief(s, e, wtPath, ""); err != nil {
 				// Non-fatal for baselines: no hypothesis to brief about.
 				_ = err
 			}
-			if err := emitEvent(s, "experiment.implement", "system", id, map[string]any{
-				"from":     entity.ExpDesigned,
-				"to":       entity.ExpImplemented,
-				"worktree": wtPath,
-				"branch":   branch,
-				"attempt":  e.Attempt,
-			}); err != nil {
+			if err := emitExperimentImplementEvent(s, id, wtPath, branch, e.Attempt, ""); err != nil {
 				return err
 			}
 

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -420,7 +420,11 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 			}
 
 			// --- Phase 3: Observe all instruments ---
-			exec, err := observeAll(s, cfg, e, instruments, 0, false, or(author, "system"))
+			scope, priorObs, err := loadCurrentObservations(s, e, "")
+			if err != nil {
+				return err
+			}
+			exec, err := observeAll(s, cfg, e, scope, priorObs, instruments, 0, false, or(author, "system"))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/experiment.go
+++ b/internal/cli/experiment.go
@@ -180,6 +180,7 @@ func experimentImplementCmd() *cobra.Command {
 
 			e.Worktree = wtPath
 			e.Branch = branch
+			e.Attempt++
 			e.Status = entity.ExpImplemented
 			e.Body = entity.AppendMarkdownSection(e.Body, "Implementation notes", implNotes)
 			if err := s.WriteExperiment(e); err != nil {
@@ -195,6 +196,7 @@ func experimentImplementCmd() *cobra.Command {
 				"to":       entity.ExpImplemented,
 				"worktree": wtPath,
 				"branch":   branch,
+				"attempt":  e.Attempt,
 			}
 			if snippet := truncate(strings.TrimSpace(implNotes), 200); snippet != "" {
 				eventData["impl_notes"] = snippet
@@ -398,6 +400,7 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 
 			e.Worktree = wtPath
 			e.Branch = branch
+			e.Attempt++
 			e.Status = entity.ExpImplemented
 			if err := s.WriteExperiment(e); err != nil {
 				return err
@@ -411,33 +414,30 @@ The returned experiment ID is used as --baseline-experiment in conclude.`,
 				"to":       entity.ExpImplemented,
 				"worktree": wtPath,
 				"branch":   branch,
+				"attempt":  e.Attempt,
 			}); err != nil {
 				return err
 			}
 
 			// --- Phase 3: Observe all instruments ---
-			results, err := observeAll(s, cfg, e, instruments, 0, false, or(author, "system"))
+			exec, err := observeAll(s, cfg, e, instruments, 0, false, or(author, "system"))
 			if err != nil {
 				return err
 			}
 
 			// Output.
 			if w.IsJSON() {
-				obsIDs := make([]string, 0, len(results))
-				for _, r := range results {
-					obsIDs = append(obsIDs, r.ID)
-				}
 				return w.JSON(map[string]any{
 					"status":       "ok",
 					"id":           id,
 					"experiment":   e,
-					"observations": obsIDs,
+					"observations": observationIDs(exec.CurrentObservations),
 				})
 			}
 			w.Textf("created baseline %s (ref=%s, sha=%s)\n", id, baseline, sha[:12])
 			w.Textf("  worktree: %s\n", wtPath)
 			w.Textln("  observations:")
-			for _, r := range results {
+			for _, r := range exec.Results {
 				w.Textf("    %-16s %s = %g %s\n", r.ID, r.Inst, r.Value, r.Unit)
 			}
 			return nil

--- a/internal/cli/frontier.go
+++ b/internal/cli/frontier.go
@@ -130,7 +130,7 @@ func collectFrontiers(s *store.Store, scope goalScope) ([]goalFrontier, error) {
 	if err != nil {
 		return nil, err
 	}
-	obsByExp := readmodel.LoadObservationsByExperiment(s)
+	obsByExp := readmodel.LoadObservationIndex(s)
 	expClassByID, err := readmodel.ClassifyAllExperimentsForRead(s)
 	if err != nil {
 		return nil, err

--- a/internal/cli/goal_frontier_test.go
+++ b/internal/cli/goal_frontier_test.go
@@ -8,6 +8,25 @@ import (
 	"github.com/bytter/autoresearch/internal/readmodel"
 )
 
+func observationIndexForFrontierTest(m map[string][]*entity.Observation) *readmodel.ObservationIndex {
+	var all []*entity.Observation
+	for expID, obs := range m {
+		for _, o := range obs {
+			if o == nil {
+				continue
+			}
+			if o.Experiment == expID {
+				all = append(all, o)
+				continue
+			}
+			copyObs := *o
+			copyObs.Experiment = expID
+			all = append(all, &copyObs)
+		}
+	}
+	return readmodel.NewObservationIndex(all)
+}
+
 func TestBuildGoalFromFlags_DefaultsThresholdPolicy(t *testing.T) {
 	g, err := buildGoalFromFlags(
 		"host_timing",
@@ -176,7 +195,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-0001": {{Instrument: "host_timing", Value: 0.75}},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), nil)
 		if !got.Met || got.MetByConclusion != "C-0001" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -212,7 +231,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-0001": {{Instrument: "host_timing", Value: 0.70}},
 			"E-0002": {{Instrument: "host_timing", Value: 0.82}},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), nil)
 		if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -280,7 +299,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 				{Instrument: "host_test", Pass: &pass},
 			},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), nil)
 		if !got.Met || got.MetByConclusion != "C-0102" || got.RecommendedAction != "ask_human" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -307,7 +326,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 		obsByExp := map[string][]*entity.Observation{
 			"E-1000": {{Instrument: "throughput", Value: 112}},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), nil)
 		if !got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -343,7 +362,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 			"E-2000": {{Instrument: "host_timing", Value: 0.70}},
 			"E-2001": {{Instrument: "host_timing", Value: 0.70}},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, nil)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), nil)
 		if got.Met || got.RecommendedAction != "continue" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -376,7 +395,7 @@ func TestAssessGoalCompletion(t *testing.T) {
 				HypothesisStatus: entity.StatusSupported,
 			},
 		}
-		got := readmodel.AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
+		got := readmodel.AssessGoalCompletion(goal, concls, observationIndexForFrontierTest(obsByExp), expClassByID)
 		if !got.Met || got.MetByConclusion != "C-3000" || got.RecommendedAction != "stop" {
 			t.Fatalf("unexpected assessment: %+v", got)
 		}
@@ -399,7 +418,7 @@ func TestComputeFrontierFromObservations_CarriesExperimentClassification(t *test
 	obsByExp := map[string][]*entity.Observation{
 		"E-0001": {{Instrument: "host_timing", Value: 0.75}},
 	}
-	rows, _ := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
+	rows, _ := readmodel.ComputeFrontierFromObservations(goal, concls, observationIndexForFrontierTest(obsByExp), map[string]experimentReadClass{
 		"E-0001": {
 			Classification:   experimentClassificationDead,
 			HypothesisStatus: entity.StatusSupported,
@@ -452,7 +471,7 @@ func TestComputeFrontierFromObservations_StalledForCountsLaterConclusionsAfterAc
 		"E-0002": {{Instrument: "host_timing", Value: 101}},
 		"E-0003": {{Instrument: "host_timing", Value: 90}},
 	}
-	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]experimentReadClass{
+	rows, stalled := readmodel.ComputeFrontierFromObservations(goal, concls, observationIndexForFrontierTest(obsByExp), map[string]experimentReadClass{
 		"E-0001": {
 			Classification:   experimentClassificationDead,
 			HypothesisStatus: entity.StatusSupported,

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -463,6 +463,21 @@ func abs(f float64) float64 {
 	return f
 }
 
+func conclusionMeasuredCandidateRef(concl *entity.Conclusion, exp *entity.Experiment) string {
+	if concl != nil {
+		if strings.TrimSpace(concl.CandidateSHA) != "" {
+			return concl.CandidateSHA
+		}
+		if strings.TrimSpace(concl.CandidateRef) != "" {
+			return concl.CandidateRef
+		}
+	}
+	if exp == nil {
+		return ""
+	}
+	return exp.Branch
+}
+
 func hypothesisWorktreeCmd() *cobra.Command {
 	var conclusionID string
 	c := &cobra.Command{
@@ -514,18 +529,19 @@ Use --conclusion C-NNNN to pick a specific conclusion.`,
 			if err != nil {
 				return err
 			}
-			_, exp, err := resolveWinningExperiment(s, args[0], conclusionID)
+			concl, exp, err := resolveWinningExperiment(s, args[0], conclusionID)
 			if err != nil {
 				return err
 			}
-			if exp.Branch == "" {
+			source := conclusionMeasuredCandidateRef(concl, exp)
+			if source == "" {
 				return fmt.Errorf("%s has no branch (status=%s)", exp.ID, exp.Status)
 			}
 			base := exp.Baseline.SHA
 			if base == "" {
 				base = exp.Baseline.Ref
 			}
-			diff, err := worktree.Diff(globalProjectDir, base, exp.Branch)
+			diff, err := worktree.Diff(globalProjectDir, base, source)
 			if err != nil {
 				return err
 			}
@@ -536,6 +552,19 @@ Use --conclusion C-NNNN to pick a specific conclusion.`,
 					"experiment": exp.ID,
 					"baseline":   base,
 					"branch":     exp.Branch,
+					"candidate_ref": func() string {
+						if concl == nil {
+							return ""
+						}
+						return concl.CandidateRef
+					}(),
+					"candidate_sha": func() string {
+						if concl == nil {
+							return ""
+						}
+						return concl.CandidateSHA
+					}(),
+					"source_ref": source,
 					"diff":       diff,
 				})
 			}
@@ -586,40 +615,47 @@ Use --conclusion C-NNNN to pick a specific conclusion.`,
 			if hyp.Status == entity.StatusUnreviewed {
 				return fmt.Errorf("hypothesis %s is unreviewed — dispatch the gate reviewer to review %s first (or self-review with `conclusion accept %s --reviewed-by ...`)", args[0], concl.ID, concl.ID)
 			}
-			if exp.Branch == "" {
+			source := conclusionMeasuredCandidateRef(concl, exp)
+			if source == "" {
 				return fmt.Errorf("%s has no branch (status=%s)", exp.ID, exp.Status)
 			}
 			verb := "cherry-pick"
 			if merge {
 				verb = "merge"
 			}
-			if err := dryRun(w, fmt.Sprintf("%s branch %s (experiment %s, conclusion %s)", verb, exp.Branch, exp.ID, concl.ID), map[string]any{
-				"action":     verb,
-				"hypothesis": args[0],
-				"conclusion": concl.ID,
-				"experiment": exp.ID,
-				"branch":     exp.Branch,
+			if err := dryRun(w, fmt.Sprintf("%s ref %s (experiment %s, conclusion %s)", verb, source, exp.ID, concl.ID), map[string]any{
+				"action":        verb,
+				"hypothesis":    args[0],
+				"conclusion":    concl.ID,
+				"experiment":    exp.ID,
+				"branch":        exp.Branch,
+				"candidate_ref": concl.CandidateRef,
+				"candidate_sha": concl.CandidateSHA,
+				"source_ref":    source,
 			}); err != nil {
 				return err
 			}
 			var out string
 			if merge {
-				out, err = worktree.Merge(globalProjectDir, exp.Branch)
+				out, err = worktree.Merge(globalProjectDir, source)
 			} else {
-				out, err = worktree.CherryPick(globalProjectDir, exp.Baseline.SHA, exp.Branch)
+				out, err = worktree.CherryPick(globalProjectDir, exp.Baseline.SHA, source)
 			}
 			if err != nil {
 				return err
 			}
 			return w.Emit(
-				fmt.Sprintf("applied %s → %s\n%s", concl.ID, exp.Branch, out),
+				fmt.Sprintf("applied %s → %s\n%s", concl.ID, source, out),
 				map[string]any{
-					"status":     "ok",
-					"hypothesis": args[0],
-					"conclusion": concl.ID,
-					"experiment": exp.ID,
-					"branch":     exp.Branch,
-					"output":     out,
+					"status":        "ok",
+					"hypothesis":    args[0],
+					"conclusion":    concl.ID,
+					"experiment":    exp.ID,
+					"branch":        exp.Branch,
+					"candidate_ref": concl.CandidateRef,
+					"candidate_sha": concl.CandidateSHA,
+					"source_ref":    source,
+					"output":        out,
 				},
 			)
 		},

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -23,9 +23,15 @@ type cliImplementResponse struct {
 }
 
 type cliObserveAllResponse struct {
-	Results []struct {
-		ID   string `json:"id"`
-		Inst string `json:"instrument"`
+	Action             string   `json:"action"`
+	Observations       []string `json:"observations"`
+	NewObservations    []string `json:"new_observations"`
+	ReusedObservations []string `json:"reused_observations"`
+	Results            []struct {
+		ID     string   `json:"id"`
+		IDs    []string `json:"ids"`
+		Inst   string   `json:"instrument"`
+		Action string   `json:"action"`
 	} `json:"results"`
 }
 

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -126,9 +126,10 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 	impl1 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp1.ID)
 	writeScenarioMetrics(t, impl1.Worktree, "80\n", "900\n")
 	gitCommitAll(t, impl1.Worktree, "improve timing")
+	candidateRef1 := gitCreateCandidateRef(t, impl1.Worktree, "candidate/lifecycle-e1")
 
-	obs1 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp1.ID, "--all")
-	analyze1 := runCLIJSON[cliAnalyzeResponse](t, dir, "analyze", exp1.ID, "--baseline", baseline.ID)
+	obs1 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp1.ID, "--all", "--candidate-ref", candidateRef1)
+	analyze1 := runCLIJSON[cliAnalyzeResponse](t, dir, "analyze", exp1.ID, "--candidate-ref", candidateRef1, "--baseline", baseline.ID)
 	if got, want := len(analyze1.Rows), 3; got != want {
 		t.Fatalf("analyze rows len = %d, want %d", got, want)
 	}
@@ -164,8 +165,9 @@ func TestLifecycleScenario_ReadSurfacesStayConsistentAfterAcceptedWinAndLaterSta
 	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp2.ID)
 	writeScenarioMetrics(t, impl2.Worktree, "95\n", "900\n")
 	gitCommitAll(t, impl2.Worktree, "small tweak")
+	candidateRef2 := gitCreateCandidateRef(t, impl2.Worktree, "candidate/lifecycle-e2")
 
-	obs2 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp2.ID, "--all")
+	obs2 := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp2.ID, "--all", "--candidate-ref", candidateRef2)
 	runCLIJSON[cliIDResponse](t, dir,
 		"conclude", hyp2.ID,
 		"--verdict", "inconclusive",
@@ -298,8 +300,9 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 	writeScenarioMechanism(t, impl.Worktree, "candidate trace\n")
 	gitRun(t, impl.Worktree, "add", "timing.txt", "size.txt", "mechanism.txt")
 	gitRun(t, impl.Worktree, "commit", "-m", "improve timing")
+	candidateRef := gitCreateCandidateRef(t, impl.Worktree, "candidate/evidence-e1")
 
-	obs := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	obs := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all", "--candidate-ref", candidateRef)
 	timingObsID := observeResultID(t, obs, "timing")
 	concl := runCLIJSON[cliIDResponse](t, dir,
 		"conclude", hyp.ID,
@@ -359,7 +362,8 @@ func TestLifecycleScenario_EvidenceArtifactsCloseAuditChain(t *testing.T) {
 	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp2.ID)
 	writeScenarioMetrics(t, impl2.Worktree, "95\n", "900\n")
 	gitCommitAll(t, impl2.Worktree, "small tweak")
-	obs2 := runCLIJSON[cliIDResponse](t, dir, "observe", exp2.ID, "--instrument", "timing")
+	candidateRef2 := gitCreateCandidateRef(t, impl2.Worktree, "candidate/evidence-e2")
+	obs2 := runCLIJSON[cliIDResponse](t, dir, "observe", exp2.ID, "--instrument", "timing", "--candidate-ref", candidateRef2)
 	concl2 := runCLIJSON[cliIDResponse](t, dir,
 		"conclude", hyp2.ID,
 		"--verdict", "inconclusive",
@@ -504,6 +508,12 @@ func gitCommitAll(t *testing.T, dir, msg string) {
 	t.Helper()
 	gitRun(t, dir, "add", "timing.txt", "size.txt")
 	gitRun(t, dir, "commit", "-m", msg)
+}
+
+func gitCreateCandidateRef(t *testing.T, dir, ref string) string {
+	t.Helper()
+	gitRun(t, dir, "branch", ref, "HEAD")
+	return ref
 }
 
 func gitRun(t *testing.T, dir string, args ...string) {

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -165,7 +165,7 @@ the requested total. Pass --append to force another run.`,
 			if err := dryRun(w, actionText, actionPayload); err != nil {
 				return err
 			}
-			exec, err := executeObservationRun(s, cfg, exp, scope, priorObs, check, appendMode, or(author, "agent:observer"))
+			exec, err := executeObservationRun(s, cfg, exp, scope, check, appendMode, or(author, "agent:observer"))
 			if err != nil {
 				return err
 			}

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -19,6 +19,7 @@ func observeCommands() []*cobra.Command {
 		appendMode     bool
 		allowUnchanged bool
 		all            bool
+		candidateRef   string
 	)
 	c := &cobra.Command{
 		Use:   "observe <exp-id>",
@@ -36,11 +37,15 @@ the artifact is guaranteed to exist on disk. This is the speculation/
 observation firewall, made physical.
 
 By default, observe is idempotent for the current implementation attempt
-and candidate snapshot:
-if enough samples already exist for the current implementation attempt and
-candidate snapshot, it no-ops; if some exist but not enough, it tops up to
-the requested total. Dirty worktrees disable reuse until the candidate is
-clean or committed again. Pass --append to force another run.`,
+and measured candidate provenance: if enough samples already exist for the
+current implementation attempt and candidate ref/SHA, it no-ops; if some
+exist but not enough, it tops up to the requested total.
+
+For non-baseline experiments, observe requires --candidate-ref. The CLI
+does not create candidate commits or refs for you: use normal git to
+create a clean, reviewable ref for the commit you want to measure, then
+pass that ref to observe. The worktree must be clean and HEAD must match
+the candidate ref. Pass --append to force another run.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
@@ -75,16 +80,18 @@ clean or committed again. Pass --append to force another run.`,
 			// commit any changes.
 			if !allowUnchanged && !exp.IsBaseline && exp.Branch != "" && exp.Baseline.SHA != "" {
 				if hasCommits, err := worktree.HasCommitsAbove(globalProjectDir, exp.Branch, exp.Baseline.SHA); err == nil && !hasCommits {
-					inst := instName
+					proceedArgs := "--all"
 					if all {
-						inst = "--all"
+						proceedArgs = "--all"
+					} else {
+						proceedArgs = fmt.Sprintf("--instrument %s", instName)
 					}
 					return fmt.Errorf(
 						"experiment %s branch %s has no commits above baseline %s — "+
 							"the implementation may not have succeeded\n"+
 							"  reset:   autoresearch experiment reset %s --reason \"...\"\n"+
-							"  proceed: autoresearch observe %s --instrument %s --allow-unchanged",
-						expID, exp.Branch, exp.Baseline.SHA[:12], expID, expID, inst)
+							"  proceed: autoresearch observe %s %s --candidate-ref <ref> --allow-unchanged",
+						expID, exp.Branch, exp.Baseline.SHA[:12], expID, expID, proceedArgs)
 				}
 			}
 
@@ -93,11 +100,20 @@ clean or committed again. Pass --append to force another run.`,
 				if len(exp.Instruments) == 0 {
 					return fmt.Errorf("experiment %s declares no instruments", expID)
 				}
-				if err := dryRun(w, fmt.Sprintf("observe all %d instruments on %s", len(exp.Instruments), expID), map[string]any{"instruments": exp.Instruments, "worktree": exp.Worktree}); err != nil {
+				scope, priorObs, err := loadCurrentObservations(s, exp, candidateRef)
+				if err != nil {
+					return err
+				}
+				payload := map[string]any{"instruments": exp.Instruments, "worktree": exp.Worktree}
+				if scope.CandidateRef != "" {
+					payload["candidate_ref"] = scope.CandidateRef
+					payload["candidate_sha"] = scope.CandidateSHA
+				}
+				if err := dryRun(w, fmt.Sprintf("observe all %d instruments on %s", len(exp.Instruments), expID), payload); err != nil {
 					return err
 				}
 
-				exec, err := observeAll(s, cfg, exp, exp.Instruments, samples, appendMode, or(author, "agent:observer"))
+				exec, err := observeAll(s, cfg, exp, scope, priorObs, exp.Instruments, samples, appendMode, or(author, "agent:observer"))
 				if err != nil {
 					return err
 				}
@@ -137,7 +153,7 @@ clean or committed again. Pass --append to force another run.`,
 			if err := firewall.CheckObservationRequest(instName, samples, exp, cfg, strict); err != nil {
 				return err
 			}
-			scope, priorObs, err := loadCurrentObservations(s, exp)
+			scope, priorObs, err := loadCurrentObservations(s, exp, candidateRef)
 			if err != nil {
 				return err
 			}
@@ -163,6 +179,10 @@ clean or committed again. Pass --append to force another run.`,
 				}
 			}
 			actionText, actionPayload := describeObserveAction(exp, check, appendMode)
+			if scope.CandidateRef != "" {
+				actionPayload["candidate_ref"] = scope.CandidateRef
+				actionPayload["candidate_sha"] = scope.CandidateSHA
+			}
 			if err := dryRun(w, actionText, actionPayload); err != nil {
 				return err
 			}
@@ -207,14 +227,16 @@ clean or committed again. Pass --append to force another run.`,
 	c.Flags().BoolVar(&force, "force", false, "bypass instrument dependency checks")
 	c.Flags().BoolVar(&appendMode, "append", false, "force another observation run even when enough samples already exist")
 	c.Flags().BoolVar(&allowUnchanged, "allow-unchanged", false, "proceed even when the experiment branch has no commits above baseline")
+	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "reviewable git ref naming the clean candidate being measured (required for non-baseline experiments)")
 	c.AddCommand(observeCheckCommand())
 	return []*cobra.Command{c}
 }
 
 func observeCheckCommand() *cobra.Command {
 	var (
-		instName string
-		samples  int
+		instName     string
+		samples      int
+		candidateRef string
 	)
 	c := &cobra.Command{
 		Use:   "check <exp-id>",
@@ -239,7 +261,7 @@ func observeCheckCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			_, priorObs, err := loadCurrentObservations(s, exp)
+			_, priorObs, err := loadCurrentObservations(s, exp, candidateRef)
 			if err != nil {
 				return err
 			}
@@ -260,5 +282,6 @@ func observeCheckCommand() *cobra.Command {
 	}
 	c.Flags().StringVar(&instName, "instrument", "", "registered instrument name")
 	c.Flags().IntVar(&samples, "samples", 0, "desired total sample count to check; 0 uses instrument min_samples or parser default")
+	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "reviewable git ref naming the clean candidate whose observations should be checked (required for non-baseline experiments)")
 	return c
 }

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -35,9 +35,11 @@ Observations are never hand-authored — the CLI is the sole writer and
 the artifact is guaranteed to exist on disk. This is the speculation/
 observation firewall, made physical.
 
-By default, observe is idempotent on the (experiment, instrument) pair:
-if enough samples already exist, it no-ops; if some exist but not enough,
-it tops up to the requested total. Pass --append to force another run.`,
+By default, observe is idempotent for the current implementation attempt
+and candidate commit:
+if enough samples already exist for the current implementation attempt and
+candidate commit, it no-ops; if some exist but not enough, it tops up to
+the requested total. Pass --append to force another run.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
@@ -94,19 +96,21 @@ it tops up to the requested total. Pass --append to force another run.`,
 					return err
 				}
 
-				results, err := observeAll(s, cfg, exp, exp.Instruments, samples, appendMode, or(author, "agent:observer"))
+				exec, err := observeAll(s, cfg, exp, exp.Instruments, samples, appendMode, or(author, "agent:observer"))
 				if err != nil {
 					return err
 				}
-				summary := summarizeObserveResults(results)
+				summary := buildObserveResultSummary(exec.Results, exec.CurrentObservations, exec.NewObservations)
 
 				if w.IsJSON() {
 					return w.JSON(map[string]any{
-						"status":       "ok",
-						"experiment":   expID,
-						"action":       summary.Action,
-						"observations": summary.RecordedIDs,
-						"results":      results,
+						"status":              "ok",
+						"experiment":          expID,
+						"action":              summary.Action,
+						"observations":        summary.CurrentIDs,
+						"new_observations":    summary.RecordedIDs,
+						"reused_observations": summary.ReusedIDs,
+						"results":             exec.Results,
 					})
 				}
 				switch {
@@ -117,7 +121,7 @@ it tops up to the requested total. Pass --append to force another run.`,
 				default:
 					w.Textf("observed %d instrument(s) on %s; skipped %d already satisfied instrument(s)\n", summary.RecordedCount, expID, summary.SkippedCount)
 				}
-				for _, r := range results {
+				for _, r := range exec.Results {
 					if r.skipped() {
 						w.Textf("  %-16s already satisfied (have %d, target %d)\n", r.Inst, r.CurrentSamples, r.TargetSamples)
 						continue
@@ -132,7 +136,7 @@ it tops up to the requested total. Pass --append to force another run.`,
 			if err := firewall.CheckObservationRequest(instName, samples, exp, cfg, strict); err != nil {
 				return err
 			}
-			priorObs, err := s.ListObservationsForExperiment(expID)
+			scope, priorObs, err := loadCurrentObservations(s, exp)
 			if err != nil {
 				return err
 			}
@@ -161,7 +165,7 @@ it tops up to the requested total. Pass --append to force another run.`,
 			if err := dryRun(w, actionText, actionPayload); err != nil {
 				return err
 			}
-			exec, err := executeObservationRun(s, cfg, exp, check, appendMode, or(author, "agent:observer"))
+			exec, err := executeObservationRun(s, cfg, exp, scope, priorObs, check, appendMode, or(author, "agent:observer"))
 			if err != nil {
 				return err
 			}
@@ -230,10 +234,11 @@ func observeCheckCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if _, err := s.ReadExperiment(expID); err != nil {
+			exp, err := s.ReadExperiment(expID)
+			if err != nil {
 				return err
 			}
-			priorObs, err := s.ListObservationsForExperiment(expID)
+			_, priorObs, err := loadCurrentObservations(s, exp)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/output"
 	"github.com/bytter/autoresearch/internal/worktree"
@@ -17,6 +16,7 @@ func observeCommands() []*cobra.Command {
 		samples        int
 		author         string
 		force          bool
+		appendMode     bool
 		allowUnchanged bool
 		all            bool
 	)
@@ -33,7 +33,11 @@ instrument declared on the experiment in dependency-safe order.
 
 Observations are never hand-authored — the CLI is the sole writer and
 the artifact is guaranteed to exist on disk. This is the speculation/
-observation firewall, made physical.`,
+observation firewall, made physical.
+
+By default, observe is idempotent on the (experiment, instrument) pair:
+if enough samples already exist, it no-ops; if some exist but not enough,
+it tops up to the requested total. Pass --append to force another run.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
@@ -90,26 +94,35 @@ observation firewall, made physical.`,
 					return err
 				}
 
-				results, err := observeAll(s, cfg, exp, exp.Instruments, samples, or(author, "agent:observer"))
+				results, err := observeAll(s, cfg, exp, exp.Instruments, samples, appendMode, or(author, "agent:observer"))
 				if err != nil {
 					return err
 				}
+				summary := summarizeObserveResults(results)
 
 				if w.IsJSON() {
-					ids := make([]string, 0, len(results))
-					for _, r := range results {
-						ids = append(ids, r.ID)
-					}
 					return w.JSON(map[string]any{
 						"status":       "ok",
 						"experiment":   expID,
-						"observations": ids,
+						"action":       summary.Action,
+						"observations": summary.RecordedIDs,
 						"results":      results,
 					})
 				}
-				w.Textf("observed %d instruments on %s\n", len(results), expID)
+				switch {
+				case summary.RecordedCount == 0 && summary.SkippedCount > 0:
+					w.Textf("no new observations on %s; %d instrument(s) already satisfied\n", expID, summary.SkippedCount)
+				case summary.SkippedCount == 0:
+					w.Textf("observed %d instrument(s) on %s\n", summary.RecordedCount, expID)
+				default:
+					w.Textf("observed %d instrument(s) on %s; skipped %d already satisfied instrument(s)\n", summary.RecordedCount, expID, summary.SkippedCount)
+				}
 				for _, r := range results {
-					w.Textf("  %-16s %s = %g %s\n", r.ID, r.Inst, r.Value, r.Unit)
+					if r.skipped() {
+						w.Textf("  %-16s already satisfied (have %d, target %d)\n", r.Inst, r.CurrentSamples, r.TargetSamples)
+						continue
+					}
+					w.Textf("  %-16s %s = %g %s  (recorded %d, now %d/%d)\n", r.ID, r.Inst, r.Value, r.Unit, r.Samples, r.CurrentSamples, r.TargetSamples)
 				}
 				return nil
 			}
@@ -119,51 +132,64 @@ observation firewall, made physical.`,
 			if err := firewall.CheckObservationRequest(instName, samples, exp, cfg, strict); err != nil {
 				return err
 			}
+			priorObs, err := s.ListObservationsForExperiment(expID)
+			if err != nil {
+				return err
+			}
+			check, err := buildObserveSampleCheck(cfg, expID, instName, samples, priorObs)
+			if err != nil {
+				return err
+			}
+			if !appendMode && check.TargetSatisfied {
+				result := buildSkippedObservationResult(check)
+				return w.Emit(
+					fmt.Sprintf("observation already satisfied for %s on %s: %s", instName, expID, formatObserveSatisfiedText(check)),
+					map[string]any{
+						"status":       "ok",
+						"action":       result.Action,
+						"sample_check": check,
+					},
+				)
+			}
+
 			if !force {
-				priorObs, err := s.ListObservationsForExperiment(expID)
-				if err != nil {
-					return err
-				}
 				if err := firewall.CheckInstrumentDependencies(instName, cfg, priorObs); err != nil {
 					return err
 				}
 			}
-
-			if err := dryRun(w, fmt.Sprintf("run instrument %q against %s", instName, exp.Worktree), map[string]any{"instrument": instName, "worktree": exp.Worktree}); err != nil {
+			actionText, actionPayload := describeObserveAction(exp, check, appendMode)
+			if err := dryRun(w, actionText, actionPayload); err != nil {
 				return err
 			}
-
-			obs, err := runAndRecordObservation(s, cfg, exp, instName, samples, or(author, "agent:observer"))
+			exec, err := executeObservationRun(s, cfg, exp, check, appendMode, or(author, "agent:observer"))
 			if err != nil {
 				return err
 			}
-
-			// Bump experiment status on first observation.
-			if exp.Status == entity.ExpImplemented {
-				exp.Status = entity.ExpMeasured
-				if err := s.WriteExperiment(exp); err != nil {
-					return fmt.Errorf("update experiment status: %w", err)
+			if err := markExperimentMeasuredIfNeeded(s, exp); err != nil {
+				return err
+			}
+			if w.IsJSON() {
+				return w.JSON(recordedObservationPayload(exec))
+			}
+			if len(exec.Observations) == 1 {
+				w.Textf("recorded %s\n", exec.Latest.ID)
+			} else {
+				w.Textf("recorded %d observations for %s on %s\n", len(exec.Observations), instName, expID)
+				for _, id := range exec.Result.IDs {
+					w.Textf("  id:          %s\n", id)
 				}
 			}
-
-			if w.IsJSON() {
-				return w.JSON(map[string]any{
-					"status":      "ok",
-					"id":          obs.ID,
-					"observation": obs,
-				})
-			}
-			w.Textf("recorded %s\n", obs.ID)
 			w.Textf("  instrument:  %s\n", instName)
-			w.Textf("  value:       %g %s\n", obs.Value, obs.Unit)
-			if obs.Samples > 1 && obs.CILow != nil && obs.CIHigh != nil {
-				w.Textf("  samples:     %d (95%% CI [%g, %g], %s)\n", obs.Samples, *obs.CILow, *obs.CIHigh, obs.CIMethod)
+			w.Textf("  value:       %g %s\n", exec.Latest.Value, exec.Latest.Unit)
+			w.Textf("  samples:     +%d (now %d/%d)\n", exec.Result.Samples, exec.Result.CurrentSamples, exec.Result.TargetSamples)
+			if exec.Latest.Samples > 1 && exec.Latest.CILow != nil && exec.Latest.CIHigh != nil {
+				w.Textf("  latest run:  %d (95%% CI [%g, %g], %s)\n", exec.Latest.Samples, *exec.Latest.CILow, *exec.Latest.CIHigh, exec.Latest.CIMethod)
 			}
-			if obs.Pass != nil {
-				w.Textf("  pass:        %v (exit=%d)\n", *obs.Pass, obs.ExitCode)
+			if exec.Latest.Pass != nil {
+				w.Textf("  pass:        %v (exit=%d)\n", *exec.Latest.Pass, exec.Latest.ExitCode)
 			}
 			w.Textln("  artifacts:")
-			for _, a := range obs.Artifacts {
+			for _, a := range exec.Latest.Artifacts {
 				w.Textf("    - %-10s %s  (%d bytes)  sha=%s\n", a.Name, a.Path, a.Bytes, a.SHA[:12])
 			}
 			return nil
@@ -171,9 +197,62 @@ observation firewall, made physical.`,
 	}
 	c.Flags().StringVar(&instName, "instrument", "", "registered instrument name")
 	c.Flags().BoolVar(&all, "all", false, "run all instruments declared on the experiment in dependency order")
-	c.Flags().IntVar(&samples, "samples", 0, "number of samples (timing); 0 uses instrument min_samples or default 5")
+	c.Flags().IntVar(&samples, "samples", 0, "desired sample count; without --append, tops up to this total for multi-sample instruments")
 	addAuthorFlag(c, &author, "")
 	c.Flags().BoolVar(&force, "force", false, "bypass instrument dependency checks")
+	c.Flags().BoolVar(&appendMode, "append", false, "force another observation run even when enough samples already exist")
 	c.Flags().BoolVar(&allowUnchanged, "allow-unchanged", false, "proceed even when the experiment branch has no commits above baseline")
+	c.AddCommand(observeCheckCommand())
 	return []*cobra.Command{c}
+}
+
+func observeCheckCommand() *cobra.Command {
+	var (
+		instName string
+		samples  int
+	)
+	c := &cobra.Command{
+		Use:   "check <exp-id>",
+		Short: "Report sample sufficiency for one instrument on one experiment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := output.Default(globalJSON)
+			expID := args[0]
+			if instName == "" {
+				return errors.New("--instrument is required")
+			}
+
+			s, err := openStore()
+			if err != nil {
+				return err
+			}
+			cfg, err := s.Config()
+			if err != nil {
+				return err
+			}
+			if _, err := s.ReadExperiment(expID); err != nil {
+				return err
+			}
+			priorObs, err := s.ListObservationsForExperiment(expID)
+			if err != nil {
+				return err
+			}
+			check, err := buildObserveSampleCheck(cfg, expID, instName, samples, priorObs)
+			if err != nil {
+				return err
+			}
+
+			if w.IsJSON() {
+				return w.JSON(map[string]any{
+					"status": "ok",
+					"check":  check,
+				})
+			}
+			w.Textln(formatObserveCheckText(check))
+			return nil
+		},
+	}
+	c.Flags().StringVar(&instName, "instrument", "", "registered instrument name")
+	c.Flags().IntVar(&samples, "samples", 0, "desired total sample count to check; 0 uses instrument min_samples or parser default")
+	return c
 }

--- a/internal/cli/observe.go
+++ b/internal/cli/observe.go
@@ -36,10 +36,11 @@ the artifact is guaranteed to exist on disk. This is the speculation/
 observation firewall, made physical.
 
 By default, observe is idempotent for the current implementation attempt
-and candidate commit:
+and candidate snapshot:
 if enough samples already exist for the current implementation attempt and
-candidate commit, it no-ops; if some exist but not enough, it tops up to
-the requested total. Pass --append to force another run.`,
+candidate snapshot, it no-ops; if some exist but not enough, it tops up to
+the requested total. Dirty worktrees disable reuse until the candidate is
+clean or committed again. Pass --append to force another run.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -45,6 +45,7 @@ type observeExecution struct {
 type observeScope struct {
 	Attempt      int
 	CandidateSHA string
+	DirtyPaths   []string
 }
 
 type observeAllExecution struct {
@@ -110,9 +111,14 @@ func resolveObserveScope(exp *entity.Experiment) (observeScope, error) {
 	if err != nil {
 		return observeScope{}, fmt.Errorf("resolve candidate HEAD for %s: %w", exp.ID, err)
 	}
+	dirtyPaths, err := observeScopeDirtyPaths(exp.Worktree)
+	if err != nil {
+		return observeScope{}, fmt.Errorf("inspect candidate dirtiness for %s: %w", exp.ID, err)
+	}
 	return observeScope{
 		Attempt:      exp.Attempt,
 		CandidateSHA: sha,
+		DirtyPaths:   dirtyPaths,
 	}, nil
 }
 
@@ -121,11 +127,37 @@ func loadCurrentObservations(s *store.Store, exp *entity.Experiment) (observeSco
 	if err != nil {
 		return observeScope{}, nil, err
 	}
+	if !scope.reuseEnabled() {
+		return scope, nil, nil
+	}
 	all, err := s.ListObservationsForExperiment(exp.ID)
 	if err != nil {
 		return observeScope{}, nil, err
 	}
 	return scope, filterObservationsByScope(all, scope), nil
+}
+
+func observeScopeDirtyPaths(worktreeDir string) ([]string, error) {
+	paths, err := worktree.DirtyPaths(worktreeDir)
+	if err != nil {
+		return nil, err
+	}
+	managed, err := autoresearchManagedCheckoutPaths()
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == entity.BriefFileName || isAutoresearchManagedCheckoutPath(path, managed) {
+			continue
+		}
+		filtered = append(filtered, path)
+	}
+	return filtered, nil
+}
+
+func (s observeScope) reuseEnabled() bool {
+	return len(s.DirtyPaths) == 0
 }
 
 func filterObservationsByScope(observations []*entity.Observation, scope observeScope) []*entity.Observation {
@@ -140,6 +172,9 @@ func filterObservationsByScope(observations []*entity.Observation, scope observe
 
 func observationInScope(o *entity.Observation, scope observeScope) bool {
 	if o == nil {
+		return false
+	}
+	if !scope.reuseEnabled() {
 		return false
 	}
 	if o.Attempt != scope.Attempt {

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -292,7 +292,6 @@ func executeObservationRun(
 	cfg *store.Config,
 	exp *entity.Experiment,
 	scope observeScope,
-	currentObservations []*entity.Observation,
 	check observeSampleCheck,
 	appendMode bool,
 	author string,
@@ -301,11 +300,7 @@ func executeObservationRun(
 	if err != nil {
 		return observeExecution{}, err
 	}
-	currentSamples := samplesForObservedInstrument(
-		cfg.Instruments[check.Instrument],
-		append(append([]*entity.Observation(nil), currentObservations...), observations...),
-		check.Instrument,
-	)
+	currentSamples := check.CurrentSamples + samplesForObservedInstrument(cfg.Instruments[check.Instrument], observations, check.Instrument)
 	return buildRecordedObservationResult(check, observations, currentSamples)
 }
 
@@ -328,10 +323,12 @@ func describeObserveAction(exp *entity.Experiment, check observeSampleCheck, app
 	}
 }
 
-func summarizeObserveResults(results []observationResult) observeResultSummary {
+func buildObserveResultSummary(results []observationResult, currentObservations, newObservations []*entity.Observation) observeResultSummary {
 	summary := observeResultSummary{
 		Action:      observeActionRecorded,
-		RecordedIDs: make([]string, 0, len(results)),
+		CurrentIDs:  observationIDs(currentObservations),
+		RecordedIDs: observationIDs(newObservations),
+		ReusedIDs:   currentObservationReuseIDs(currentObservations, newObservations),
 	}
 	for _, r := range results {
 		if r.skipped() {
@@ -339,7 +336,6 @@ func summarizeObserveResults(results []observationResult) observeResultSummary {
 			continue
 		}
 		summary.RecordedCount++
-		summary.RecordedIDs = append(summary.RecordedIDs, r.IDs...)
 	}
 	if summary.RecordedCount == 0 && summary.SkippedCount > 0 {
 		summary.Action = observeActionSkipped
@@ -347,17 +343,14 @@ func summarizeObserveResults(results []observationResult) observeResultSummary {
 	return summary
 }
 
-func buildObserveResultSummary(results []observationResult, currentObservations, newObservations []*entity.Observation) observeResultSummary {
-	summary := summarizeObserveResults(results)
-	summary.CurrentIDs = observationIDs(currentObservations)
-	summary.RecordedIDs = observationIDs(newObservations)
-	reused := make([]*entity.Observation, 0, len(currentObservations))
+func currentObservationReuseIDs(currentObservations, newObservations []*entity.Observation) []string {
 	recorded := make(map[string]struct{}, len(newObservations))
 	for _, o := range newObservations {
 		if o != nil {
 			recorded[o.ID] = struct{}{}
 		}
 	}
+	reused := make([]string, 0, len(currentObservations))
 	for _, o := range currentObservations {
 		if o == nil {
 			continue
@@ -365,10 +358,9 @@ func buildObserveResultSummary(results []observationResult, currentObservations,
 		if _, ok := recorded[o.ID]; ok {
 			continue
 		}
-		reused = append(reused, o)
+		reused = append(reused, o.ID)
 	}
-	summary.ReusedIDs = observationIDs(reused)
-	return summary
+	return reused
 }
 
 func recordedObservationPayload(exec observeExecution) map[string]any {
@@ -588,7 +580,7 @@ func observeAll(
 				continue
 			}
 
-			exec, err := executeObservationRun(s, cfg, exp, scope, priorObs, check, appendMode, author)
+			exec, err := executeObservationRun(s, cfg, exp, scope, check, appendMode, author)
 			if err != nil {
 				return observeAllExecution{}, err
 			}

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/bytter/autoresearch/internal/firewall"
 	"github.com/bytter/autoresearch/internal/instrument"
 	"github.com/bytter/autoresearch/internal/store"
+	"github.com/bytter/autoresearch/internal/worktree"
 )
 
 const (
@@ -41,9 +42,22 @@ type observeExecution struct {
 	Latest       *entity.Observation
 }
 
+type observeScope struct {
+	Attempt      int
+	CandidateSHA string
+}
+
+type observeAllExecution struct {
+	Results             []observationResult
+	CurrentObservations []*entity.Observation
+	NewObservations     []*entity.Observation
+}
+
 type observeResultSummary struct {
 	Action        string
+	CurrentIDs    []string
 	RecordedIDs   []string
+	ReusedIDs     []string
 	RecordedCount int
 	SkippedCount  int
 }
@@ -67,7 +81,7 @@ func buildObserveSampleCheck(cfg *store.Config, expID, instName string, requeste
 		return observeSampleCheck{}, fmt.Errorf("instrument %q is not registered in config.yaml", instName)
 	}
 	plan := instrument.PlanSamples(inst, requestedSamples)
-	current := samplesForObservedInstrument(observations, instName)
+	current := samplesForObservedInstrument(inst, observations, instName)
 	check := observeSampleCheck{
 		Experiment:        expID,
 		Instrument:        instName,
@@ -85,15 +99,80 @@ func buildObserveSampleCheck(cfg *store.Config, expID, instName string, requeste
 	return check, nil
 }
 
-func samplesForObservedInstrument(observations []*entity.Observation, instName string) int {
+func resolveObserveScope(exp *entity.Experiment) (observeScope, error) {
+	if exp == nil {
+		return observeScope{}, fmt.Errorf("experiment is required")
+	}
+	if strings.TrimSpace(exp.Worktree) == "" {
+		return observeScope{}, fmt.Errorf("experiment %s has no worktree; run `autoresearch experiment implement %s` first", exp.ID, exp.ID)
+	}
+	sha, err := worktree.ResolveRef(exp.Worktree, "HEAD")
+	if err != nil {
+		return observeScope{}, fmt.Errorf("resolve candidate HEAD for %s: %w", exp.ID, err)
+	}
+	return observeScope{
+		Attempt:      exp.Attempt,
+		CandidateSHA: sha,
+	}, nil
+}
+
+func loadCurrentObservations(s *store.Store, exp *entity.Experiment) (observeScope, []*entity.Observation, error) {
+	scope, err := resolveObserveScope(exp)
+	if err != nil {
+		return observeScope{}, nil, err
+	}
+	all, err := s.ListObservationsForExperiment(exp.ID)
+	if err != nil {
+		return observeScope{}, nil, err
+	}
+	return scope, filterObservationsByScope(all, scope), nil
+}
+
+func filterObservationsByScope(observations []*entity.Observation, scope observeScope) []*entity.Observation {
+	out := make([]*entity.Observation, 0, len(observations))
+	for _, o := range observations {
+		if observationInScope(o, scope) {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func observationInScope(o *entity.Observation, scope observeScope) bool {
+	if o == nil {
+		return false
+	}
+	if o.Attempt != scope.Attempt {
+		return false
+	}
+	if scope.CandidateSHA == "" || o.CandidateSHA == "" {
+		return false
+	}
+	return o.CandidateSHA == scope.CandidateSHA
+}
+
+func samplesForObservedInstrument(inst store.Instrument, observations []*entity.Observation, instName string) int {
 	total := 0
 	for _, o := range observations {
 		if o == nil || o.Instrument != instName {
 			continue
 		}
+		if !observationCountsTowardTarget(inst, o) {
+			continue
+		}
 		total += observationSampleCount(o)
 	}
 	return total
+}
+
+func observationCountsTowardTarget(inst store.Instrument, o *entity.Observation) bool {
+	if o == nil {
+		return false
+	}
+	if inst.Parser != "builtin:passfail" {
+		return true
+	}
+	return o.Pass != nil && *o.Pass
 }
 
 func observationSampleCount(o *entity.Observation) int {
@@ -139,13 +218,14 @@ func collectObservationRuns(
 	s *store.Store,
 	cfg *store.Config,
 	exp *entity.Experiment,
+	scope observeScope,
 	instName string,
 	check observeSampleCheck,
 	appendMode bool,
 	author string,
 ) ([]*entity.Observation, error) {
 	if appendMode {
-		obs, err := runAndRecordObservation(s, cfg, exp, instName, check.TargetSamples, author)
+		obs, err := runAndRecordObservation(s, cfg, exp, scope, instName, check.TargetSamples, author)
 		if err != nil {
 			return nil, err
 		}
@@ -156,7 +236,7 @@ func collectObservationRuns(
 	}
 	plan := instrument.PlanSamples(cfg.Instruments[instName], 0)
 	if plan.MultiSample {
-		obs, err := runAndRecordObservation(s, cfg, exp, instName, check.AdditionalSamples, author)
+		obs, err := runAndRecordObservation(s, cfg, exp, scope, instName, check.AdditionalSamples, author)
 		if err != nil {
 			return nil, err
 		}
@@ -165,7 +245,7 @@ func collectObservationRuns(
 
 	out := make([]*entity.Observation, 0, check.AdditionalSamples)
 	for i := 0; i < check.AdditionalSamples; i++ {
-		obs, err := runAndRecordObservation(s, cfg, exp, instName, 1, author)
+		obs, err := runAndRecordObservation(s, cfg, exp, scope, instName, 1, author)
 		if err != nil {
 			return out, err
 		}
@@ -183,7 +263,7 @@ func buildSkippedObservationResult(check observeSampleCheck) observationResult {
 	}
 }
 
-func buildRecordedObservationResult(check observeSampleCheck, observations []*entity.Observation) (observeExecution, error) {
+func buildRecordedObservationResult(check observeSampleCheck, observations []*entity.Observation, currentSamples int) (observeExecution, error) {
 	last := latestObservation(observations)
 	if last == nil {
 		return observeExecution{}, fmt.Errorf("instrument %s produced no observation", check.Instrument)
@@ -201,7 +281,7 @@ func buildRecordedObservationResult(check observeSampleCheck, observations []*en
 			Unit:           last.Unit,
 			Action:         observeActionRecorded,
 			Samples:        added,
-			CurrentSamples: check.CurrentSamples + added,
+			CurrentSamples: currentSamples,
 			TargetSamples:  check.TargetSamples,
 		},
 	}, nil
@@ -211,15 +291,22 @@ func executeObservationRun(
 	s *store.Store,
 	cfg *store.Config,
 	exp *entity.Experiment,
+	scope observeScope,
+	currentObservations []*entity.Observation,
 	check observeSampleCheck,
 	appendMode bool,
 	author string,
 ) (observeExecution, error) {
-	observations, err := collectObservationRuns(s, cfg, exp, check.Instrument, check, appendMode, author)
+	observations, err := collectObservationRuns(s, cfg, exp, scope, check.Instrument, check, appendMode, author)
 	if err != nil {
 		return observeExecution{}, err
 	}
-	return buildRecordedObservationResult(check, observations)
+	currentSamples := samplesForObservedInstrument(
+		cfg.Instruments[check.Instrument],
+		append(append([]*entity.Observation(nil), currentObservations...), observations...),
+		check.Instrument,
+	)
+	return buildRecordedObservationResult(check, observations, currentSamples)
 }
 
 func describeObserveAction(exp *entity.Experiment, check observeSampleCheck, appendMode bool) (string, map[string]any) {
@@ -257,6 +344,30 @@ func summarizeObserveResults(results []observationResult) observeResultSummary {
 	if summary.RecordedCount == 0 && summary.SkippedCount > 0 {
 		summary.Action = observeActionSkipped
 	}
+	return summary
+}
+
+func buildObserveResultSummary(results []observationResult, currentObservations, newObservations []*entity.Observation) observeResultSummary {
+	summary := summarizeObserveResults(results)
+	summary.CurrentIDs = observationIDs(currentObservations)
+	summary.RecordedIDs = observationIDs(newObservations)
+	reused := make([]*entity.Observation, 0, len(currentObservations))
+	recorded := make(map[string]struct{}, len(newObservations))
+	for _, o := range newObservations {
+		if o != nil {
+			recorded[o.ID] = struct{}{}
+		}
+	}
+	for _, o := range currentObservations {
+		if o == nil {
+			continue
+		}
+		if _, ok := recorded[o.ID]; ok {
+			continue
+		}
+		reused = append(reused, o)
+	}
+	summary.ReusedIDs = observationIDs(reused)
 	return summary
 }
 
@@ -313,6 +424,7 @@ func runAndRecordObservation(
 	s *store.Store,
 	cfg *store.Config,
 	exp *entity.Experiment,
+	scope observeScope,
 	instName string,
 	samples int,
 	author string,
@@ -372,6 +484,8 @@ func runAndRecordObservation(
 		Command:          result.Command,
 		ExitCode:         result.ExitCode,
 		Worktree:         exp.Worktree,
+		Attempt:          scope.Attempt,
+		CandidateSHA:     scope.CandidateSHA,
 		BaselineSHA:      exp.Baseline.SHA,
 		Author:           or(author, "agent:observer"),
 		Aux:              result.Aux,
@@ -392,6 +506,8 @@ func runAndRecordObservation(
 		"unit":          unit,
 		"samples":       result.SamplesN,
 		"artifact_shas": artShas,
+		"attempt":       scope.Attempt,
+		"candidate_sha": scope.CandidateSHA,
 	}
 	if result.Pass != nil {
 		eventData["pass"] = *result.Pass
@@ -442,16 +558,14 @@ func observeAll(
 	samples int,
 	appendMode bool,
 	author string,
-) ([]observationResult, error) {
-	var results []observationResult
-	var priorObs []*entity.Observation
-	recordedAny := false
-
-	// Seed with any existing observations on this experiment so that
-	// partially-observed experiments can resume.
-	if existing, err := s.ListObservationsForExperiment(exp.ID); err == nil {
-		priorObs = existing
+) (observeAllExecution, error) {
+	scope, priorObs, err := loadCurrentObservations(s, exp)
+	if err != nil {
+		return observeAllExecution{}, err
 	}
+	var results []observationResult
+	var newObs []*entity.Observation
+	recordedAny := false
 
 	remaining := make([]string, len(instruments))
 	copy(remaining, instruments)
@@ -462,7 +576,7 @@ func observeAll(
 		for _, instName := range remaining {
 			check, err := buildObserveSampleCheck(cfg, exp.ID, instName, samples, priorObs)
 			if err != nil {
-				return results, err
+				return observeAllExecution{}, err
 			}
 			if !appendMode && check.TargetSatisfied {
 				results = append(results, buildSkippedObservationResult(check))
@@ -474,17 +588,18 @@ func observeAll(
 				continue
 			}
 
-			exec, err := executeObservationRun(s, cfg, exp, check, appendMode, author)
+			exec, err := executeObservationRun(s, cfg, exp, scope, priorObs, check, appendMode, author)
 			if err != nil {
-				return results, err
+				return observeAllExecution{}, err
 			}
 			priorObs = append(priorObs, exec.Observations...)
+			newObs = append(newObs, exec.Observations...)
 			recordedAny = true
 			results = append(results, exec.Result)
 			progress = true
 		}
 		if !progress {
-			return results, fmt.Errorf("stuck: instruments %v have unsatisfied dependencies", deferred)
+			return observeAllExecution{}, fmt.Errorf("stuck: instruments %v have unsatisfied dependencies", deferred)
 		}
 		remaining = deferred
 	}
@@ -492,9 +607,13 @@ func observeAll(
 	// Bump experiment status to measured if this was the first observation.
 	if recordedAny {
 		if err := markExperimentMeasuredIfNeeded(s, exp); err != nil {
-			return results, err
+			return observeAllExecution{}, err
 		}
 	}
 
-	return results, nil
+	return observeAllExecution{
+		Results:             results,
+		CurrentObservations: priorObs,
+		NewObservations:     newObs,
+	}, nil
 }

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -11,13 +11,294 @@ import (
 	"github.com/bytter/autoresearch/internal/store"
 )
 
+const (
+	observeActionRecorded = "recorded"
+	observeActionSkipped  = "skipped"
+)
+
 // observationResult holds the output of a single instrument observation,
 // used by observeAll to collect results for display.
 type observationResult struct {
-	ID    string  `json:"id"`
-	Inst  string  `json:"instrument"`
-	Value float64 `json:"value"`
-	Unit  string  `json:"unit"`
+	ID             string   `json:"id,omitempty"`
+	IDs            []string `json:"ids,omitempty"`
+	Inst           string   `json:"instrument"`
+	Value          float64  `json:"value,omitempty"`
+	Unit           string   `json:"unit,omitempty"`
+	Action         string   `json:"action,omitempty"`
+	Samples        int      `json:"samples,omitempty"`
+	CurrentSamples int      `json:"current_samples,omitempty"`
+	TargetSamples  int      `json:"target_samples,omitempty"`
+}
+
+func (r observationResult) skipped() bool {
+	return r.Action == observeActionSkipped
+}
+
+type observeExecution struct {
+	Check        observeSampleCheck
+	Result       observationResult
+	Observations []*entity.Observation
+	Latest       *entity.Observation
+}
+
+type observeResultSummary struct {
+	Action        string
+	RecordedIDs   []string
+	RecordedCount int
+	SkippedCount  int
+}
+
+type observeSampleCheck struct {
+	Experiment        string `json:"experiment"`
+	Instrument        string `json:"instrument"`
+	RequestedSamples  int    `json:"requested_samples,omitempty"`
+	MinSamples        int    `json:"min_samples,omitempty"`
+	MinSatisfied      bool   `json:"min_satisfied"`
+	CurrentSamples    int    `json:"current_samples"`
+	TargetSamples     int    `json:"target_samples"`
+	TargetSource      string `json:"target_source"`
+	TargetSatisfied   bool   `json:"target_satisfied"`
+	AdditionalSamples int    `json:"additional_samples"`
+}
+
+func buildObserveSampleCheck(cfg *store.Config, expID, instName string, requestedSamples int, observations []*entity.Observation) (observeSampleCheck, error) {
+	inst, ok := cfg.Instruments[instName]
+	if !ok {
+		return observeSampleCheck{}, fmt.Errorf("instrument %q is not registered in config.yaml", instName)
+	}
+	plan := instrument.PlanSamples(inst, requestedSamples)
+	current := samplesForObservedInstrument(observations, instName)
+	check := observeSampleCheck{
+		Experiment:        expID,
+		Instrument:        instName,
+		MinSamples:        inst.MinSamples,
+		MinSatisfied:      inst.MinSamples == 0 || current >= inst.MinSamples,
+		CurrentSamples:    current,
+		TargetSamples:     plan.Target,
+		TargetSource:      plan.Source,
+		TargetSatisfied:   current >= plan.Target,
+		AdditionalSamples: max(plan.Target-current, 0),
+	}
+	if requestedSamples > 0 {
+		check.RequestedSamples = requestedSamples
+	}
+	return check, nil
+}
+
+func samplesForObservedInstrument(observations []*entity.Observation, instName string) int {
+	total := 0
+	for _, o := range observations {
+		if o == nil || o.Instrument != instName {
+			continue
+		}
+		total += observationSampleCount(o)
+	}
+	return total
+}
+
+func observationSampleCount(o *entity.Observation) int {
+	if o == nil {
+		return 0
+	}
+	if len(o.PerSample) > 0 {
+		return len(o.PerSample)
+	}
+	if o.Samples > 0 {
+		return o.Samples
+	}
+	return 1
+}
+
+func sumObservationSamples(observations []*entity.Observation) int {
+	total := 0
+	for _, o := range observations {
+		total += observationSampleCount(o)
+	}
+	return total
+}
+
+func latestObservation(observations []*entity.Observation) *entity.Observation {
+	if len(observations) == 0 {
+		return nil
+	}
+	return observations[len(observations)-1]
+}
+
+func markExperimentMeasuredIfNeeded(s *store.Store, exp *entity.Experiment) error {
+	if exp == nil || exp.Status != entity.ExpImplemented {
+		return nil
+	}
+	exp.Status = entity.ExpMeasured
+	if err := s.WriteExperiment(exp); err != nil {
+		return fmt.Errorf("update experiment status: %w", err)
+	}
+	return nil
+}
+
+func collectObservationRuns(
+	s *store.Store,
+	cfg *store.Config,
+	exp *entity.Experiment,
+	instName string,
+	check observeSampleCheck,
+	appendMode bool,
+	author string,
+) ([]*entity.Observation, error) {
+	if appendMode {
+		obs, err := runAndRecordObservation(s, cfg, exp, instName, check.TargetSamples, author)
+		if err != nil {
+			return nil, err
+		}
+		return []*entity.Observation{obs}, nil
+	}
+	if check.AdditionalSamples <= 0 {
+		return nil, fmt.Errorf("instrument %s has no additional samples to record", instName)
+	}
+	plan := instrument.PlanSamples(cfg.Instruments[instName], 0)
+	if plan.MultiSample {
+		obs, err := runAndRecordObservation(s, cfg, exp, instName, check.AdditionalSamples, author)
+		if err != nil {
+			return nil, err
+		}
+		return []*entity.Observation{obs}, nil
+	}
+
+	out := make([]*entity.Observation, 0, check.AdditionalSamples)
+	for i := 0; i < check.AdditionalSamples; i++ {
+		obs, err := runAndRecordObservation(s, cfg, exp, instName, 1, author)
+		if err != nil {
+			return out, err
+		}
+		out = append(out, obs)
+	}
+	return out, nil
+}
+
+func buildSkippedObservationResult(check observeSampleCheck) observationResult {
+	return observationResult{
+		Inst:           check.Instrument,
+		Action:         observeActionSkipped,
+		CurrentSamples: check.CurrentSamples,
+		TargetSamples:  check.TargetSamples,
+	}
+}
+
+func buildRecordedObservationResult(check observeSampleCheck, observations []*entity.Observation) (observeExecution, error) {
+	last := latestObservation(observations)
+	if last == nil {
+		return observeExecution{}, fmt.Errorf("instrument %s produced no observation", check.Instrument)
+	}
+	added := sumObservationSamples(observations)
+	return observeExecution{
+		Check:        check,
+		Observations: observations,
+		Latest:       last,
+		Result: observationResult{
+			ID:             last.ID,
+			IDs:            observationIDs(observations),
+			Inst:           check.Instrument,
+			Value:          last.Value,
+			Unit:           last.Unit,
+			Action:         observeActionRecorded,
+			Samples:        added,
+			CurrentSamples: check.CurrentSamples + added,
+			TargetSamples:  check.TargetSamples,
+		},
+	}, nil
+}
+
+func executeObservationRun(
+	s *store.Store,
+	cfg *store.Config,
+	exp *entity.Experiment,
+	check observeSampleCheck,
+	appendMode bool,
+	author string,
+) (observeExecution, error) {
+	observations, err := collectObservationRuns(s, cfg, exp, check.Instrument, check, appendMode, author)
+	if err != nil {
+		return observeExecution{}, err
+	}
+	return buildRecordedObservationResult(check, observations)
+}
+
+func describeObserveAction(exp *entity.Experiment, check observeSampleCheck, appendMode bool) (string, map[string]any) {
+	samplesToRecord := check.TargetSamples
+	actionText := fmt.Sprintf("run instrument %q against %s", check.Instrument, exp.Worktree)
+	if appendMode {
+		actionText = fmt.Sprintf("append another %q observation on %s", check.Instrument, exp.ID)
+	} else if check.CurrentSamples > 0 {
+		actionText = fmt.Sprintf("top up %q on %s by %d sample(s)", check.Instrument, exp.ID, check.AdditionalSamples)
+		samplesToRecord = check.AdditionalSamples
+	}
+	return actionText, map[string]any{
+		"instrument":        check.Instrument,
+		"worktree":          exp.Worktree,
+		"current_samples":   check.CurrentSamples,
+		"target_samples":    check.TargetSamples,
+		"samples_to_record": samplesToRecord,
+		"append":            appendMode,
+	}
+}
+
+func summarizeObserveResults(results []observationResult) observeResultSummary {
+	summary := observeResultSummary{
+		Action:      observeActionRecorded,
+		RecordedIDs: make([]string, 0, len(results)),
+	}
+	for _, r := range results {
+		if r.skipped() {
+			summary.SkippedCount++
+			continue
+		}
+		summary.RecordedCount++
+		summary.RecordedIDs = append(summary.RecordedIDs, r.IDs...)
+	}
+	if summary.RecordedCount == 0 && summary.SkippedCount > 0 {
+		summary.Action = observeActionSkipped
+	}
+	return summary
+}
+
+func recordedObservationPayload(exec observeExecution) map[string]any {
+	return map[string]any{
+		"status":        "ok",
+		"action":        exec.Result.Action,
+		"id":            exec.Result.ID,
+		"ids":           exec.Result.IDs,
+		"samples_added": exec.Result.Samples,
+		"observation":   exec.Latest,
+		"observations":  exec.Observations,
+	}
+}
+
+func formatObserveSatisfiedText(check observeSampleCheck) string {
+	return fmt.Sprintf("have %d samples; pass `--append` to add more, or `--samples N` with N>%d to top up",
+		check.CurrentSamples, check.CurrentSamples)
+}
+
+func formatObserveCheckText(check observeSampleCheck) string {
+	minStatus := "satisfied"
+	if !check.MinSatisfied {
+		minStatus = "not satisfied"
+	}
+	if check.MinSamples == 0 {
+		minStatus = "not set"
+	}
+	line := fmt.Sprintf("%s on %s: have %d sample", check.Instrument, check.Experiment, check.CurrentSamples)
+	if check.CurrentSamples != 1 {
+		line += "s"
+	}
+	line += fmt.Sprintf("; target=%d (%s)", check.TargetSamples, check.TargetSource)
+	if check.MinSamples > 0 {
+		line += fmt.Sprintf("; min_samples=%d (%s)", check.MinSamples, minStatus)
+	}
+	if check.TargetSatisfied {
+		line += "; target satisfied"
+	} else {
+		line += fmt.Sprintf("; need %d more", check.AdditionalSamples)
+	}
+	return line
 }
 
 // runAndRecordObservation runs a single instrument against an experiment's
@@ -159,10 +440,12 @@ func observeAll(
 	exp *entity.Experiment,
 	instruments []string,
 	samples int,
+	appendMode bool,
 	author string,
 ) ([]observationResult, error) {
 	var results []observationResult
 	var priorObs []*entity.Observation
+	recordedAny := false
 
 	// Seed with any existing observations on this experiment so that
 	// partially-observed experiments can resume.
@@ -177,24 +460,27 @@ func observeAll(
 		progress := false
 		var deferred []string
 		for _, instName := range remaining {
+			check, err := buildObserveSampleCheck(cfg, exp.ID, instName, samples, priorObs)
+			if err != nil {
+				return results, err
+			}
+			if !appendMode && check.TargetSatisfied {
+				results = append(results, buildSkippedObservationResult(check))
+				progress = true
+				continue
+			}
 			if err := firewall.CheckInstrumentDependencies(instName, cfg, priorObs); err != nil {
 				deferred = append(deferred, instName)
 				continue
 			}
 
-			obs, err := runAndRecordObservation(s, cfg, exp, instName, samples, author)
+			exec, err := executeObservationRun(s, cfg, exp, check, appendMode, author)
 			if err != nil {
 				return results, err
 			}
-			priorObs = append(priorObs, obs)
-
-			unit := obs.Unit
-			results = append(results, observationResult{
-				ID:    obs.ID,
-				Inst:  instName,
-				Value: obs.Value,
-				Unit:  unit,
-			})
+			priorObs = append(priorObs, exec.Observations...)
+			recordedAny = true
+			results = append(results, exec.Result)
 			progress = true
 		}
 		if !progress {
@@ -204,10 +490,9 @@ func observeAll(
 	}
 
 	// Bump experiment status to measured if this was the first observation.
-	if exp.Status == entity.ExpImplemented {
-		exp.Status = entity.ExpMeasured
-		if err := s.WriteExperiment(exp); err != nil {
-			return results, fmt.Errorf("update experiment status: %w", err)
+	if recordedAny {
+		if err := markExperimentMeasuredIfNeeded(s, exp); err != nil {
+			return results, err
 		}
 	}
 

--- a/internal/cli/observe_helpers.go
+++ b/internal/cli/observe_helpers.go
@@ -44,8 +44,8 @@ type observeExecution struct {
 
 type observeScope struct {
 	Attempt      int
+	CandidateRef string
 	CandidateSHA string
-	DirtyPaths   []string
 }
 
 type observeAllExecution struct {
@@ -100,35 +100,69 @@ func buildObserveSampleCheck(cfg *store.Config, expID, instName string, requeste
 	return check, nil
 }
 
-func resolveObserveScope(exp *entity.Experiment) (observeScope, error) {
+func resolveObserveScope(exp *entity.Experiment, candidateRef string) (observeScope, error) {
 	if exp == nil {
 		return observeScope{}, fmt.Errorf("experiment is required")
 	}
 	if strings.TrimSpace(exp.Worktree) == "" {
 		return observeScope{}, fmt.Errorf("experiment %s has no worktree; run `autoresearch experiment implement %s` first", exp.ID, exp.ID)
 	}
-	sha, err := worktree.ResolveRef(exp.Worktree, "HEAD")
-	if err != nil {
-		return observeScope{}, fmt.Errorf("resolve candidate HEAD for %s: %w", exp.ID, err)
-	}
 	dirtyPaths, err := observeScopeDirtyPaths(exp.Worktree)
 	if err != nil {
 		return observeScope{}, fmt.Errorf("inspect candidate dirtiness for %s: %w", exp.ID, err)
 	}
+
+	headSHA, err := worktree.ResolveRef(exp.Worktree, "HEAD")
+	if err != nil {
+		return observeScope{}, fmt.Errorf("resolve candidate HEAD for %s: %w", exp.ID, err)
+	}
+	if exp.IsBaseline {
+		if strings.TrimSpace(candidateRef) != "" {
+			return observeScope{}, fmt.Errorf("--candidate-ref is only valid for non-baseline experiments")
+		}
+		if len(dirtyPaths) > 0 {
+			return observeScope{}, fmt.Errorf(
+				"baseline experiment %s worktree has uncommitted changes (%s); observe requires a clean checkout",
+				exp.ID, formatObserveDirtyPaths(dirtyPaths),
+			)
+		}
+		return observeScope{
+			Attempt:      exp.Attempt,
+			CandidateSHA: headSHA,
+		}, nil
+	}
+
+	normRef, err := normalizeObserveCandidateRef(exp, candidateRef)
+	if err != nil {
+		return observeScope{}, err
+	}
+	if len(dirtyPaths) > 0 {
+		return observeScope{}, fmt.Errorf(
+			"experiment %s worktree has uncommitted changes (%s); observe requires a clean checkout that matches --candidate-ref %s",
+			exp.ID, formatObserveDirtyPaths(dirtyPaths), normRef,
+		)
+	}
+	refSHA, err := worktree.ResolveRef(exp.Worktree, normRef)
+	if err != nil {
+		return observeScope{}, fmt.Errorf("resolve candidate ref %q for %s: %w", normRef, exp.ID, err)
+	}
+	if headSHA != refSHA {
+		return observeScope{}, fmt.Errorf(
+			"experiment %s worktree HEAD %s does not match --candidate-ref %s (%s)",
+			exp.ID, shortSHA(headSHA), normRef, shortSHA(refSHA),
+		)
+	}
 	return observeScope{
 		Attempt:      exp.Attempt,
-		CandidateSHA: sha,
-		DirtyPaths:   dirtyPaths,
+		CandidateRef: normRef,
+		CandidateSHA: headSHA,
 	}, nil
 }
 
-func loadCurrentObservations(s *store.Store, exp *entity.Experiment) (observeScope, []*entity.Observation, error) {
-	scope, err := resolveObserveScope(exp)
+func loadCurrentObservations(s *store.Store, exp *entity.Experiment, candidateRef string) (observeScope, []*entity.Observation, error) {
+	scope, err := resolveObserveScope(exp, candidateRef)
 	if err != nil {
 		return observeScope{}, nil, err
-	}
-	if !scope.reuseEnabled() {
-		return scope, nil, nil
 	}
 	all, err := s.ListObservationsForExperiment(exp.ID)
 	if err != nil {
@@ -156,8 +190,35 @@ func observeScopeDirtyPaths(worktreeDir string) ([]string, error) {
 	return filtered, nil
 }
 
-func (s observeScope) reuseEnabled() bool {
-	return len(s.DirtyPaths) == 0
+func normalizeObserveCandidateRef(exp *entity.Experiment, candidateRef string) (string, error) {
+	ref := strings.TrimSpace(candidateRef)
+	if ref == "" {
+		return "", fmt.Errorf(
+			"experiment %s requires --candidate-ref <ref>; create a unique reviewable git ref for the measured candidate (for example `git -C %s branch <name> HEAD`) and rerun observe",
+			exp.ID, exp.Worktree,
+		)
+	}
+	sym, err := worktree.SymbolicFullName(exp.Worktree, ref)
+	if err != nil {
+		return "", fmt.Errorf("resolve candidate ref %q for %s: %w", ref, exp.ID, err)
+	}
+	if !strings.HasPrefix(sym, "refs/") {
+		return "", fmt.Errorf(
+			"candidate ref %q is not a named git ref; create a branch or tag for the measured candidate and rerun observe with --candidate-ref <ref>",
+			ref,
+		)
+	}
+	return sym, nil
+}
+
+func formatObserveDirtyPaths(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	if len(paths) <= 3 {
+		return strings.Join(paths, ", ")
+	}
+	return fmt.Sprintf("%s (+%d more)", strings.Join(paths[:3], ", "), len(paths)-3)
 }
 
 func filterObservationsByScope(observations []*entity.Observation, scope observeScope) []*entity.Observation {
@@ -174,10 +235,19 @@ func observationInScope(o *entity.Observation, scope observeScope) bool {
 	if o == nil {
 		return false
 	}
-	if !scope.reuseEnabled() {
+	if o.Attempt != scope.Attempt {
 		return false
 	}
-	if o.Attempt != scope.Attempt {
+	if scope.CandidateRef != "" {
+		if strings.TrimSpace(o.CandidateRef) != scope.CandidateRef {
+			return false
+		}
+		if scope.CandidateSHA == "" || o.CandidateSHA == "" {
+			return false
+		}
+		return o.CandidateSHA == scope.CandidateSHA
+	}
+	if strings.TrimSpace(o.CandidateRef) != "" {
 		return false
 	}
 	if scope.CandidateSHA == "" || o.CandidateSHA == "" {
@@ -512,6 +582,7 @@ func runAndRecordObservation(
 		ExitCode:         result.ExitCode,
 		Worktree:         exp.Worktree,
 		Attempt:          scope.Attempt,
+		CandidateRef:     scope.CandidateRef,
 		CandidateSHA:     scope.CandidateSHA,
 		BaselineSHA:      exp.Baseline.SHA,
 		Author:           or(author, "agent:observer"),
@@ -534,6 +605,7 @@ func runAndRecordObservation(
 		"samples":       result.SamplesN,
 		"artifact_shas": artShas,
 		"attempt":       scope.Attempt,
+		"candidate_ref": scope.CandidateRef,
 		"candidate_sha": scope.CandidateSHA,
 	}
 	if result.Pass != nil {
@@ -581,15 +653,13 @@ func observeAll(
 	s *store.Store,
 	cfg *store.Config,
 	exp *entity.Experiment,
+	scope observeScope,
+	priorObs []*entity.Observation,
 	instruments []string,
 	samples int,
 	appendMode bool,
 	author string,
 ) (observeAllExecution, error) {
-	scope, priorObs, err := loadCurrentObservations(s, exp)
-	if err != nil {
-		return observeAllExecution{}, err
-	}
 	var results []observationResult
 	var newObs []*entity.Observation
 	recordedAny := false

--- a/internal/cli/observe_test.go
+++ b/internal/cli/observe_test.go
@@ -340,6 +340,40 @@ func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T
 	}
 }
 
+func TestObserveDirtyWorktreeDisablesReuse(t *testing.T) {
+	saveGlobals(t)
+	dir := setupObserveScenarioStore(t)
+	registerScenarioInstruments(t, dir)
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate a")
+	first := runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
+
+	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
+
+	check := runCLIJSON[observeCheckJSON](t, dir,
+		"observe", "check", scenario.ExpID,
+		"--instrument", "timing",
+	)
+	if got, want := check.Check.CurrentSamples, 0; got != want {
+		t.Fatalf("current_samples after dirty edit = %d, want %d", got, want)
+	}
+	if check.Check.TargetSatisfied {
+		t.Fatal("target_satisfied = true after dirty edit, want false")
+	}
+
+	second := runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
+	if second.ID == first.ID {
+		t.Fatalf("reused stale observation id %q after dirty edit", second.ID)
+	}
+	if got, want := second.Observation.Value, 80.0; got != want {
+		t.Fatalf("second observation value = %v, want %v", got, want)
+	}
+	if got, want := second.SamplesAdded, 3; got != want {
+		t.Fatalf("samples_added after dirty edit = %d, want %d", got, want)
+	}
+}
+
 func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.T) {
 	saveGlobals(t)
 	dir := setupObserveScenarioStore(t)

--- a/internal/cli/observe_test.go
+++ b/internal/cli/observe_test.go
@@ -143,13 +143,14 @@ func setupObserveFixture(t *testing.T) (string, *store.Store) {
 func TestObserveSkipsWhenSamplesAlreadySatisfied(t *testing.T) {
 	saveGlobals(t)
 	dir, s := setupObserveFixture(t)
+	candidateRef := gitCreateCandidateRef(t, dir, "candidate/e-0001-a1")
 
-	first := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
+	first := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef)
 	if got, want := first.Observation.Samples, 5; got != want {
 		t.Fatalf("first observe samples = %d, want %d", got, want)
 	}
 
-	out := runCLI(t, dir, "observe", "E-0001", "--instrument", "timing")
+	out := runCLI(t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef)
 	if !strings.Contains(out, "observation already satisfied") {
 		t.Fatalf("skip output missing satisfied message:\n%s", out)
 	}
@@ -175,9 +176,10 @@ func TestObserveSkipsWhenSamplesAlreadySatisfied(t *testing.T) {
 func TestObserveTopsUpToRequestedTotal(t *testing.T) {
 	saveGlobals(t)
 	dir, s := setupObserveFixture(t)
+	candidateRef := gitCreateCandidateRef(t, dir, "candidate/e-0001-a1")
 
-	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
-	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--samples", "7")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef)
+	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef, "--samples", "7")
 
 	if got, want := resp.Action, "recorded"; got != want {
 		t.Fatalf("action = %q, want %q", got, want)
@@ -215,9 +217,10 @@ func TestObserveTopsUpToRequestedTotal(t *testing.T) {
 func TestObserveAppendPreservesAnotherFullRun(t *testing.T) {
 	saveGlobals(t)
 	dir, s := setupObserveFixture(t)
+	candidateRef := gitCreateCandidateRef(t, dir, "candidate/e-0001-a1")
 
-	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
-	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--append")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef)
+	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef, "--append")
 
 	if got, want := resp.SamplesAdded, 5; got != want {
 		t.Fatalf("samples_added = %d, want %d", got, want)
@@ -241,9 +244,10 @@ func TestObserveAppendPreservesAnotherFullRun(t *testing.T) {
 func TestObserveCheckReportsCurrentAndNeededSamples(t *testing.T) {
 	saveGlobals(t)
 	dir, _ := setupObserveFixture(t)
+	candidateRef := gitCreateCandidateRef(t, dir, "candidate/e-0001-a1")
 
-	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
-	resp := runCLIJSON[observeCheckJSON](t, dir, "observe", "check", "E-0001", "--instrument", "timing", "--samples", "7")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef)
+	resp := runCLIJSON[observeCheckJSON](t, dir, "observe", "check", "E-0001", "--instrument", "timing", "--candidate-ref", candidateRef, "--samples", "7")
 
 	if got, want := resp.Check.CurrentSamples, 5; got != want {
 		t.Fatalf("current_samples = %d, want %d", got, want)
@@ -268,25 +272,50 @@ func TestObserveCheckReportsCurrentAndNeededSamples(t *testing.T) {
 	}
 }
 
+func TestObserveRequiresCandidateRefForNonBaselineExperiments(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupObserveFixture(t)
+
+	_, _, err := runCLIResult(t, dir, "observe", "E-0001", "--instrument", "timing")
+	if err == nil {
+		t.Fatal("observe without --candidate-ref unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "requires --candidate-ref") {
+		t.Fatalf("unexpected observe error: %v", err)
+	}
+
+	_, _, err = runCLIResult(t, dir, "observe", "check", "E-0001", "--instrument", "timing")
+	if err == nil {
+		t.Fatal("observe check without --candidate-ref unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "requires --candidate-ref") {
+		t.Fatalf("unexpected observe check error: %v", err)
+	}
+}
+
 func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 	saveGlobals(t)
 	dir := setupObserveScenarioStore(t)
 	registerScenarioInstruments(t, dir)
 	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+	candidateRef1 := gitCreateCandidateRef(t, scenario.Worktree, "candidate/reset-a1")
 	first := runCLIJSON[observeRecordJSON](t, dir,
 		"observe", scenario.ExpID,
 		"--instrument", "timing",
+		"--candidate-ref", candidateRef1,
 		"--allow-unchanged",
 	)
 	if first.ID == "" {
 		t.Fatal("first observation id missing")
 	}
 	runCLI(t, dir, "experiment", "reset", scenario.ExpID, "--reason", "retry measurement")
-	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", scenario.ExpID)
+	impl2 := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", scenario.ExpID)
+	candidateRef2 := gitCreateCandidateRef(t, impl2.Worktree, "candidate/reset-a2")
 
 	check := runCLIJSON[observeCheckJSON](t, dir,
 		"observe", "check", scenario.ExpID,
 		"--instrument", "timing",
+		"--candidate-ref", candidateRef2,
 	)
 	if got, want := check.Check.CurrentSamples, 0; got != want {
 		t.Fatalf("current_samples after reset = %d, want %d", got, want)
@@ -298,6 +327,7 @@ func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 	second := runCLIJSON[observeRecordJSON](t, dir,
 		"observe", scenario.ExpID,
 		"--instrument", "timing",
+		"--candidate-ref", candidateRef2,
 		"--allow-unchanged",
 	)
 	if second.ID == first.ID {
@@ -324,13 +354,16 @@ func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T
 	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
 	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
 	gitCommitAll(t, scenario.Worktree, "candidate a")
-	runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
+	candidateRefA := gitCreateCandidateRef(t, scenario.Worktree, "candidate/commit-a")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing", "--candidate-ref", candidateRefA)
 	writeScenarioMetrics(t, scenario.Worktree, "85\n", "900\n")
 	gitCommitAll(t, scenario.Worktree, "candidate b")
+	candidateRefB := gitCreateCandidateRef(t, scenario.Worktree, "candidate/commit-b")
 
 	check := runCLIJSON[observeCheckJSON](t, dir,
 		"observe", "check", scenario.ExpID,
 		"--instrument", "timing",
+		"--candidate-ref", candidateRefB,
 	)
 	if got, want := check.Check.CurrentSamples, 0; got != want {
 		t.Fatalf("current_samples after new commit = %d, want %d", got, want)
@@ -340,37 +373,103 @@ func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T
 	}
 }
 
-func TestObserveDirtyWorktreeDisablesReuse(t *testing.T) {
+func TestObserveCheckDoesNotReuseSameSHAOnDifferentCandidateRef(t *testing.T) {
 	saveGlobals(t)
 	dir := setupObserveScenarioStore(t)
 	registerScenarioInstruments(t, dir)
 	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
 	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
 	gitCommitAll(t, scenario.Worktree, "candidate a")
-	first := runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
-
-	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
+	candidateRefA := gitCreateCandidateRef(t, scenario.Worktree, "candidate/ref-a")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing", "--candidate-ref", candidateRefA)
+	candidateRefB := gitCreateCandidateRef(t, scenario.Worktree, "candidate/ref-b")
 
 	check := runCLIJSON[observeCheckJSON](t, dir,
 		"observe", "check", scenario.ExpID,
 		"--instrument", "timing",
+		"--candidate-ref", candidateRefB,
 	)
 	if got, want := check.Check.CurrentSamples, 0; got != want {
-		t.Fatalf("current_samples after dirty edit = %d, want %d", got, want)
+		t.Fatalf("current_samples for alternate candidate ref = %d, want %d", got, want)
 	}
 	if check.Check.TargetSatisfied {
-		t.Fatal("target_satisfied = true after dirty edit, want false")
+		t.Fatal("target_satisfied = true for alternate candidate ref, want false")
+	}
+}
+
+func TestObserveRefusesWhenHeadDoesNotMatchCandidateRef(t *testing.T) {
+	saveGlobals(t)
+	dir := setupObserveScenarioStore(t)
+	registerScenarioInstruments(t, dir)
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate a")
+	candidateRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/mismatch-a")
+	writeScenarioMetrics(t, scenario.Worktree, "85\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate b")
+
+	_, _, err := runCLIResult(t, dir,
+		"observe", scenario.ExpID,
+		"--instrument", "timing",
+		"--candidate-ref", candidateRef,
+	)
+	if err == nil {
+		t.Fatal("observe with mismatched candidate ref unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "does not match --candidate-ref") {
+		t.Fatalf("unexpected mismatched candidate ref error: %v", err)
+	}
+}
+
+func TestObserveDirtyWorktreeRefusesMeasurement(t *testing.T) {
+	saveGlobals(t)
+	dir := setupObserveScenarioStore(t)
+	registerScenarioInstruments(t, dir)
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate a")
+	candidateRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/dirty-a")
+	first := runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing", "--candidate-ref", candidateRef)
+
+	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
+
+	_, _, err := runCLIResult(t, dir,
+		"observe", "check", scenario.ExpID,
+		"--instrument", "timing",
+		"--candidate-ref", candidateRef,
+	)
+	if err == nil {
+		t.Fatal("observe check on dirty worktree unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "has uncommitted changes") {
+		t.Fatalf("unexpected dirty observe check error: %v", err)
 	}
 
-	second := runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
-	if second.ID == first.ID {
-		t.Fatalf("reused stale observation id %q after dirty edit", second.ID)
+	_, _, err = runCLIResult(t, dir,
+		"observe", scenario.ExpID,
+		"--instrument", "timing",
+		"--candidate-ref", candidateRef,
+	)
+	if err == nil {
+		t.Fatal("observe on dirty worktree unexpectedly succeeded")
 	}
-	if got, want := second.Observation.Value, 80.0; got != want {
-		t.Fatalf("second observation value = %v, want %v", got, want)
+	if !strings.Contains(err.Error(), "has uncommitted changes") {
+		t.Fatalf("unexpected dirty observe error: %v", err)
 	}
-	if got, want := second.SamplesAdded, 3; got != want {
-		t.Fatalf("samples_added after dirty edit = %d, want %d", got, want)
+
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	obs, err := s.ListObservationsForExperiment(scenario.ExpID)
+	if err != nil {
+		t.Fatalf("ListObservationsForExperiment: %v", err)
+	}
+	if got, want := len(obs), 1; got != want {
+		t.Fatalf("observation count after dirty refusal = %d, want %d", got, want)
+	}
+	if obs[0].ID != first.ID {
+		t.Fatalf("observation after dirty refusal = %q, want %q", obs[0].ID, first.ID)
 	}
 }
 
@@ -384,8 +483,9 @@ func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.
 	)
 	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
 	gitCommitAll(t, scenario.Worktree, "candidate")
+	candidateRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/all-a")
 
-	first := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
+	first := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all", "--candidate-ref", candidateRef)
 	if got, want := len(first.Observations), 3; got != want {
 		t.Fatalf("first observations len = %d, want %d", got, want)
 	}
@@ -396,7 +496,7 @@ func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.
 		t.Fatalf("first reused_observations len = %d, want %d", got, want)
 	}
 
-	second := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
+	second := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all", "--candidate-ref", candidateRef)
 	if got, want := second.Action, observeActionSkipped; got != want {
 		t.Fatalf("second action = %q, want %q", got, want)
 	}
@@ -434,12 +534,14 @@ func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.
 	)
 	scenario := setupObserveScenarioExperiment(t, dir, "timing,host_test", "--constraint-require", "host_test=pass")
 	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
-	gitCommitAll(t, scenario.Worktree, "candidate")
 	if err := os.Remove(filepath.Join(scenario.Worktree, "PASS")); err != nil {
 		t.Fatalf("remove PASS: %v", err)
 	}
+	gitRun(t, scenario.Worktree, "add", "timing.txt", "PASS")
+	gitRun(t, scenario.Worktree, "commit", "-m", "candidate without pass marker")
+	failingRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/prereq-fail")
 
-	_, _, err := runCLIResult(t, dir, "observe", scenario.ExpID, "--all")
+	_, _, err := runCLIResult(t, dir, "observe", scenario.ExpID, "--all", "--candidate-ref", failingRef)
 	if err == nil {
 		t.Fatal("observe --all unexpectedly succeeded with failed prerequisite")
 	}
@@ -450,7 +552,10 @@ func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.
 	if err := os.WriteFile(filepath.Join(scenario.Worktree, "PASS"), []byte("ok\n"), 0o644); err != nil {
 		t.Fatalf("restore PASS: %v", err)
 	}
-	resp := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
+	gitRun(t, scenario.Worktree, "add", "PASS")
+	gitRun(t, scenario.Worktree, "commit", "-m", "restore pass marker")
+	recoveryRef := gitCreateCandidateRef(t, scenario.Worktree, "candidate/prereq-pass")
+	resp := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all", "--candidate-ref", recoveryRef)
 
 	hostTestRecorded := false
 	timingRecorded := false

--- a/internal/cli/observe_test.go
+++ b/internal/cli/observe_test.go
@@ -24,8 +24,59 @@ type observeCheckJSON struct {
 	Check observeSampleCheck `json:"check"`
 }
 
+type observeScenarioExperiment struct {
+	ExpID    string
+	Worktree string
+}
+
 func timingSampleTotal(observations []*entity.Observation) int {
 	return samplesForObservedInstrument(store.Instrument{Parser: "builtin:scalar"}, observations, "timing")
+}
+
+func setupObserveScenarioStore(t *testing.T) string {
+	t.Helper()
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+	return dir
+}
+
+func setupObserveScenarioExperiment(t *testing.T, dir, instruments string, goalArgs ...string) observeScenarioExperiment {
+	t.Helper()
+
+	args := []string{
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+	}
+	args = append(args, goalArgs...)
+	runCLIJSON[cliIDResponse](t, dir, args...)
+
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", instruments,
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	return observeScenarioExperiment{
+		ExpID:    exp.ID,
+		Worktree: impl.Worktree,
+	}
 }
 
 func setupObserveFixture(t *testing.T) (string, *store.Store) {
@@ -219,52 +270,22 @@ func TestObserveCheckReportsCurrentAndNeededSamples(t *testing.T) {
 
 func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
+	dir := setupObserveScenarioStore(t)
 	registerScenarioInstruments(t, dir)
-
-	runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
-		"--constraint-max", "binary_size=1000",
-	)
-	hyp := runCLIJSON[cliIDResponse](t, dir,
-		"hypothesis", "add",
-		"--claim", "tighten the hot loop",
-		"--predicts-instrument", "timing",
-		"--predicts-target", "kernel",
-		"--predicts-direction", "decrease",
-		"--predicts-min-effect", "0.1",
-		"--kill-if", "tests fail",
-	)
-	exp := runCLIJSON[cliIDResponse](t, dir,
-		"experiment", "design", hyp.ID,
-		"--baseline", "HEAD",
-		"--instruments", "timing",
-	)
-	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
 	first := runCLIJSON[observeRecordJSON](t, dir,
-		"observe", exp.ID,
+		"observe", scenario.ExpID,
 		"--instrument", "timing",
 		"--allow-unchanged",
 	)
 	if first.ID == "" {
 		t.Fatal("first observation id missing")
 	}
-	runCLI(t, dir, "experiment", "reset", exp.ID, "--reason", "retry measurement")
-	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	runCLI(t, dir, "experiment", "reset", scenario.ExpID, "--reason", "retry measurement")
+	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", scenario.ExpID)
 
 	check := runCLIJSON[observeCheckJSON](t, dir,
-		"observe", "check", exp.ID,
+		"observe", "check", scenario.ExpID,
 		"--instrument", "timing",
 	)
 	if got, want := check.Check.CurrentSamples, 0; got != want {
@@ -275,7 +296,7 @@ func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 	}
 
 	second := runCLIJSON[observeRecordJSON](t, dir,
-		"observe", exp.ID,
+		"observe", scenario.ExpID,
 		"--instrument", "timing",
 		"--allow-unchanged",
 	)
@@ -287,7 +308,7 @@ func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.Open: %v", err)
 	}
-	expEntity, err := s.ReadExperiment(exp.ID)
+	expEntity, err := s.ReadExperiment(scenario.ExpID)
 	if err != nil {
 		t.Fatalf("ReadExperiment: %v", err)
 	}
@@ -298,47 +319,17 @@ func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
 
 func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T) {
 	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
+	dir := setupObserveScenarioStore(t)
 	registerScenarioInstruments(t, dir)
-
-	runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
-		"--constraint-max", "binary_size=1000",
-	)
-	hyp := runCLIJSON[cliIDResponse](t, dir,
-		"hypothesis", "add",
-		"--claim", "tighten the hot loop",
-		"--predicts-instrument", "timing",
-		"--predicts-target", "kernel",
-		"--predicts-direction", "decrease",
-		"--predicts-min-effect", "0.1",
-		"--kill-if", "tests fail",
-	)
-	exp := runCLIJSON[cliIDResponse](t, dir,
-		"experiment", "design", hyp.ID,
-		"--baseline", "HEAD",
-		"--instruments", "timing",
-	)
-	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
-	writeScenarioMetrics(t, impl.Worktree, "90\n", "900\n")
-	gitCommitAll(t, impl.Worktree, "candidate a")
-	runCLIJSON[observeRecordJSON](t, dir, "observe", exp.ID, "--instrument", "timing")
-	writeScenarioMetrics(t, impl.Worktree, "85\n", "900\n")
-	gitCommitAll(t, impl.Worktree, "candidate b")
+	scenario := setupObserveScenarioExperiment(t, dir, "timing", "--constraint-max", "binary_size=1000")
+	writeScenarioMetrics(t, scenario.Worktree, "90\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate a")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", scenario.ExpID, "--instrument", "timing")
+	writeScenarioMetrics(t, scenario.Worktree, "85\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate b")
 
 	check := runCLIJSON[observeCheckJSON](t, dir,
-		"observe", "check", exp.ID,
+		"observe", "check", scenario.ExpID,
 		"--instrument", "timing",
 	)
 	if got, want := check.Check.CurrentSamples, 0; got != want {
@@ -351,44 +342,16 @@ func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T
 
 func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.T) {
 	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
+	dir := setupObserveScenarioStore(t)
 	registerScenarioInstruments(t, dir)
-
-	runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
+	scenario := setupObserveScenarioExperiment(t, dir, "timing,binary_size,host_test",
 		"--constraint-max", "binary_size=1000",
 		"--constraint-require", "host_test=pass",
 	)
-	hyp := runCLIJSON[cliIDResponse](t, dir,
-		"hypothesis", "add",
-		"--claim", "tighten the hot loop",
-		"--predicts-instrument", "timing",
-		"--predicts-target", "kernel",
-		"--predicts-direction", "decrease",
-		"--predicts-min-effect", "0.1",
-		"--kill-if", "tests fail",
-	)
-	exp := runCLIJSON[cliIDResponse](t, dir,
-		"experiment", "design", hyp.ID,
-		"--baseline", "HEAD",
-		"--instruments", "timing,binary_size,host_test",
-	)
-	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
-	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
-	gitCommitAll(t, impl.Worktree, "candidate")
+	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate")
 
-	first := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	first := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
 	if got, want := len(first.Observations), 3; got != want {
 		t.Fatalf("first observations len = %d, want %d", got, want)
 	}
@@ -399,7 +362,7 @@ func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.
 		t.Fatalf("first reused_observations len = %d, want %d", got, want)
 	}
 
-	second := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	second := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
 	if got, want := second.Action, observeActionSkipped; got != want {
 		t.Fatalf("second action = %q, want %q", got, want)
 	}
@@ -416,15 +379,7 @@ func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.
 
 func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.T) {
 	saveGlobals(t)
-	dir := gitInitScenarioRepo(t)
-	if _, err := store.Create(dir, store.Config{
-		Build:     store.CommandSpec{Command: "true"},
-		Test:      store.CommandSpec{Command: "true"},
-		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
-	}); err != nil {
-		t.Fatalf("store.Create: %v", err)
-	}
-
+	dir := setupObserveScenarioStore(t)
 	runCLI(t, dir,
 		"instrument", "register", "timing",
 		"--cmd", "sh",
@@ -443,36 +398,14 @@ func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.
 		"--parser", "builtin:passfail",
 		"--unit", "bool",
 	)
-
-	runCLIJSON[cliIDResponse](t, dir,
-		"goal", "set",
-		"--objective-instrument", "timing",
-		"--objective-target", "kernel",
-		"--objective-direction", "decrease",
-		"--constraint-require", "host_test=pass",
-	)
-	hyp := runCLIJSON[cliIDResponse](t, dir,
-		"hypothesis", "add",
-		"--claim", "tighten the hot loop",
-		"--predicts-instrument", "timing",
-		"--predicts-target", "kernel",
-		"--predicts-direction", "decrease",
-		"--predicts-min-effect", "0.1",
-		"--kill-if", "tests fail",
-	)
-	exp := runCLIJSON[cliIDResponse](t, dir,
-		"experiment", "design", hyp.ID,
-		"--baseline", "HEAD",
-		"--instruments", "timing,host_test",
-	)
-	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
-	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
-	gitCommitAll(t, impl.Worktree, "candidate")
-	if err := os.Remove(filepath.Join(impl.Worktree, "PASS")); err != nil {
+	scenario := setupObserveScenarioExperiment(t, dir, "timing,host_test", "--constraint-require", "host_test=pass")
+	writeScenarioMetrics(t, scenario.Worktree, "80\n", "900\n")
+	gitCommitAll(t, scenario.Worktree, "candidate")
+	if err := os.Remove(filepath.Join(scenario.Worktree, "PASS")); err != nil {
 		t.Fatalf("remove PASS: %v", err)
 	}
 
-	_, _, err := runCLIResult(t, dir, "observe", exp.ID, "--all")
+	_, _, err := runCLIResult(t, dir, "observe", scenario.ExpID, "--all")
 	if err == nil {
 		t.Fatal("observe --all unexpectedly succeeded with failed prerequisite")
 	}
@@ -480,10 +413,10 @@ func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.
 		t.Fatalf("unexpected observe --all error: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(impl.Worktree, "PASS"), []byte("ok\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(scenario.Worktree, "PASS"), []byte("ok\n"), 0o644); err != nil {
 		t.Fatalf("restore PASS: %v", err)
 	}
-	resp := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	resp := runCLIJSON[cliObserveAllResponse](t, dir, "observe", scenario.ExpID, "--all")
 
 	hostTestRecorded := false
 	timingRecorded := false

--- a/internal/cli/observe_test.go
+++ b/internal/cli/observe_test.go
@@ -1,0 +1,203 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type observeRecordJSON struct {
+	Action       string               `json:"action"`
+	ID           string               `json:"id"`
+	IDs          []string             `json:"ids"`
+	SamplesAdded int                  `json:"samples_added"`
+	Observation  entity.Observation   `json:"observation"`
+	Observations []entity.Observation `json:"observations"`
+}
+
+type observeCheckJSON struct {
+	Check observeSampleCheck `json:"check"`
+}
+
+func setupObserveFixture(t *testing.T) (string, *store.Store) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "timing.txt"), []byte("100\n"), 0o644); err != nil {
+		t.Fatalf("write timing.txt: %v", err)
+	}
+
+	s, err := store.Create(dir, store.Config{
+		Build: store.CommandSpec{Command: "true"},
+		Test:  store.CommandSpec{Command: "true"},
+		Instruments: map[string]store.Instrument{
+			"timing": {
+				Cmd:        []string{"sh", "-c", "cat timing.txt"},
+				Parser:     "builtin:scalar",
+				Pattern:    "([0-9]+)",
+				Unit:       "ns",
+				MinSamples: 5,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	now := time.Now().UTC()
+	exp := &entity.Experiment{
+		ID:         "E-0001",
+		GoalID:     "G-0001",
+		Hypothesis: "H-0001",
+		Status:     entity.ExpImplemented,
+		Baseline:   entity.Baseline{Ref: "HEAD"},
+		Instruments: []string{
+			"timing",
+		},
+		Worktree:  dir,
+		Author:    "human:test",
+		CreatedAt: now,
+	}
+	if err := s.WriteExperiment(exp); err != nil {
+		t.Fatalf("WriteExperiment: %v", err)
+	}
+	if err := s.UpdateState(func(st *store.State) error {
+		st.Counters["E"] = 1
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateState: %v", err)
+	}
+	return dir, s
+}
+
+func TestObserveSkipsWhenSamplesAlreadySatisfied(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupObserveFixture(t)
+
+	first := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
+	if got, want := first.Observation.Samples, 5; got != want {
+		t.Fatalf("first observe samples = %d, want %d", got, want)
+	}
+
+	out := runCLI(t, dir, "observe", "E-0001", "--instrument", "timing")
+	if !strings.Contains(out, "observation already satisfied") {
+		t.Fatalf("skip output missing satisfied message:\n%s", out)
+	}
+	if !strings.Contains(out, "have 5 samples") {
+		t.Fatalf("skip output missing sample count:\n%s", out)
+	}
+	if !strings.Contains(out, "--append") {
+		t.Fatalf("skip output missing append hint:\n%s", out)
+	}
+
+	obs, err := s.ListObservationsForExperiment("E-0001")
+	if err != nil {
+		t.Fatalf("ListObservationsForExperiment: %v", err)
+	}
+	if got, want := len(obs), 1; got != want {
+		t.Fatalf("observation count after skip = %d, want %d", got, want)
+	}
+	if got, want := samplesForObservedInstrument(obs, "timing"), 5; got != want {
+		t.Fatalf("sample total after skip = %d, want %d", got, want)
+	}
+}
+
+func TestObserveTopsUpToRequestedTotal(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupObserveFixture(t)
+
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
+	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--samples", "7")
+
+	if got, want := resp.Action, "recorded"; got != want {
+		t.Fatalf("action = %q, want %q", got, want)
+	}
+	if got, want := resp.SamplesAdded, 2; got != want {
+		t.Fatalf("samples_added = %d, want %d", got, want)
+	}
+	if got, want := resp.Observation.Samples, 2; got != want {
+		t.Fatalf("latest observation samples = %d, want %d", got, want)
+	}
+	if got, want := len(resp.Observations), 1; got != want {
+		t.Fatalf("new observation count = %d, want %d", got, want)
+	}
+
+	obs, err := s.ListObservationsForExperiment("E-0001")
+	if err != nil {
+		t.Fatalf("ListObservationsForExperiment: %v", err)
+	}
+	if got, want := len(obs), 2; got != want {
+		t.Fatalf("observation count after top-up = %d, want %d", got, want)
+	}
+	if got, want := samplesForObservedInstrument(obs, "timing"), 7; got != want {
+		t.Fatalf("sample total after top-up = %d, want %d", got, want)
+	}
+
+	exp, err := s.ReadExperiment("E-0001")
+	if err != nil {
+		t.Fatalf("ReadExperiment: %v", err)
+	}
+	if got, want := exp.Status, entity.ExpMeasured; got != want {
+		t.Fatalf("experiment status = %q, want %q", got, want)
+	}
+}
+
+func TestObserveAppendPreservesAnotherFullRun(t *testing.T) {
+	saveGlobals(t)
+	dir, s := setupObserveFixture(t)
+
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
+	resp := runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing", "--append")
+
+	if got, want := resp.SamplesAdded, 5; got != want {
+		t.Fatalf("samples_added = %d, want %d", got, want)
+	}
+	if got, want := resp.Observation.Samples, 5; got != want {
+		t.Fatalf("latest observation samples = %d, want %d", got, want)
+	}
+
+	obs, err := s.ListObservationsForExperiment("E-0001")
+	if err != nil {
+		t.Fatalf("ListObservationsForExperiment: %v", err)
+	}
+	if got, want := len(obs), 2; got != want {
+		t.Fatalf("observation count after append = %d, want %d", got, want)
+	}
+	if got, want := samplesForObservedInstrument(obs, "timing"), 10; got != want {
+		t.Fatalf("sample total after append = %d, want %d", got, want)
+	}
+}
+
+func TestObserveCheckReportsCurrentAndNeededSamples(t *testing.T) {
+	saveGlobals(t)
+	dir, _ := setupObserveFixture(t)
+
+	runCLIJSON[observeRecordJSON](t, dir, "observe", "E-0001", "--instrument", "timing")
+	resp := runCLIJSON[observeCheckJSON](t, dir, "observe", "check", "E-0001", "--instrument", "timing", "--samples", "7")
+
+	if got, want := resp.Check.CurrentSamples, 5; got != want {
+		t.Fatalf("current_samples = %d, want %d", got, want)
+	}
+	if got, want := resp.Check.MinSamples, 5; got != want {
+		t.Fatalf("min_samples = %d, want %d", got, want)
+	}
+	if !resp.Check.MinSatisfied {
+		t.Fatal("min_satisfied = false, want true")
+	}
+	if got, want := resp.Check.TargetSamples, 7; got != want {
+		t.Fatalf("target_samples = %d, want %d", got, want)
+	}
+	if got, want := resp.Check.TargetSource, "requested"; got != want {
+		t.Fatalf("target_source = %q, want %q", got, want)
+	}
+	if resp.Check.TargetSatisfied {
+		t.Fatal("target_satisfied = true, want false")
+	}
+	if got, want := resp.Check.AdditionalSamples, 2; got != want {
+		t.Fatalf("additional_samples = %d, want %d", got, want)
+	}
+}

--- a/internal/cli/observe_test.go
+++ b/internal/cli/observe_test.go
@@ -24,12 +24,26 @@ type observeCheckJSON struct {
 	Check observeSampleCheck `json:"check"`
 }
 
+func timingSampleTotal(observations []*entity.Observation) int {
+	return samplesForObservedInstrument(store.Instrument{Parser: "builtin:scalar"}, observations, "timing")
+}
+
 func setupObserveFixture(t *testing.T) (string, *store.Store) {
 	t.Helper()
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "timing.txt"), []byte("100\n"), 0o644); err != nil {
 		t.Fatalf("write timing.txt: %v", err)
 	}
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "test"},
+		{"config", "commit.gpgsign", "false"},
+	} {
+		gitRun(t, dir, args...)
+	}
+	gitRun(t, dir, "add", "timing.txt")
+	gitRun(t, dir, "commit", "-m", "init")
 
 	s, err := store.Create(dir, store.Config{
 		Build: store.CommandSpec{Command: "true"},
@@ -55,6 +69,7 @@ func setupObserveFixture(t *testing.T) (string, *store.Store) {
 		Hypothesis: "H-0001",
 		Status:     entity.ExpImplemented,
 		Baseline:   entity.Baseline{Ref: "HEAD"},
+		Attempt:    1,
 		Instruments: []string{
 			"timing",
 		},
@@ -101,7 +116,7 @@ func TestObserveSkipsWhenSamplesAlreadySatisfied(t *testing.T) {
 	if got, want := len(obs), 1; got != want {
 		t.Fatalf("observation count after skip = %d, want %d", got, want)
 	}
-	if got, want := samplesForObservedInstrument(obs, "timing"), 5; got != want {
+	if got, want := timingSampleTotal(obs), 5; got != want {
 		t.Fatalf("sample total after skip = %d, want %d", got, want)
 	}
 }
@@ -133,7 +148,7 @@ func TestObserveTopsUpToRequestedTotal(t *testing.T) {
 	if got, want := len(obs), 2; got != want {
 		t.Fatalf("observation count after top-up = %d, want %d", got, want)
 	}
-	if got, want := samplesForObservedInstrument(obs, "timing"), 7; got != want {
+	if got, want := timingSampleTotal(obs), 7; got != want {
 		t.Fatalf("sample total after top-up = %d, want %d", got, want)
 	}
 
@@ -167,7 +182,7 @@ func TestObserveAppendPreservesAnotherFullRun(t *testing.T) {
 	if got, want := len(obs), 2; got != want {
 		t.Fatalf("observation count after append = %d, want %d", got, want)
 	}
-	if got, want := samplesForObservedInstrument(obs, "timing"), 10; got != want {
+	if got, want := timingSampleTotal(obs), 10; got != want {
 		t.Fatalf("sample total after append = %d, want %d", got, want)
 	}
 }
@@ -199,5 +214,288 @@ func TestObserveCheckReportsCurrentAndNeededSamples(t *testing.T) {
 	}
 	if got, want := resp.Check.AdditionalSamples, 2; got != want {
 		t.Fatalf("additional_samples = %d, want %d", got, want)
+	}
+}
+
+func TestObserveCheckIgnoresObservationsFromResetAttempts(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-max", "binary_size=1000",
+	)
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing",
+	)
+	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	first := runCLIJSON[observeRecordJSON](t, dir,
+		"observe", exp.ID,
+		"--instrument", "timing",
+		"--allow-unchanged",
+	)
+	if first.ID == "" {
+		t.Fatal("first observation id missing")
+	}
+	runCLI(t, dir, "experiment", "reset", exp.ID, "--reason", "retry measurement")
+	runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+
+	check := runCLIJSON[observeCheckJSON](t, dir,
+		"observe", "check", exp.ID,
+		"--instrument", "timing",
+	)
+	if got, want := check.Check.CurrentSamples, 0; got != want {
+		t.Fatalf("current_samples after reset = %d, want %d", got, want)
+	}
+	if check.Check.TargetSatisfied {
+		t.Fatal("target_satisfied = true after reset, want false")
+	}
+
+	second := runCLIJSON[observeRecordJSON](t, dir,
+		"observe", exp.ID,
+		"--instrument", "timing",
+		"--allow-unchanged",
+	)
+	if second.ID == first.ID {
+		t.Fatalf("reused stale observation id %q after reset", second.ID)
+	}
+
+	s, err := store.Open(dir)
+	if err != nil {
+		t.Fatalf("store.Open: %v", err)
+	}
+	expEntity, err := s.ReadExperiment(exp.ID)
+	if err != nil {
+		t.Fatalf("ReadExperiment: %v", err)
+	}
+	if got, want := expEntity.Attempt, 2; got != want {
+		t.Fatalf("experiment attempt = %d, want %d", got, want)
+	}
+}
+
+func TestObserveCheckIgnoresObservationsAfterCandidateCommitChanges(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-max", "binary_size=1000",
+	)
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	writeScenarioMetrics(t, impl.Worktree, "90\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "candidate a")
+	runCLIJSON[observeRecordJSON](t, dir, "observe", exp.ID, "--instrument", "timing")
+	writeScenarioMetrics(t, impl.Worktree, "85\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "candidate b")
+
+	check := runCLIJSON[observeCheckJSON](t, dir,
+		"observe", "check", exp.ID,
+		"--instrument", "timing",
+	)
+	if got, want := check.Check.CurrentSamples, 0; got != want {
+		t.Fatalf("current_samples after new commit = %d, want %d", got, want)
+	}
+	if check.Check.TargetSatisfied {
+		t.Fatal("target_satisfied = true after new commit, want false")
+	}
+}
+
+func TestObserveAllJSONReturnsCurrentObservationSetOnIdempotentRerun(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	registerScenarioInstruments(t, dir)
+
+	runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-max", "binary_size=1000",
+		"--constraint-require", "host_test=pass",
+	)
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,binary_size,host_test",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "candidate")
+
+	first := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	if got, want := len(first.Observations), 3; got != want {
+		t.Fatalf("first observations len = %d, want %d", got, want)
+	}
+	if got, want := len(first.NewObservations), 3; got != want {
+		t.Fatalf("first new_observations len = %d, want %d", got, want)
+	}
+	if got, want := len(first.ReusedObservations), 0; got != want {
+		t.Fatalf("first reused_observations len = %d, want %d", got, want)
+	}
+
+	second := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+	if got, want := second.Action, observeActionSkipped; got != want {
+		t.Fatalf("second action = %q, want %q", got, want)
+	}
+	if got, want := len(second.Observations), 3; got != want {
+		t.Fatalf("second observations len = %d, want %d", got, want)
+	}
+	if got, want := len(second.NewObservations), 0; got != want {
+		t.Fatalf("second new_observations len = %d, want %d", got, want)
+	}
+	if got, want := len(second.ReusedObservations), 3; got != want {
+		t.Fatalf("second reused_observations len = %d, want %d", got, want)
+	}
+}
+
+func TestObserveAllRerunsFailedPrerequisitesInsteadOfSkippingByCount(t *testing.T) {
+	saveGlobals(t)
+	dir := gitInitScenarioRepo(t)
+	if _, err := store.Create(dir, store.Config{
+		Build:     store.CommandSpec{Command: "true"},
+		Test:      store.CommandSpec{Command: "true"},
+		Worktrees: store.WorktreesConfig{Root: filepath.Join(t.TempDir(), "worktrees")},
+	}); err != nil {
+		t.Fatalf("store.Create: %v", err)
+	}
+
+	runCLI(t, dir,
+		"instrument", "register", "timing",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "cat timing.txt",
+		"--parser", "builtin:scalar",
+		"--pattern", "([0-9]+)",
+		"--unit", "ns",
+		"--requires", "host_test=pass",
+	)
+	runCLI(t, dir,
+		"instrument", "register", "host_test",
+		"--cmd", "sh",
+		"--cmd", "-c",
+		"--cmd", "test -f PASS",
+		"--parser", "builtin:passfail",
+		"--unit", "bool",
+	)
+
+	runCLIJSON[cliIDResponse](t, dir,
+		"goal", "set",
+		"--objective-instrument", "timing",
+		"--objective-target", "kernel",
+		"--objective-direction", "decrease",
+		"--constraint-require", "host_test=pass",
+	)
+	hyp := runCLIJSON[cliIDResponse](t, dir,
+		"hypothesis", "add",
+		"--claim", "tighten the hot loop",
+		"--predicts-instrument", "timing",
+		"--predicts-target", "kernel",
+		"--predicts-direction", "decrease",
+		"--predicts-min-effect", "0.1",
+		"--kill-if", "tests fail",
+	)
+	exp := runCLIJSON[cliIDResponse](t, dir,
+		"experiment", "design", hyp.ID,
+		"--baseline", "HEAD",
+		"--instruments", "timing,host_test",
+	)
+	impl := runCLIJSON[cliImplementResponse](t, dir, "experiment", "implement", exp.ID)
+	writeScenarioMetrics(t, impl.Worktree, "80\n", "900\n")
+	gitCommitAll(t, impl.Worktree, "candidate")
+	if err := os.Remove(filepath.Join(impl.Worktree, "PASS")); err != nil {
+		t.Fatalf("remove PASS: %v", err)
+	}
+
+	_, _, err := runCLIResult(t, dir, "observe", exp.ID, "--all")
+	if err == nil {
+		t.Fatal("observe --all unexpectedly succeeded with failed prerequisite")
+	}
+	if !strings.Contains(err.Error(), "stuck: instruments [timing] have unsatisfied dependencies") {
+		t.Fatalf("unexpected observe --all error: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(impl.Worktree, "PASS"), []byte("ok\n"), 0o644); err != nil {
+		t.Fatalf("restore PASS: %v", err)
+	}
+	resp := runCLIJSON[cliObserveAllResponse](t, dir, "observe", exp.ID, "--all")
+
+	hostTestRecorded := false
+	timingRecorded := false
+	for _, result := range resp.Results {
+		switch result.Inst {
+		case "host_test":
+			hostTestRecorded = result.Action == observeActionRecorded
+		case "timing":
+			timingRecorded = result.Action == observeActionRecorded
+		}
+	}
+	if !hostTestRecorded || !timingRecorded {
+		t.Fatalf("expected host_test and timing to record on recovery run, got %+v", resp.Results)
 	}
 }

--- a/internal/cli/report.go
+++ b/internal/cli/report.go
@@ -278,6 +278,12 @@ func renderReportMarkdown(r *reportData) string {
 				sb.WriteString("> **Directional** — the hypothesis predicted direction only (`min_effect: 0`); any clean-CI effect in the predicted direction counts as supported. Follow-up hypotheses should refine this into a quantitative claim once the magnitude is known.\n\n")
 			}
 			fmt.Fprintf(&sb, "- **Candidate experiment**: %s\n", c.CandidateExp)
+			if c.CandidateRef != "" {
+				fmt.Fprintf(&sb, "- **Measured candidate ref**: %s\n", c.CandidateRef)
+			}
+			if c.CandidateSHA != "" {
+				fmt.Fprintf(&sb, "- **Measured candidate SHA**: %s\n", c.CandidateSHA)
+			}
 			if c.BaselineExp != "" {
 				fmt.Fprintf(&sb, "- **Baseline experiment**: %s\n", c.BaselineExp)
 			}

--- a/internal/cli/tui_view_conclusion.go
+++ b/internal/cli/tui_view_conclusion.go
@@ -190,6 +190,12 @@ func (v *conclusionDetailView) view(width, height int) string {
 	if c.CandidateExp != "" {
 		lines = append(lines, tuiDim.Render("candidate=")+c.CandidateExp+"  "+tuiDim.Render("baseline=")+emptyDash(c.BaselineExp))
 	}
+	if c.CandidateRef != "" {
+		lines = append(lines, tuiDim.Render("candidate_ref=")+c.CandidateRef)
+	}
+	if c.CandidateSHA != "" {
+		lines = append(lines, tuiDim.Render("candidate_sha=")+c.CandidateSHA)
+	}
 	if c.Strict.RequestedFrom != "" {
 		lines = append(lines, "")
 		lines = append(lines, tuiBoldYellow.Render("⚠ downgraded from "+c.Strict.RequestedFrom))

--- a/internal/cli/tui_view_misc.go
+++ b/internal/cli/tui_view_misc.go
@@ -226,7 +226,7 @@ func (v *frontierView) init(s *store.Store) tea.Cmd {
 		if err != nil {
 			return frontierLoadedMsg{err: err}
 		}
-		obsByExp := readmodel.LoadObservationsByExperiment(s)
+		obsByExp := readmodel.LoadObservationIndex(s)
 		expClassByID := readmodel.LoadExperimentReadClasses(s)
 		frontier := readmodel.BuildFrontierSnapshot(goal, concls, obsByExp, expClassByID)
 		return frontierLoadedMsg{

--- a/internal/entity/conclusion.go
+++ b/internal/entity/conclusion.go
@@ -14,15 +14,19 @@ const (
 )
 
 type Conclusion struct {
-	ID           string   `yaml:"id"                            json:"id"`
-	Hypothesis   string   `yaml:"hypothesis"                    json:"hypothesis"`
-	Verdict      string   `yaml:"verdict"                       json:"verdict"`
-	Observations []string `yaml:"observations"                  json:"observations"`
-	CandidateExp string   `yaml:"candidate_experiment,omitempty" json:"candidate_experiment,omitempty"`
-	CandidateRef string   `yaml:"candidate_ref,omitempty"        json:"candidate_ref,omitempty"`
-	CandidateSHA string   `yaml:"candidate_sha,omitempty"        json:"candidate_sha,omitempty"`
-	BaselineExp  string   `yaml:"baseline_experiment,omitempty"  json:"baseline_experiment,omitempty"`
-	Effect       Effect   `yaml:"effect"                        json:"effect"`
+	ID               string   `yaml:"id"                              json:"id"`
+	Hypothesis       string   `yaml:"hypothesis"                      json:"hypothesis"`
+	Verdict          string   `yaml:"verdict"                         json:"verdict"`
+	Observations     []string `yaml:"observations"                    json:"observations"`
+	CandidateExp     string   `yaml:"candidate_experiment,omitempty"  json:"candidate_experiment,omitempty"`
+	CandidateAttempt int      `yaml:"candidate_attempt,omitempty"     json:"candidate_attempt,omitempty"`
+	CandidateRef     string   `yaml:"candidate_ref,omitempty"         json:"candidate_ref,omitempty"`
+	CandidateSHA     string   `yaml:"candidate_sha,omitempty"         json:"candidate_sha,omitempty"`
+	BaselineExp      string   `yaml:"baseline_experiment,omitempty"   json:"baseline_experiment,omitempty"`
+	BaselineAttempt  int      `yaml:"baseline_attempt,omitempty"      json:"baseline_attempt,omitempty"`
+	BaselineRef      string   `yaml:"baseline_ref,omitempty"          json:"baseline_ref,omitempty"`
+	BaselineSHA      string   `yaml:"baseline_sha,omitempty"          json:"baseline_sha,omitempty"`
+	Effect           Effect   `yaml:"effect"                          json:"effect"`
 	// IncrementalExp is the frontier-best experiment at the time this
 	// conclusion was written. Together with IncrementalEffect it answers
 	// "how much did this improve over the current best?" as opposed to

--- a/internal/entity/conclusion.go
+++ b/internal/entity/conclusion.go
@@ -14,13 +14,15 @@ const (
 )
 
 type Conclusion struct {
-	ID           string    `yaml:"id"                            json:"id"`
-	Hypothesis   string    `yaml:"hypothesis"                    json:"hypothesis"`
-	Verdict      string    `yaml:"verdict"                       json:"verdict"`
-	Observations []string  `yaml:"observations"                  json:"observations"`
-	CandidateExp string    `yaml:"candidate_experiment,omitempty" json:"candidate_experiment,omitempty"`
-	BaselineExp  string    `yaml:"baseline_experiment,omitempty"  json:"baseline_experiment,omitempty"`
-	Effect       Effect    `yaml:"effect"                        json:"effect"`
+	ID           string   `yaml:"id"                            json:"id"`
+	Hypothesis   string   `yaml:"hypothesis"                    json:"hypothesis"`
+	Verdict      string   `yaml:"verdict"                       json:"verdict"`
+	Observations []string `yaml:"observations"                  json:"observations"`
+	CandidateExp string   `yaml:"candidate_experiment,omitempty" json:"candidate_experiment,omitempty"`
+	CandidateRef string   `yaml:"candidate_ref,omitempty"        json:"candidate_ref,omitempty"`
+	CandidateSHA string   `yaml:"candidate_sha,omitempty"        json:"candidate_sha,omitempty"`
+	BaselineExp  string   `yaml:"baseline_experiment,omitempty"  json:"baseline_experiment,omitempty"`
+	Effect       Effect   `yaml:"effect"                        json:"effect"`
 	// IncrementalExp is the frontier-best experiment at the time this
 	// conclusion was written. Together with IncrementalEffect it answers
 	// "how much did this improve over the current best?" as opposed to
@@ -68,9 +70,9 @@ type Effect struct {
 }
 
 type Strict struct {
-	Passed        bool     `yaml:"passed"                    json:"passed"`
-	RequestedFrom string   `yaml:"downgraded_from,omitempty" json:"downgraded_from,omitempty"`
-	RescuedBy     string   `yaml:"rescued_by,omitempty"      json:"rescued_by,omitempty"`
+	Passed        bool   `yaml:"passed"                    json:"passed"`
+	RequestedFrom string `yaml:"downgraded_from,omitempty" json:"downgraded_from,omitempty"`
+	RescuedBy     string `yaml:"rescued_by,omitempty"      json:"rescued_by,omitempty"`
 	// Directional is true when the hypothesis predicted a direction
 	// with MinEffect == 0 (no magnitude commitment). A directional
 	// "supported" verdict must be rendered distinctly so readers don't

--- a/internal/entity/conclusion_test.go
+++ b/internal/entity/conclusion_test.go
@@ -9,14 +9,18 @@ import (
 
 func TestConclusionRoundTrip(t *testing.T) {
 	c := &entity.Conclusion{
-		ID:           "C-0001",
-		Hypothesis:   "H-0001",
-		Verdict:      entity.VerdictSupported,
-		Observations: []string{"O-0001", "O-0002"},
-		CandidateExp: "E-0002",
-		CandidateRef: "refs/heads/candidate/E-0002-a1",
-		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
-		BaselineExp:  "E-0001",
+		ID:               "C-0001",
+		Hypothesis:       "H-0001",
+		Verdict:          entity.VerdictSupported,
+		Observations:     []string{"O-0001", "O-0002"},
+		CandidateExp:     "E-0002",
+		CandidateAttempt: 2,
+		CandidateRef:     "refs/heads/candidate/E-0002-a1",
+		CandidateSHA:     "0123456789abcdef0123456789abcdef01234567",
+		BaselineExp:      "E-0001",
+		BaselineAttempt:  1,
+		BaselineRef:      "refs/heads/baseline/E-0001-a1",
+		BaselineSHA:      "89abcdef0123456789abcdef0123456789abcdef",
 		Effect: entity.Effect{
 			Instrument: "host_timing",
 			DeltaAbs:   -0.0005,
@@ -58,6 +62,18 @@ func TestConclusionRoundTrip(t *testing.T) {
 	}
 	if back.CandidateSHA != c.CandidateSHA {
 		t.Errorf("candidate_sha: %q", back.CandidateSHA)
+	}
+	if back.CandidateAttempt != c.CandidateAttempt {
+		t.Errorf("candidate_attempt: %d", back.CandidateAttempt)
+	}
+	if back.BaselineAttempt != c.BaselineAttempt {
+		t.Errorf("baseline_attempt: %d", back.BaselineAttempt)
+	}
+	if back.BaselineRef != c.BaselineRef {
+		t.Errorf("baseline_ref: %q", back.BaselineRef)
+	}
+	if back.BaselineSHA != c.BaselineSHA {
+		t.Errorf("baseline_sha: %q", back.BaselineSHA)
 	}
 	if back.Body != c.Body {
 		t.Errorf("body round-trip:\n want: %q\n  got: %q", c.Body, back.Body)

--- a/internal/entity/conclusion_test.go
+++ b/internal/entity/conclusion_test.go
@@ -14,6 +14,8 @@ func TestConclusionRoundTrip(t *testing.T) {
 		Verdict:      entity.VerdictSupported,
 		Observations: []string{"O-0001", "O-0002"},
 		CandidateExp: "E-0002",
+		CandidateRef: "refs/heads/candidate/E-0002-a1",
+		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
 		BaselineExp:  "E-0001",
 		Effect: entity.Effect{
 			Instrument: "host_timing",
@@ -50,6 +52,12 @@ func TestConclusionRoundTrip(t *testing.T) {
 	}
 	if len(back.Observations) != 2 {
 		t.Errorf("observations: %+v", back.Observations)
+	}
+	if back.CandidateRef != c.CandidateRef {
+		t.Errorf("candidate_ref: %q", back.CandidateRef)
+	}
+	if back.CandidateSHA != c.CandidateSHA {
+		t.Errorf("candidate_sha: %q", back.CandidateSHA)
 	}
 	if back.Body != c.Body {
 		t.Errorf("body round-trip:\n want: %q\n  got: %q", c.Body, back.Body)

--- a/internal/entity/experiment.go
+++ b/internal/entity/experiment.go
@@ -30,6 +30,7 @@ type Experiment struct {
 	Instruments []string  `yaml:"instruments"                         json:"instruments"`
 	Worktree    string    `yaml:"worktree,omitempty"                  json:"worktree,omitempty"`
 	Branch      string    `yaml:"branch,omitempty"                    json:"branch,omitempty"`
+	Attempt     int       `yaml:"attempt,omitempty"                   json:"attempt,omitempty"`
 	Budget      Budget    `yaml:"budget,omitempty"                    json:"budget,omitempty"`
 	Author      string    `yaml:"author"                              json:"author"`
 	CreatedAt   time.Time `yaml:"created_at"                          json:"created_at"`

--- a/internal/entity/experiment_test.go
+++ b/internal/entity/experiment_test.go
@@ -18,6 +18,7 @@ func TestExperimentRoundTrip(t *testing.T) {
 			SHA: "abcdef1234567890",
 		},
 		Instruments: []string{"host_compile", "host_test", "host_timing"},
+		Attempt:     2,
 		Budget: entity.Budget{
 			WallTimeS:  600,
 			MaxSamples: 30,
@@ -49,6 +50,9 @@ func TestExperimentRoundTrip(t *testing.T) {
 	}
 	if back.Budget.MaxSamples != 30 {
 		t.Errorf("budget max_samples: %d", back.Budget.MaxSamples)
+	}
+	if back.Attempt != 2 {
+		t.Errorf("attempt round-trip: got %d, want 2", back.Attempt)
 	}
 	if back.Body != e.Body {
 		t.Errorf("body round-trip:\n want: %q\n  got: %q", e.Body, back.Body)

--- a/internal/entity/observation.go
+++ b/internal/entity/observation.go
@@ -50,6 +50,7 @@ type Observation struct {
 	ExitCode     int            `json:"exit_code"`
 	Worktree     string         `json:"worktree,omitempty"`
 	Attempt      int            `json:"attempt,omitempty"`
+	CandidateRef string         `json:"candidate_ref,omitempty"`
 	CandidateSHA string         `json:"candidate_sha,omitempty"`
 	BaselineSHA  string         `json:"baseline_sha,omitempty"`
 	Author       string         `json:"author"`

--- a/internal/entity/observation.go
+++ b/internal/entity/observation.go
@@ -46,12 +46,14 @@ type Observation struct {
 	RawArtifact string `json:"raw_artifact,omitempty"`
 	RawSHA      string `json:"raw_sha,omitempty"`
 
-	Command     string         `json:"command"`
-	ExitCode    int            `json:"exit_code"`
-	Worktree    string         `json:"worktree,omitempty"`
-	BaselineSHA string         `json:"baseline_sha,omitempty"`
-	Author      string         `json:"author"`
-	Aux         map[string]any `json:"aux,omitempty"`
+	Command      string         `json:"command"`
+	ExitCode     int            `json:"exit_code"`
+	Worktree     string         `json:"worktree,omitempty"`
+	Attempt      int            `json:"attempt,omitempty"`
+	CandidateSHA string         `json:"candidate_sha,omitempty"`
+	BaselineSHA  string         `json:"baseline_sha,omitempty"`
+	Author       string         `json:"author"`
+	Aux          map[string]any `json:"aux,omitempty"`
 }
 
 func ParseObservation(data []byte) (*Observation, error) {

--- a/internal/entity/observation_test.go
+++ b/internal/entity/observation_test.go
@@ -30,6 +30,7 @@ func TestObservationRoundTrip(t *testing.T) {
 		Command:      "./a.out",
 		ExitCode:     0,
 		Attempt:      2,
+		CandidateRef: "refs/heads/candidate/E-0001-a2",
 		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
 		Author:       "agent:observer",
 	}
@@ -49,6 +50,9 @@ func TestObservationRoundTrip(t *testing.T) {
 	}
 	if back.Attempt != 2 {
 		t.Errorf("attempt round trip: got %d, want 2", back.Attempt)
+	}
+	if back.CandidateRef != "refs/heads/candidate/E-0001-a2" {
+		t.Errorf("candidate_ref round trip: %q", back.CandidateRef)
 	}
 	if back.CandidateSHA != "0123456789abcdef0123456789abcdef01234567" {
 		t.Errorf("candidate_sha round trip: %q", back.CandidateSHA)

--- a/internal/entity/observation_test.go
+++ b/internal/entity/observation_test.go
@@ -27,9 +27,11 @@ func TestObservationRoundTrip(t *testing.T) {
 		Artifacts: []entity.Artifact{
 			{Name: "timing", SHA: "abcd1234", Path: "artifacts/ab/cd/timing.json", Bytes: 480},
 		},
-		Command:  "./a.out",
-		ExitCode: 0,
-		Author:   "agent:observer",
+		Command:      "./a.out",
+		ExitCode:     0,
+		Attempt:      2,
+		CandidateSHA: "0123456789abcdef0123456789abcdef01234567",
+		Author:       "agent:observer",
 	}
 	data, err := o.Marshal()
 	if err != nil {
@@ -44,6 +46,12 @@ func TestObservationRoundTrip(t *testing.T) {
 	}
 	if back.CILow == nil || *back.CILow != 0.0045 {
 		t.Errorf("ci_low round trip: %v", back.CILow)
+	}
+	if back.Attempt != 2 {
+		t.Errorf("attempt round trip: got %d, want 2", back.Attempt)
+	}
+	if back.CandidateSHA != "0123456789abcdef0123456789abcdef01234567" {
+		t.Errorf("candidate_sha round trip: %q", back.CandidateSHA)
 	}
 	if len(back.Artifacts) != 1 || back.Artifacts[0].Name != "timing" {
 		t.Errorf("artifacts round trip: %+v", back.Artifacts)

--- a/internal/instrument/runner.go
+++ b/internal/instrument/runner.go
@@ -208,13 +208,7 @@ func runPassFail(ctx context.Context, cfg Config) (*Result, error) {
 }
 
 func runTiming(ctx context.Context, cfg Config) (*Result, error) {
-	samples := cfg.Samples
-	if samples <= 0 {
-		samples = cfg.Instrument.MinSamples
-	}
-	if samples <= 0 {
-		samples = 5
-	}
+	samples := PlanSamples(cfg.Instrument, cfg.Samples).Target
 
 	type sampleRec struct {
 		Run      int     `json:"run"`
@@ -313,13 +307,7 @@ func runScalar(ctx context.Context, cfg Config) (*Result, error) {
 		return nil, fmt.Errorf("pattern %q must have exactly one capture group, got %d", cfg.Instrument.Pattern, re.NumSubexp())
 	}
 
-	samples := cfg.Samples
-	if samples <= 0 {
-		samples = cfg.Instrument.MinSamples
-	}
-	if samples <= 0 {
-		samples = 3
-	}
+	samples := PlanSamples(cfg.Instrument, cfg.Samples).Target
 
 	type sampleRec struct {
 		Run      int    `json:"run"`

--- a/internal/instrument/samples.go
+++ b/internal/instrument/samples.go
@@ -1,0 +1,62 @@
+package instrument
+
+import "github.com/bytter/autoresearch/internal/store"
+
+const (
+	SamplePlanRequested     = "requested"
+	SamplePlanMinSamples    = "min_samples"
+	SamplePlanParserDefault = "parser_default"
+)
+
+// SamplePlan describes the sample target a caller should aim for before
+// deciding whether another observation run is needed.
+type SamplePlan struct {
+	Target      int
+	Source      string
+	MultiSample bool
+}
+
+// PlanSamples resolves the effective sample target for an instrument.
+//
+// Multi-sample parsers (timing, scalar) honor explicit requests, then
+// instrument.MinSamples, then their parser defaults. One-shot parsers still
+// honor explicit requests and MinSamples as a target across observations, but
+// a single execution contributes only one sample.
+func PlanSamples(inst store.Instrument, requested int) SamplePlan {
+	plan := SamplePlan{
+		Target:      1,
+		Source:      SamplePlanParserDefault,
+		MultiSample: parserSupportsMultipleSamples(inst.Parser),
+	}
+	switch {
+	case requested > 0:
+		plan.Target = requested
+		plan.Source = SamplePlanRequested
+	case inst.MinSamples > 0:
+		plan.Target = inst.MinSamples
+		plan.Source = SamplePlanMinSamples
+	case plan.MultiSample:
+		plan.Target = parserDefaultSamples(inst.Parser)
+	}
+	return plan
+}
+
+func parserSupportsMultipleSamples(parser string) bool {
+	switch parser {
+	case "builtin:timing", "builtin:scalar":
+		return true
+	default:
+		return false
+	}
+}
+
+func parserDefaultSamples(parser string) int {
+	switch parser {
+	case "builtin:timing":
+		return 5
+	case "builtin:scalar":
+		return 3
+	default:
+		return 1
+	}
+}

--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -26,7 +26,8 @@ positives, which are far more expensive than false negatives.
 2. `autoresearch conclusion show <C-id> --json` — the verdict, effect
    (vs absolute baseline), `incremental_effect` (vs frontier best, if
    present), `strict_check` (firewall's own assessment), interpretation,
-   author, plus evidence-side join fields for cited observations:
+   author, measured candidate provenance (`candidate_ref`, `candidate_sha`),
+   plus evidence-side join fields for cited observations:
    `observation_artifacts`, `observation_evidence_failures`, and
    `observation_read_issues`.
 3. `autoresearch hypothesis show <hyp-id> --json` — the claim, predicted
@@ -34,6 +35,7 @@ positives, which are far more expensive than false negatives.
 4. Recompute the stats yourself:
 
        autoresearch analyze <candidate-exp-id> \
+           --candidate-ref <candidate-ref> \
            --baseline <baseline-exp-id> \
            --instrument <name> --json
 
@@ -72,7 +74,8 @@ the needed flag is genuinely absent from those references.
 7. **Review the code change for correctness and gaming** — this is as
    important as the statistics:
 
-       git show autoresearch/<candidate-exp-id>
+       git show <candidate-ref>
+       git rev-parse <candidate-ref>   # should match candidate_sha from conclusion show
 
    Check:
    - **Mechanism match**: Does the diff implement what the interpretation
@@ -136,7 +139,7 @@ a reason. Good reasons:
 - **Goodharting**: "Reduction is in LOC / complexity, a static proxy.
   No runtime instrument shows improvement."
 - **Mechanism mismatch**: "Interpretation claims loop unrolling, but
-  the diff (git show autoresearch/E-NNNN) shows the inner loop is
+  the diff (git show <candidate-ref>) shows the inner loop is
   unchanged — the actual change was a deleted debug branch."
 - **Unsupported mechanism**: "Interpretation claims SIMPLIFY_TRACE
   collapsed 14 redundant expressions, but no evidence artifact was

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -131,8 +131,8 @@ before you reach for `--help`:
     autoresearch hypothesis add ... --author agent:orchestrator --json
     autoresearch experiment design <H-id> --baseline HEAD --instruments ... --design-notes "..." --author agent:orchestrator --json
     autoresearch experiment implement <E-id> --impl-notes "..." --json
-    autoresearch observe <E-id> --all --json
-    autoresearch analyze <E-id> [--baseline <baseline-exp-id>] --json
+    autoresearch observe <E-id> --all --candidate-ref <ref> --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline <baseline-exp-id>] --json
     autoresearch conclude <H-id> --verdict ... --observations O-... --interpretation "..." --author agent:orchestrator --json
     autoresearch lesson add ... --from <C-id> --author agent:orchestrator --json   # decisive conclusions
     # then yield to the main session with review pending so it can dispatch research-gate-reviewer
@@ -289,7 +289,10 @@ Spawn Agent:
     2. Test: <test command from config>
     3. If both pass, commit:
        git commit -am 'E-NNNN: <one-line summary>'
-    4. Report: commit SHA, changed files, build/test status, anything
+    4. Create a unique reviewable candidate ref for the commit you want
+       to measure, for example:
+       git branch autoresearch/candidate/<exp-id>-<shortsha> HEAD
+    5. Report: commit SHA, candidate ref, changed files, build/test status, anything
        surprising you noticed.
 
     If the build or tests fail and you can't fix it, report the
@@ -308,7 +311,7 @@ Run all instruments in one shot — the CLI resolves dependency order
 automatically:
 
 ```sh
-autoresearch observe <exp-id> --all --json
+autoresearch observe <exp-id> --all --candidate-ref <candidate-ref> --json
 ```
 
 This runs every instrument declared on the experiment, respecting
@@ -320,20 +323,24 @@ recorded by this invocation.
 Before re-running an expensive single instrument, use the cheap probe:
 
 ```sh
-autoresearch observe check <exp-id> --instrument <name> --json
+autoresearch observe check <exp-id> --instrument <name> --candidate-ref <candidate-ref> --json
 ```
 
 `observe` is idempotent by default for the current implementation
-attempt and candidate snapshot: if enough samples already exist in that
-scope it no-ops, and if some exist but not enough it tops up to the
-target. Dirty worktrees disable reuse until the candidate is clean or
-committed again. Use `--append` only when you intentionally want
-another fresh run even though the target is already met.
+attempt and measured candidate provenance: if enough samples already
+exist for the same attempt + candidate ref + candidate SHA, it no-ops,
+and if some exist but not enough it tops up to the target. For
+non-baseline experiments you must pass `--candidate-ref`, and the
+worktree must be clean with `HEAD` matching that ref. The CLI records
+candidate provenance; it does not create git refs for you. Use a unique
+reviewable candidate ref per measured commit. Use `--append` only when
+you intentionally want another fresh run even though the target is
+already met.
 
 To run a single instrument instead:
 
 ```sh
-autoresearch observe <exp-id> --instrument <name> --json
+autoresearch observe <exp-id> --instrument <name> --candidate-ref <candidate-ref> --json
 ```
 
 If an instrument fails, stop and report — do not retry or fix.
@@ -341,7 +348,7 @@ If an instrument fails, stop and report — do not retry or fix.
 ### 5. Analyze and conclude
 
 ```sh
-autoresearch analyze <exp-id> --baseline <baseline-exp-id> --json
+autoresearch analyze <exp-id> --candidate-ref <candidate-ref> --baseline <baseline-exp-id> --json
 ```
 
 Read the `comparison` object: `delta_frac`, `ci_low_frac`,

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -313,7 +313,9 @@ autoresearch observe <exp-id> --all --json
 
 This runs every instrument declared on the experiment, respecting
 `--requires` edges (e.g. compile before test before timing). Capture
-the `.observations` array from the response.
+the `.observations` array from the response; it is the authoritative
+current-scope observation set. `.new_observations` contains only the ids
+recorded by this invocation.
 
 Before re-running an expensive single instrument, use the cheap probe:
 
@@ -321,10 +323,11 @@ Before re-running an expensive single instrument, use the cheap probe:
 autoresearch observe check <exp-id> --instrument <name> --json
 ```
 
-`observe` is idempotent by default: if enough samples already exist it
-no-ops, and if some exist but not enough it tops up to the target. Use
-`--append` only when you intentionally want another fresh run even
-though the target is already met.
+`observe` is idempotent by default for the current implementation
+attempt and candidate commit: if enough samples already exist in that
+scope it no-ops, and if some exist but not enough it tops up to the
+target. Use `--append` only when you intentionally want another fresh
+run even though the target is already met.
 
 To run a single instrument instead:
 

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -315,7 +315,18 @@ This runs every instrument declared on the experiment, respecting
 `--requires` edges (e.g. compile before test before timing). Capture
 the `.observations` array from the response.
 
-To run a single instrument instead (e.g. for re-measurement):
+Before re-running an expensive single instrument, use the cheap probe:
+
+```sh
+autoresearch observe check <exp-id> --instrument <name> --json
+```
+
+`observe` is idempotent by default: if enough samples already exist it
+no-ops, and if some exist but not enough it tops up to the target. Use
+`--append` only when you intentionally want another fresh run even
+though the target is already met.
+
+To run a single instrument instead:
 
 ```sh
 autoresearch observe <exp-id> --instrument <name> --json

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -324,10 +324,11 @@ autoresearch observe check <exp-id> --instrument <name> --json
 ```
 
 `observe` is idempotent by default for the current implementation
-attempt and candidate commit: if enough samples already exist in that
+attempt and candidate snapshot: if enough samples already exist in that
 scope it no-ops, and if some exist but not enough it tops up to the
-target. Use `--append` only when you intentionally want another fresh
-run even though the target is already met.
+target. Dirty worktrees disable reuse until the candidate is clean or
+committed again. Use `--append` only when you intentionally want
+another fresh run even though the target is already met.
 
 To run a single instrument instead:
 

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -257,9 +257,16 @@ instruments have already been observed with a passing result on the same
 experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 ` + "`observe --force`" + ` to bypass the dependency gate when you know what you're doing.
 
+` + "`observe`" + ` is idempotent by default on the (experiment, instrument) pair: if
+enough samples already exist it no-ops, and if some exist but not enough it
+tops up to the requested total. Use ` + "`observe check`" + ` as the cheap probe
+before rerunning an expensive measurement. Use ` + "`observe --append`" + ` only when
+you intentionally want another fresh run even though the target is already met.
+
 ### Observations and analysis
-    autoresearch observe  <exp-id> --instrument NAME [--samples N]   # single instrument
-    autoresearch observe  <exp-id> --all [--samples N]              # all instruments in dependency order
+    autoresearch observe  check <exp-id> --instrument NAME [--samples N]  # read-only sample probe
+    autoresearch observe  <exp-id> --instrument NAME [--samples N] [--append]
+    autoresearch observe  <exp-id> --all [--samples N] [--append]         # all instruments in dependency order
     autoresearch analyze  <exp-id> [--baseline <baseline-exp-id>] [--instrument NAME] [--iters N]
     autoresearch conclude <hyp-id> \
         --verdict {supported|refuted|inconclusive} \

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -137,8 +137,9 @@ For the routine optimization loop, the canonical command spine is:
     autoresearch hypothesis add ... --author agent:orchestrator --json
     autoresearch experiment design <H-id> --baseline HEAD --instruments ... --design-notes "..." --author agent:orchestrator --json
     autoresearch experiment implement <E-id> --impl-notes "..." --json
-    autoresearch observe <E-id> --all --json
-    autoresearch analyze <E-id> [--baseline <baseline-exp-id>] --json
+    # create a unique reviewable git ref for the measured candidate, then:
+    autoresearch observe <E-id> --all --candidate-ref <ref> --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline <baseline-exp-id>] --json
     autoresearch conclude <H-id> --verdict ... --observations O-... --interpretation "..." --author agent:orchestrator --json
     autoresearch lesson add ... --from <C-id> --author agent:orchestrator --json   # decisive conclusions
     # then yield with review pending so the parent/main session can dispatch research-gate-reviewer
@@ -258,18 +259,21 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 ` + "`observe --force`" + ` to bypass the dependency gate when you know what you're doing.
 
 ` + "`observe`" + ` is idempotent by default for the current implementation attempt
-and candidate snapshot: if enough samples already exist in that scope it
-no-ops, and if some exist but not enough it tops up to the requested total.
-Dirty worktrees disable reuse until the candidate is clean or committed again.
-Use ` + "`observe check`" + ` as the cheap probe before rerunning an expensive
-measurement. Use ` + "`observe --append`" + ` only when you intentionally want
-another fresh run even though the target is already met.
+and measured candidate provenance: if enough samples already exist for the same
+attempt + candidate ref + candidate SHA, it no-ops, and if some exist but not
+enough it tops up to the requested total. For non-baseline experiments you must
+pass ` + "`--candidate-ref`" + ` and the worktree must be clean with ` + "`HEAD`" + `
+matching that ref. The CLI records candidate provenance; it does not create git
+refs for you. Use normal git to create a unique reviewable candidate ref before
+measuring. Use ` + "`observe check`" + ` as the cheap probe before rerunning an
+expensive measurement. Use ` + "`observe --append`" + ` only when you
+intentionally want another fresh run even though the target is already met.
 
 ### Observations and analysis
-    autoresearch observe  check <exp-id> --instrument NAME [--samples N]  # read-only sample probe
-    autoresearch observe  <exp-id> --instrument NAME [--samples N] [--append]
-    autoresearch observe  <exp-id> --all [--samples N] [--append]         # all instruments in dependency order
-    autoresearch analyze  <exp-id> [--baseline <baseline-exp-id>] [--instrument NAME] [--iters N]
+    autoresearch observe  check <exp-id> --instrument NAME --candidate-ref REF [--samples N]  # required for non-baseline experiments
+    autoresearch observe  <exp-id> --instrument NAME --candidate-ref REF [--samples N] [--append]
+    autoresearch observe  <exp-id> --all --candidate-ref REF [--samples N] [--append]         # all instruments in dependency order
+    autoresearch analyze  <exp-id> [--candidate-ref REF] [--baseline <baseline-exp-id>] [--instrument NAME] [--iters N]
     autoresearch conclude <hyp-id> \
         --verdict {supported|refuted|inconclusive} \
         --observations O-XXXX,O-YYYY \
@@ -299,6 +303,7 @@ Decisive conclusions (` + "`supported`" + ` / ` + "`refuted`" + `) are provision
 In ` + "`--json`" + ` mode, ` + "`conclusion show`" + ` returns the conclusion plus three
 additive maps keyed by cited observation id:
 
+- ` + "`candidate_ref`" + ` / ` + "`candidate_sha`" + ` on the conclusion identify the measured candidate's named git ref and resolved commit at observe time
 - ` + "`observation_artifacts`" + ` — artifact metadata only (` + "`name`" + ` / ` + "`sha`" + ` / ` + "`path`" + ` / ` + "`bytes`" + ` / ` + "`mime`" + `), never artifact content
 - ` + "`observation_evidence_failures`" + ` — non-fatal evidence-capture failures persisted on readable observations
 - ` + "`observation_read_issues`" + ` — cited observations that could not be read (for example missing or corrupt persisted evidence)

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -258,9 +258,10 @@ experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 ` + "`observe --force`" + ` to bypass the dependency gate when you know what you're doing.
 
 ` + "`observe`" + ` is idempotent by default for the current implementation attempt
-and candidate commit: if enough samples already exist in that scope it no-ops,
-and if some exist but not enough it tops up to the requested total. Use
-` + "`observe check`" + ` as the cheap probe before rerunning an expensive
+and candidate snapshot: if enough samples already exist in that scope it
+no-ops, and if some exist but not enough it tops up to the requested total.
+Dirty worktrees disable reuse until the candidate is clean or committed again.
+Use ` + "`observe check`" + ` as the cheap probe before rerunning an expensive
 measurement. Use ` + "`observe --append`" + ` only when you intentionally want
 another fresh run even though the target is already met.
 

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -257,11 +257,12 @@ instruments have already been observed with a passing result on the same
 experiment. If a dependency is not satisfied, ` + "`observe`" + ` refuses. Use
 ` + "`observe --force`" + ` to bypass the dependency gate when you know what you're doing.
 
-` + "`observe`" + ` is idempotent by default on the (experiment, instrument) pair: if
-enough samples already exist it no-ops, and if some exist but not enough it
-tops up to the requested total. Use ` + "`observe check`" + ` as the cheap probe
-before rerunning an expensive measurement. Use ` + "`observe --append`" + ` only when
-you intentionally want another fresh run even though the target is already met.
+` + "`observe`" + ` is idempotent by default for the current implementation attempt
+and candidate commit: if enough samples already exist in that scope it no-ops,
+and if some exist but not enough it tops up to the requested total. Use
+` + "`observe check`" + ` as the cheap probe before rerunning an expensive
+measurement. Use ` + "`observe --append`" + ` only when you intentionally want
+another fresh run even though the target is already met.
 
 ### Observations and analysis
     autoresearch observe  check <exp-id> --instrument NAME [--samples N]  # read-only sample probe

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -3,7 +3,6 @@ package readmodel
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/bytter/autoresearch/internal/entity"
@@ -22,10 +21,25 @@ const (
 // inferred.
 type BaselineResolution struct {
 	ExperimentID       string `json:"experiment,omitempty"`
+	Attempt            int    `json:"attempt,omitempty"`
+	Ref                string `json:"ref,omitempty"`
+	SHA                string `json:"sha,omitempty"`
 	Source             string `json:"source,omitempty"`
 	AncestorHypothesis string `json:"ancestor_hypothesis,omitempty"`
 	AncestorConclusion string `json:"ancestor_conclusion,omitempty"`
 	Note               string `json:"note,omitempty"`
+}
+
+func (r *BaselineResolution) Scope() ObservationScope {
+	if r == nil {
+		return ObservationScope{}
+	}
+	return ObservationScope{
+		Experiment: strings.TrimSpace(r.ExperimentID),
+		Attempt:    r.Attempt,
+		Ref:        strings.TrimSpace(r.Ref),
+		SHA:        strings.TrimSpace(r.SHA),
+	}
 }
 
 // ResolveInferredBaseline resolves conclude's default absolute baseline order:
@@ -33,6 +47,14 @@ type BaselineResolution struct {
 // current goal's mapped baseline. It never applies the explicit
 // --baseline-experiment override; callers handle that strictly at the CLI.
 func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *entity.Experiment, instrument string) (*BaselineResolution, error) {
+	obs, err := LoadObservationIndexStrict(s)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveInferredBaselineWithIndex(s, obs, hyp, candidate, instrument)
+}
+
+func ResolveInferredBaselineWithIndex(s *store.Store, obs *ObservationIndex, hyp *entity.Hypothesis, candidate *entity.Experiment, instrument string) (*BaselineResolution, error) {
 	if s == nil || hyp == nil || candidate == nil {
 		return nil, nil
 	}
@@ -40,21 +62,19 @@ func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *
 	if instrument == "" {
 		return nil, nil
 	}
-
-	obsByExp, err := loadObservationsByExperimentStrict(s)
-	if err != nil {
-		return nil, err
-	}
 	var notes []string
 
 	if expID := strings.TrimSpace(candidate.Baseline.Experiment); expID != "" {
-		ok, note, err := experimentHasInstrumentData(s, obsByExp, expID, instrument, "candidate recorded baseline")
+		scope, ok, note, err := ResolveExperimentInstrumentScope(s, obs, expID, instrument, "candidate recorded baseline")
 		if err != nil {
 			return nil, err
 		}
 		if ok {
 			return &BaselineResolution{
 				ExperimentID: expID,
+				Attempt:      scope.Attempt,
+				Ref:          scope.Ref,
+				SHA:          scope.SHA,
 				Source:       BaselineSourceCandidateRecorded,
 			}, nil
 		}
@@ -65,7 +85,7 @@ func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *
 	if err != nil {
 		return nil, err
 	}
-	ancestor, note, err := resolveAncestorSupportedBaseline(s, hyp, instrument, concls, obsByExp)
+	ancestor, note, err := resolveAncestorSupportedBaseline(s, hyp, instrument, concls, obs)
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +95,7 @@ func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *
 		return ancestor, nil
 	}
 
-	goalBase, note, err := resolveGoalBaseline(s, hyp.GoalID, instrument, obsByExp)
+	goalBase, note, err := resolveGoalBaseline(s, hyp.GoalID, instrument, obs)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +111,7 @@ func ResolveInferredBaseline(s *store.Store, hyp *entity.Hypothesis, candidate *
 	return &BaselineResolution{Note: joinNotes(notes...)}, nil
 }
 
-func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, instrument string, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation) (*BaselineResolution, string, error) {
+func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, instrument string, concls []*entity.Conclusion, obs *ObservationIndex) (*BaselineResolution, string, error) {
 	if hyp == nil || strings.TrimSpace(hyp.Parent) == "" {
 		return nil, "", nil
 	}
@@ -118,37 +138,40 @@ func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, in
 		}
 
 		accepted := acceptedByHyp[parentID]
-		usableByExp := map[string]*entity.Conclusion{}
+		usableByScope := map[ObservationScope]*entity.Conclusion{}
 		for _, c := range accepted {
-			ok, _, err := experimentHasInstrumentData(s, obsByExp, c.CandidateExp, instrument, "accepted supported ancestor candidate")
-			if err != nil {
-				return nil, "", err
+			scope, ok := obs.ResolveConclusionCandidateScope(c)
+			if !ok {
+				continue
 			}
-			if ok {
-				usableByExp[c.CandidateExp] = preferAncestorConclusion(usableByExp[c.CandidateExp], c)
+			if !observationsContainInstrument(obs.ObservationsForScope(scope), instrument) {
+				continue
 			}
+			usableByScope[scope] = preferAncestorConclusion(usableByScope[scope], c)
 		}
 
-		switch len(usableByExp) {
+		switch len(usableByScope) {
 		case 0:
 			if len(accepted) > 0 {
 				notes = appendNote(notes, fmt.Sprintf("accepted supported ancestor %s has no candidate with observations on instrument %q", parentID, instrument))
 			}
 		case 1:
-			chosen := onlyAncestorConclusion(usableByExp)
+			scope, chosen := onlyAncestorScopeConclusion(usableByScope)
 			return &BaselineResolution{
 				ExperimentID:       chosen.CandidateExp,
+				Attempt:            scope.Attempt,
+				Ref:                scope.Ref,
+				SHA:                scope.SHA,
 				Source:             BaselineSourceAncestorSupported,
 				AncestorHypothesis: parentID,
 				AncestorConclusion: chosen.ID,
 			}, joinNotes(notes...), nil
 		default:
-			expIDs := make([]string, 0, len(usableByExp))
-			for expID := range usableByExp {
-				expIDs = append(expIDs, expID)
+			scopeLabels := make([]ObservationScope, 0, len(usableByScope))
+			for scope := range usableByScope {
+				scopeLabels = append(scopeLabels, scope)
 			}
-			sort.Strings(expIDs)
-			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported candidate experiments with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(expIDs, ", "))
+			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported candidate scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(SortedObservationScopeLabels(scopeLabels), ", "))
 		}
 
 		parentID = strings.TrimSpace(parent.Parent)
@@ -157,7 +180,7 @@ func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, in
 	return nil, joinNotes(notes...), nil
 }
 
-func resolveGoalBaseline(s *store.Store, goalID, instrument string, obsByExp map[string][]*entity.Observation) (*BaselineResolution, string, error) {
+func resolveGoalBaseline(s *store.Store, goalID, instrument string, obs *ObservationIndex) (*BaselineResolution, string, error) {
 	goalID = strings.TrimSpace(goalID)
 	if goalID == "" {
 		return nil, "", nil
@@ -172,16 +195,16 @@ func resolveGoalBaseline(s *store.Store, goalID, instrument string, obsByExp map
 	}
 
 	var (
-		usable []string
+		usable []ObservationScope
 		notes  []string
 	)
 	for _, expID := range ids {
-		ok, note, err := experimentHasInstrumentData(s, obsByExp, expID, instrument, "goal baseline")
+		scope, ok, note, err := ResolveExperimentInstrumentScope(s, obs, expID, instrument, "goal baseline")
 		if err != nil {
 			return nil, "", err
 		}
 		if ok {
-			usable = append(usable, expID)
+			usable = append(usable, scope)
 			continue
 		}
 		notes = appendNote(notes, note)
@@ -192,12 +215,14 @@ func resolveGoalBaseline(s *store.Store, goalID, instrument string, obsByExp map
 		return nil, joinNotes(notes...), nil
 	case 1:
 		return &BaselineResolution{
-			ExperimentID: usable[0],
+			ExperimentID: usable[0].Experiment,
+			Attempt:      usable[0].Attempt,
+			Ref:          usable[0].Ref,
+			SHA:          usable[0].SHA,
 			Source:       BaselineSourceGoalBaseline,
 		}, joinNotes(notes...), nil
 	default:
-		sort.Strings(usable)
-		return nil, "", fmt.Errorf("goal %s has multiple baseline experiments with observations on instrument %q: %s; pass --baseline-experiment explicitly", goalID, instrument, strings.Join(usable, ", "))
+		return nil, "", fmt.Errorf("goal %s has multiple baseline scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", goalID, instrument, strings.Join(SortedObservationScopeLabels(usable), ", "))
 	}
 }
 
@@ -224,27 +249,25 @@ func goalBaselineExperimentIDs(s *store.Store, goalID string) ([]string, error) 
 	return ids, nil
 }
 
-func loadObservationsByExperimentStrict(s *store.Store) (map[string][]*entity.Observation, error) {
-	all, err := s.ListObservations()
-	if err != nil {
-		return nil, err
-	}
-	return GroupObservationsByExperiment(all), nil
-}
-
-func experimentHasInstrumentData(s *store.Store, obsByExp map[string][]*entity.Observation, expID, instrument, label string) (bool, string, error) {
+// ResolveExperimentInstrumentScope selects the single usable observation scope
+// for one experiment on one instrument. It distinguishes missing experiments,
+// missing instrument data, and ambiguous multi-scope measurements.
+func ResolveExperimentInstrumentScope(s *store.Store, obs *ObservationIndex, expID, instrument, label string) (ObservationScope, bool, string, error) {
 	if _, err := s.ReadExperiment(expID); err != nil {
 		if errors.Is(err, store.ErrExperimentNotFound) {
-			return false, fmt.Sprintf("%s %s does not exist", label, expID), nil
+			return ObservationScope{}, false, fmt.Sprintf("%s %s does not exist", label, expID), nil
 		}
-		return false, "", err
+		return ObservationScope{}, false, "", err
 	}
-	for _, o := range obsByExp[expID] {
-		if o != nil && o.Instrument == instrument {
-			return true, "", nil
-		}
+	scopes := obs.ScopesForExperimentInstrument(expID, instrument)
+	switch len(scopes) {
+	case 0:
+		return ObservationScope{}, false, fmt.Sprintf("%s %s has no observations on instrument %q", label, expID, instrument), nil
+	case 1:
+		return scopes[0], true, "", nil
+	default:
+		return ObservationScope{}, false, "", fmt.Errorf("%s %s has multiple observation scopes on instrument %q: %s", label, expID, instrument, strings.Join(SortedObservationScopeLabels(scopes), ", "))
 	}
-	return false, fmt.Sprintf("%s %s has no observations on instrument %q", label, expID, instrument), nil
 }
 
 func preferAncestorConclusion(cur, next *entity.Conclusion) *entity.Conclusion {
@@ -263,11 +286,11 @@ func preferAncestorConclusion(cur, next *entity.Conclusion) *entity.Conclusion {
 	return cur
 }
 
-func onlyAncestorConclusion(m map[string]*entity.Conclusion) *entity.Conclusion {
-	for _, c := range m {
-		return c
+func onlyAncestorScopeConclusion(m map[ObservationScope]*entity.Conclusion) (ObservationScope, *entity.Conclusion) {
+	for scope, c := range m {
+		return scope, c
 	}
-	return nil
+	return ObservationScope{}, nil
 }
 
 func appendNote(notes []string, note string) []string {

--- a/internal/readmodel/baseline_test.go
+++ b/internal/readmodel/baseline_test.go
@@ -117,6 +117,27 @@ func (f *baselineFixture) writeObservation(t *testing.T, id, expID, instrument s
 	}
 }
 
+func (f *baselineFixture) writeScopedObservation(t *testing.T, id, expID, instrument string, attempt int, ref, sha string) {
+	t.Helper()
+	o := &entity.Observation{
+		ID:           id,
+		Experiment:   expID,
+		Instrument:   instrument,
+		MeasuredAt:   f.now,
+		Value:        100,
+		Samples:      3,
+		PerSample:    []float64{100, 101, 99},
+		Unit:         "ns",
+		Attempt:      attempt,
+		CandidateRef: ref,
+		CandidateSHA: sha,
+		Author:       "agent:observer",
+	}
+	if err := f.s.WriteObservation(o); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func (f *baselineFixture) writeConclusion(t *testing.T, id, hypID, candidateExp string, reviewed bool) {
 	t.Helper()
 	c := &entity.Conclusion{
@@ -129,6 +150,30 @@ func (f *baselineFixture) writeConclusion(t *testing.T, id, hypID, candidateExp 
 		StatTest:     "mann_whitney_u",
 		Author:       "agent:analyst",
 		CreatedAt:    f.now,
+	}
+	if reviewed {
+		c.ReviewedBy = "human:gate"
+	}
+	if err := f.s.WriteConclusion(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *baselineFixture) writeScopedConclusion(t *testing.T, id, hypID, obsID string, scope ObservationScope, reviewed bool) {
+	t.Helper()
+	c := &entity.Conclusion{
+		ID:               id,
+		Hypothesis:       hypID,
+		Verdict:          entity.VerdictSupported,
+		Observations:     []string{obsID},
+		CandidateExp:     scope.Experiment,
+		CandidateAttempt: scope.Attempt,
+		CandidateRef:     scope.Ref,
+		CandidateSHA:     scope.SHA,
+		Effect:           entity.Effect{Instrument: "timing", DeltaFrac: -0.1},
+		StatTest:         "mann_whitney_u",
+		Author:           "agent:analyst",
+		CreatedAt:        f.now,
 	}
 	if reviewed {
 		c.ReviewedBy = "human:gate"
@@ -259,6 +304,47 @@ func TestResolveInferredBaseline_DedupesSupportedConclusionsOnSameAncestorExperi
 	}
 }
 
+func TestResolveInferredBaseline_UsesAcceptedAncestorScope(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+
+	parent := f.writeHypothesis(t, "H-0001", "G-0001", "")
+	current := f.writeHypothesis(t, "H-0002", "G-0001", parent.ID)
+
+	ancestorExp := f.writeExperiment(t, "E-0001", parent.ID, "", "", false)
+	scopeA := ObservationScope{
+		Experiment: ancestorExp.ID,
+		Attempt:    1,
+		Ref:        "refs/heads/candidate/E-0001-a1",
+		SHA:        "1111111111111111111111111111111111111111",
+	}
+	scopeB := ObservationScope{
+		Experiment: ancestorExp.ID,
+		Attempt:    2,
+		Ref:        "refs/heads/candidate/E-0001-a2",
+		SHA:        "2222222222222222222222222222222222222222",
+	}
+	f.writeScopedObservation(t, "O-0001", ancestorExp.ID, "timing", scopeA.Attempt, scopeA.Ref, scopeA.SHA)
+	f.writeScopedObservation(t, "O-0002", ancestorExp.ID, "timing", scopeB.Attempt, scopeB.Ref, scopeB.SHA)
+	f.writeScopedConclusion(t, "C-0001", parent.ID, "O-0001", scopeA, true)
+
+	candidate := f.writeExperiment(t, "E-0002", current.ID, "", "", false)
+
+	got, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("ResolveInferredBaseline returned nil result")
+	}
+	if got.ExperimentID != ancestorExp.ID {
+		t.Fatalf("experiment = %q, want %q", got.ExperimentID, ancestorExp.ID)
+	}
+	if got.Attempt != scopeA.Attempt || got.Ref != scopeA.Ref || got.SHA != scopeA.SHA {
+		t.Fatalf("ancestor scope = %+v, want %+v", got.Scope(), scopeA)
+	}
+}
+
 func TestResolveInferredBaseline_UsesGoalScopedBaselineMapping(t *testing.T) {
 	f := newBaselineFixture(t)
 	f.writeGoal(t, "G-0001")
@@ -303,8 +389,28 @@ func TestResolveInferredBaseline_ErrorsOnAmbiguousGoalBaseline(t *testing.T) {
 	if err == nil {
 		t.Fatal("ResolveInferredBaseline unexpectedly succeeded")
 	}
-	if !strings.Contains(err.Error(), "multiple baseline experiments") {
-		t.Fatalf("error = %q, want multiple baseline experiments", err)
+	if !strings.Contains(err.Error(), "multiple baseline scopes") {
+		t.Fatalf("error = %q, want multiple baseline scopes", err)
+	}
+}
+
+func TestResolveInferredBaseline_ErrorsOnAmbiguousCandidateRecordedScope(t *testing.T) {
+	f := newBaselineFixture(t)
+	f.writeGoal(t, "G-0001")
+	current := f.writeHypothesis(t, "H-0001", "G-0001", "")
+
+	recorded := f.writeExperiment(t, "E-0001", "", "G-0001", "", true)
+	f.writeScopedObservation(t, "O-0001", recorded.ID, "timing", 1, "refs/heads/baseline/E-0001-a1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	f.writeScopedObservation(t, "O-0002", recorded.ID, "timing", 2, "refs/heads/baseline/E-0001-a2", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	candidate := f.writeExperiment(t, "E-0002", current.ID, "", recorded.ID, false)
+
+	_, err := ResolveInferredBaseline(f.s, current, candidate, "timing")
+	if err == nil {
+		t.Fatal("ResolveInferredBaseline unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "multiple observation scopes") {
+		t.Fatalf("error = %q, want multiple observation scopes", err)
 	}
 }
 

--- a/internal/readmodel/frontier.go
+++ b/internal/readmodel/frontier.go
@@ -66,26 +66,30 @@ func ComputeFrontier(s *store.Store, goal *entity.Goal, concls []*entity.Conclus
 // ComputeFrontierSnapshot loads the read-side context needed to build a full
 // frontier projection from store-backed entities.
 func ComputeFrontierSnapshot(s *store.Store, goal *entity.Goal, concls []*entity.Conclusion) FrontierSnapshot {
-	return BuildFrontierSnapshot(goal, concls, LoadObservationsByExperiment(s), LoadExperimentReadClasses(s))
+	return BuildFrontierSnapshot(goal, concls, LoadObservationIndex(s), LoadExperimentReadClasses(s))
 }
 
 // BuildFrontierSnapshot composes the frontier rows, goal assessment, and
 // stalled-for counter from already-loaded read-side inputs.
-func BuildFrontierSnapshot(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierSnapshot {
-	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, expClassByID)
+func BuildFrontierSnapshot(goal *entity.Goal, concls []*entity.Conclusion, obs *ObservationIndex, expClassByID map[string]ExperimentReadClass) FrontierSnapshot {
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, obs, expClassByID)
 	return FrontierSnapshot{
 		Rows:       rows,
-		Assessment: AssessGoalCompletion(goal, concls, obsByExp, expClassByID),
+		Assessment: AssessGoalCompletion(goal, concls, obs, expClassByID),
 		StalledFor: stalled,
 	}
 }
 
-func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) (rows []FrontierRow, stalledFor int) {
+func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclusion, obs *ObservationIndex, expClassByID map[string]ExperimentReadClass) (rows []FrontierRow, stalledFor int) {
 	rows = []FrontierRow{} // always non-nil so --json emits [] not null
 	requireByInst := frontierRequireConstraints(goal)
 
 	for _, c := range concls {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		scopeObs, _, ok := obs.ObservationsForConclusionCandidate(c)
+		if !ok {
+			continue
+		}
+		val, ok := frontierCandidateValue(goal, c, scopeObs, requireByInst)
 		if !ok {
 			continue
 		}
@@ -99,7 +103,7 @@ func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 			Classification:   class.Classification,
 			HypothesisStatus: class.HypothesisStatus,
 			RescuedBy:        c.Strict.RescuedBy,
-			TiebreakValues:   rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+			TiebreakValues:   rescuerTiebreakValues(goal, scopeObs),
 		})
 	}
 	sort.Slice(rows, func(i, j int) bool {
@@ -113,11 +117,12 @@ func ComputeFrontierFromObservations(goal *entity.Goal, concls []*entity.Conclus
 	hasBest := false
 	var bestRow FrontierRow
 	for _, c := range sortedByTime {
-		val, ok := frontierCandidateValue(goal, c, obsByExp, requireByInst)
+		scopeObs, _, _ := obs.ObservationsForConclusionCandidate(c)
+		val, ok := frontierCandidateValue(goal, c, scopeObs, requireByInst)
 		if ok {
 			cur := FrontierRow{
 				Value:          val,
-				TiebreakValues: rescuerTiebreakValues(goal, obsByExp[c.CandidateExp]),
+				TiebreakValues: rescuerTiebreakValues(goal, scopeObs),
 			}
 			if !hasBest {
 				hasBest = true
@@ -169,7 +174,7 @@ func FrontierRowBetter(goal *entity.Goal, a, b FrontierRow) bool {
 	return false
 }
 
-func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByExp map[string][]*entity.Observation, expClassByID map[string]ExperimentReadClass) FrontierGoalAssessment {
+func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obs *ObservationIndex, expClassByID map[string]ExperimentReadClass) FrontierGoalAssessment {
 	_ = expClassByID
 	if goal == nil || goal.IsOpenEnded() {
 		return FrontierGoalAssessment{
@@ -200,11 +205,14 @@ func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 		if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
 			continue
 		}
-		obs := obsByExp[c.CandidateExp]
-		if !goalConstraintsSatisfied(obs, goal.Constraints) {
+		scopeObs, _, ok := obs.ObservationsForConclusionCandidate(c)
+		if !ok {
 			continue
 		}
-		val, ok := candidateObjectiveValue(obs, goal.Objective.Instrument)
+		if !goalConstraintsSatisfied(scopeObs, goal.Constraints) {
+			continue
+		}
+		val, ok := candidateObjectiveValue(scopeObs, goal.Objective.Instrument)
 		if !ok {
 			continue
 		}
@@ -229,30 +237,6 @@ func AssessGoalCompletion(goal *entity.Goal, concls []*entity.Conclusion, obsByE
 		}
 	}
 	return assessment
-}
-
-// LoadObservationsByExperiment reads all observations once and returns them
-// indexed by experiment ID. A nil map (on read error) is safe — callers get
-// empty slices from the nil map.
-func LoadObservationsByExperiment(s *store.Store) map[string][]*entity.Observation {
-	all, err := s.ListObservations()
-	if err != nil {
-		return nil
-	}
-	return GroupObservationsByExperiment(all)
-}
-
-// GroupObservationsByExperiment buckets already-loaded observations by their
-// experiment ID for frontier and status projections.
-func GroupObservationsByExperiment(all []*entity.Observation) map[string][]*entity.Observation {
-	m := make(map[string][]*entity.Observation, len(all))
-	for _, o := range all {
-		if o == nil {
-			continue
-		}
-		m[o.Experiment] = append(m[o.Experiment], o)
-	}
-	return m
 }
 
 // rescuerTiebreakValues extracts one candidate value per goal rescuer, in
@@ -300,17 +284,17 @@ func frontierRequireConstraints(goal *entity.Goal) map[string]string {
 	return requireByInst
 }
 
-func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obsByExp map[string][]*entity.Observation, requireByInst map[string]string) (float64, bool) {
+func frontierCandidateValue(goal *entity.Goal, c *entity.Conclusion, obs []*entity.Observation, requireByInst map[string]string) (float64, bool) {
 	if goal == nil || c == nil {
 		return 0, false
 	}
 	if c.Verdict != entity.VerdictSupported || c.Effect.Instrument != goal.Objective.Instrument {
 		return 0, false
 	}
-	if !requireSatisfied(obsByExp[c.CandidateExp], requireByInst) {
+	if !requireSatisfied(obs, requireByInst) {
 		return 0, false
 	}
-	return candidateObjectiveValue(obsByExp[c.CandidateExp], goal.Objective.Instrument)
+	return candidateObjectiveValue(obs, goal.Objective.Instrument)
 }
 
 func betterFrontierValue(direction string, candidate, incumbent float64) bool {

--- a/internal/readmodel/frontier_test.go
+++ b/internal/readmodel/frontier_test.go
@@ -7,6 +7,25 @@ import (
 	"github.com/bytter/autoresearch/internal/entity"
 )
 
+func observationIndexForTest(m map[string][]*entity.Observation) *ObservationIndex {
+	var all []*entity.Observation
+	for expID, obs := range m {
+		for _, o := range obs {
+			if o == nil {
+				continue
+			}
+			if o.Experiment == expID {
+				all = append(all, o)
+				continue
+			}
+			copyObs := *o
+			copyObs.Experiment = expID
+			all = append(all, &copyObs)
+		}
+	}
+	return NewObservationIndex(all)
+}
+
 func TestAssessGoalCompletion_CountsReviewedSupportedCandidatesAfterAcceptance(t *testing.T) {
 	goal := &entity.Goal{
 		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
@@ -35,7 +54,7 @@ func TestAssessGoalCompletion_CountsReviewedSupportedCandidatesAfterAcceptance(t
 		},
 	}
 
-	got := AssessGoalCompletion(goal, concls, obsByExp, expClassByID)
+	got := AssessGoalCompletion(goal, concls, observationIndexForTest(obsByExp), expClassByID)
 	if !got.Met || got.MetByConclusion != "C-3000" || got.RecommendedAction != "stop" {
 		t.Fatalf("unexpected assessment: %+v", got)
 	}
@@ -78,7 +97,7 @@ func TestComputeFrontierFromObservations_StalledForCountsLaterConclusionsAfterAc
 		"E-0003": {{Instrument: "host_timing", Value: 90}},
 	}
 
-	rows, stalled := ComputeFrontierFromObservations(goal, concls, obsByExp, map[string]ExperimentReadClass{
+	rows, stalled := ComputeFrontierFromObservations(goal, concls, observationIndexForTest(obsByExp), map[string]ExperimentReadClass{
 		"E-0001": {
 			Classification:   ExperimentClassificationDead,
 			HypothesisStatus: entity.StatusSupported,
@@ -126,7 +145,7 @@ func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
 		},
 	}
 
-	got := BuildFrontierSnapshot(goal, concls, GroupObservationsByExperiment(obs), expClassByID)
+	got := BuildFrontierSnapshot(goal, concls, NewObservationIndex(obs), expClassByID)
 	if got.StalledFor != 0 {
 		t.Fatalf("stalled_for = %d, want 0", got.StalledFor)
 	}
@@ -141,5 +160,128 @@ func TestBuildFrontierSnapshot_ComposesRowsAssessmentAndStall(t *testing.T) {
 	}
 	if got.Rows[0].Classification != ExperimentClassificationDead {
 		t.Fatalf("row classification = %q, want %q", got.Rows[0].Classification, ExperimentClassificationDead)
+	}
+}
+
+func TestComputeFrontierFromObservations_UsesConclusionCandidateScope(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:               "C-0001",
+			Hypothesis:       "H-0001",
+			Verdict:          entity.VerdictSupported,
+			Observations:     []string{"O-a1"},
+			CandidateExp:     "E-0001",
+			CandidateAttempt: 1,
+			CandidateRef:     "refs/heads/candidate/E-0001-a1",
+			CandidateSHA:     "1111111111111111111111111111111111111111",
+			Effect:           entity.Effect{Instrument: "host_timing", DeltaFrac: -0.10},
+		},
+		{
+			ID:               "C-0002",
+			Hypothesis:       "H-0002",
+			Verdict:          entity.VerdictSupported,
+			Observations:     []string{"O-a2"},
+			CandidateExp:     "E-0001",
+			CandidateAttempt: 2,
+			CandidateRef:     "refs/heads/candidate/E-0001-a2",
+			CandidateSHA:     "2222222222222222222222222222222222222222",
+			Effect:           entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
+		},
+	}
+	obs := NewObservationIndex([]*entity.Observation{
+		{
+			ID:           "O-a2",
+			Experiment:   "E-0001",
+			Instrument:   "host_timing",
+			Value:        80,
+			Attempt:      2,
+			CandidateRef: "refs/heads/candidate/E-0001-a2",
+			CandidateSHA: "2222222222222222222222222222222222222222",
+		},
+		{
+			ID:           "O-a1",
+			Experiment:   "E-0001",
+			Instrument:   "host_timing",
+			Value:        100,
+			Attempt:      1,
+			CandidateRef: "refs/heads/candidate/E-0001-a1",
+			CandidateSHA: "1111111111111111111111111111111111111111",
+		},
+	})
+	rows, _ := ComputeFrontierFromObservations(goal, concls, obs, nil)
+	if got, want := len(rows), 2; got != want {
+		t.Fatalf("rows len = %d, want %d", got, want)
+	}
+	if got, want := rows[0].Conclusion, "C-0002"; got != want {
+		t.Fatalf("best row conclusion = %q, want %q", got, want)
+	}
+	if got, want := rows[0].Value, 80.0; got != want {
+		t.Fatalf("best row value = %v, want %v", got, want)
+	}
+	if got, want := rows[1].Value, 100.0; got != want {
+		t.Fatalf("second row value = %v, want %v", got, want)
+	}
+}
+
+func TestAssessGoalCompletion_UsesReviewedConclusionScope(t *testing.T) {
+	goal := &entity.Goal{
+		Objective: entity.Objective{Instrument: "host_timing", Direction: "decrease"},
+		Completion: &entity.Completion{
+			Threshold:   0.15,
+			OnThreshold: entity.GoalOnThresholdStop,
+		},
+	}
+	concls := []*entity.Conclusion{
+		{
+			ID:               "C-0001",
+			Hypothesis:       "H-0001",
+			Verdict:          entity.VerdictSupported,
+			ReviewedBy:       "agent:gate",
+			Observations:     []string{"O-a1"},
+			CandidateExp:     "E-0001",
+			CandidateAttempt: 1,
+			CandidateRef:     "refs/heads/candidate/E-0001-a1",
+			CandidateSHA:     "1111111111111111111111111111111111111111",
+			Effect:           entity.Effect{Instrument: "host_timing", DeltaFrac: -0.10},
+		},
+		{
+			ID:               "C-0002",
+			Hypothesis:       "H-0002",
+			Verdict:          entity.VerdictSupported,
+			ReviewedBy:       "agent:gate",
+			Observations:     []string{"O-a2"},
+			CandidateExp:     "E-0001",
+			CandidateAttempt: 2,
+			CandidateRef:     "refs/heads/candidate/E-0001-a2",
+			CandidateSHA:     "2222222222222222222222222222222222222222",
+			Effect:           entity.Effect{Instrument: "host_timing", DeltaFrac: -0.20},
+		},
+	}
+	obs := NewObservationIndex([]*entity.Observation{
+		{
+			ID:           "O-a1",
+			Experiment:   "E-0001",
+			Instrument:   "host_timing",
+			Value:        100,
+			Attempt:      1,
+			CandidateRef: "refs/heads/candidate/E-0001-a1",
+			CandidateSHA: "1111111111111111111111111111111111111111",
+		},
+		{
+			ID:           "O-a2",
+			Experiment:   "E-0001",
+			Instrument:   "host_timing",
+			Value:        80,
+			Attempt:      2,
+			CandidateRef: "refs/heads/candidate/E-0001-a2",
+			CandidateSHA: "2222222222222222222222222222222222222222",
+		},
+	})
+	got := AssessGoalCompletion(goal, concls, obs, nil)
+	if !got.Met || got.MetByConclusion != "C-0002" || got.RecommendedAction != "stop" {
+		t.Fatalf("unexpected assessment: %+v", got)
 	}
 }

--- a/internal/readmodel/observation_scope.go
+++ b/internal/readmodel/observation_scope.go
@@ -1,0 +1,293 @@
+package readmodel
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+// ObservationScope is the durable identity of a measured candidate or
+// baseline observation set within one experiment.
+type ObservationScope struct {
+	Experiment string
+	Attempt    int
+	Ref        string
+	SHA        string
+}
+
+type observationScopeSelector struct {
+	Experiment string
+	Attempt    int
+	HasAttempt bool
+	Ref        string
+	HasRef     bool
+	SHA        string
+	HasSHA     bool
+}
+
+func (s observationScopeSelector) hasConstraints() bool {
+	return s.HasAttempt || s.HasRef || s.HasSHA
+}
+
+// ObservationIndex is the shared read-side view of recorded observations.
+// It indexes observations both by experiment and by durable scope.
+type ObservationIndex struct {
+	byID               map[string]*entity.Observation
+	byScope            map[ObservationScope][]*entity.Observation
+	scopesByExperiment map[string][]ObservationScope
+}
+
+func LoadObservationIndex(s *store.Store) *ObservationIndex {
+	idx, err := LoadObservationIndexStrict(s)
+	if err != nil {
+		return NewObservationIndex(nil)
+	}
+	return idx
+}
+
+func LoadObservationIndexStrict(s *store.Store) (*ObservationIndex, error) {
+	all, err := s.ListObservations()
+	if err != nil {
+		return nil, err
+	}
+	return NewObservationIndex(all), nil
+}
+
+func NewObservationIndex(all []*entity.Observation) *ObservationIndex {
+	idx := &ObservationIndex{
+		byID:               map[string]*entity.Observation{},
+		byScope:            map[ObservationScope][]*entity.Observation{},
+		scopesByExperiment: map[string][]ObservationScope{},
+	}
+	seenScopes := map[string]map[ObservationScope]struct{}{}
+	for _, o := range all {
+		if o == nil {
+			continue
+		}
+		if id := strings.TrimSpace(o.ID); id != "" {
+			idx.byID[id] = o
+		}
+		expID := strings.TrimSpace(o.Experiment)
+		if expID == "" {
+			continue
+		}
+		scope := ObservationScopeFromObservation(o)
+		idx.byScope[scope] = append(idx.byScope[scope], o)
+		if seenScopes[expID] == nil {
+			seenScopes[expID] = map[ObservationScope]struct{}{}
+		}
+		if _, dup := seenScopes[expID][scope]; dup {
+			continue
+		}
+		seenScopes[expID][scope] = struct{}{}
+		idx.scopesByExperiment[expID] = append(idx.scopesByExperiment[expID], scope)
+	}
+	for expID := range idx.scopesByExperiment {
+		sort.Slice(idx.scopesByExperiment[expID], func(i, j int) bool {
+			return observationScopeLess(idx.scopesByExperiment[expID][i], idx.scopesByExperiment[expID][j])
+		})
+	}
+	return idx
+}
+
+func ObservationScopeFromObservation(o *entity.Observation) ObservationScope {
+	if o == nil {
+		return ObservationScope{}
+	}
+	return ObservationScope{
+		Experiment: strings.TrimSpace(o.Experiment),
+		Attempt:    o.Attempt,
+		Ref:        strings.TrimSpace(o.CandidateRef),
+		SHA:        strings.TrimSpace(o.CandidateSHA),
+	}
+}
+
+func FormatObservationScope(scope ObservationScope) string {
+	var parts []string
+	if scope.Experiment != "" {
+		parts = append(parts, scope.Experiment)
+	}
+	if scope.Attempt > 0 {
+		parts = append(parts, fmt.Sprintf("attempt=%d", scope.Attempt))
+	}
+	switch {
+	case scope.Ref != "" && scope.SHA != "":
+		parts = append(parts, fmt.Sprintf("%s@%s", scope.Ref, shortScopeSHA(scope.SHA)))
+	case scope.Ref != "":
+		parts = append(parts, scope.Ref)
+	case scope.SHA != "":
+		parts = append(parts, shortScopeSHA(scope.SHA))
+	}
+	if len(parts) == 0 {
+		return "(legacy)"
+	}
+	return strings.Join(parts, " ")
+}
+
+func SortedObservationScopeLabels(scopes []ObservationScope) []string {
+	labels := make([]string, 0, len(scopes))
+	for _, scope := range scopes {
+		labels = append(labels, FormatObservationScope(scope))
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+func (idx *ObservationIndex) ObservationsForScope(scope ObservationScope) []*entity.Observation {
+	if idx == nil {
+		return nil
+	}
+	return idx.byScope[scope]
+}
+
+func (idx *ObservationIndex) ScopesForExperiment(expID string) []ObservationScope {
+	if idx == nil {
+		return nil
+	}
+	src := idx.scopesByExperiment[strings.TrimSpace(expID)]
+	out := make([]ObservationScope, len(src))
+	copy(out, src)
+	return out
+}
+
+func (idx *ObservationIndex) ScopesForExperimentInstrument(expID, instrument string) []ObservationScope {
+	if idx == nil {
+		return nil
+	}
+	expID = strings.TrimSpace(expID)
+	instrument = strings.TrimSpace(instrument)
+	scopes := idx.scopesByExperiment[expID]
+	out := make([]ObservationScope, 0, len(scopes))
+	for _, scope := range scopes {
+		if instrument != "" && !observationsContainInstrument(idx.byScope[scope], instrument) {
+			continue
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func (idx *ObservationIndex) ResolveConclusionCandidateScope(c *entity.Conclusion) (ObservationScope, bool) {
+	if idx == nil || c == nil || strings.TrimSpace(c.CandidateExp) == "" {
+		return ObservationScope{}, false
+	}
+	if scope, ok := idx.scopeFromObservationIDs(c.Observations); ok {
+		return scope, true
+	}
+	selector := observationScopeSelector{
+		Experiment: strings.TrimSpace(c.CandidateExp),
+		Attempt:    c.CandidateAttempt,
+		HasAttempt: c.CandidateAttempt > 0,
+		Ref:        strings.TrimSpace(c.CandidateRef),
+		HasRef:     strings.TrimSpace(c.CandidateRef) != "",
+		SHA:        strings.TrimSpace(c.CandidateSHA),
+		HasSHA:     strings.TrimSpace(c.CandidateSHA) != "",
+	}
+	if selector.hasConstraints() {
+		if scopes := idx.matchingScopes(selector, ""); len(scopes) == 1 {
+			return scopes[0], true
+		}
+	}
+	if scopes := idx.ScopesForExperiment(selector.Experiment); len(scopes) == 1 {
+		return scopes[0], true
+	}
+	return ObservationScope{}, false
+}
+
+func (idx *ObservationIndex) ObservationsForConclusionCandidate(c *entity.Conclusion) ([]*entity.Observation, ObservationScope, bool) {
+	scope, ok := idx.ResolveConclusionCandidateScope(c)
+	if !ok {
+		return nil, ObservationScope{}, false
+	}
+	obs := idx.ObservationsForScope(scope)
+	if len(obs) == 0 {
+		return nil, ObservationScope{}, false
+	}
+	return obs, scope, true
+}
+
+func (idx *ObservationIndex) scopeFromObservationIDs(ids []string) (ObservationScope, bool) {
+	if idx == nil {
+		return ObservationScope{}, false
+	}
+	var (
+		scope ObservationScope
+		found bool
+	)
+	for _, rawID := range ids {
+		id := strings.TrimSpace(rawID)
+		if id == "" {
+			continue
+		}
+		o, ok := idx.byID[id]
+		if !ok || o == nil {
+			continue
+		}
+		cur := ObservationScopeFromObservation(o)
+		if !found {
+			scope = cur
+			found = true
+			continue
+		}
+		if cur != scope {
+			return ObservationScope{}, false
+		}
+	}
+	return scope, found
+}
+
+func (idx *ObservationIndex) matchingScopes(selector observationScopeSelector, instrument string) []ObservationScope {
+	if idx == nil || selector.Experiment == "" {
+		return nil
+	}
+	scopes := idx.scopesByExperiment[selector.Experiment]
+	out := make([]ObservationScope, 0, len(scopes))
+	for _, scope := range scopes {
+		if selector.HasAttempt && scope.Attempt != selector.Attempt {
+			continue
+		}
+		if selector.HasRef && scope.Ref != selector.Ref {
+			continue
+		}
+		if selector.HasSHA && scope.SHA != selector.SHA {
+			continue
+		}
+		if instrument != "" && !observationsContainInstrument(idx.byScope[scope], instrument) {
+			continue
+		}
+		out = append(out, scope)
+	}
+	return out
+}
+
+func observationsContainInstrument(obs []*entity.Observation, instrument string) bool {
+	for _, o := range obs {
+		if o != nil && o.Instrument == instrument {
+			return true
+		}
+	}
+	return false
+}
+
+func shortScopeSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func observationScopeLess(a, b ObservationScope) bool {
+	if a.Attempt != b.Attempt {
+		return a.Attempt < b.Attempt
+	}
+	if a.Ref != b.Ref {
+		return a.Ref < b.Ref
+	}
+	if a.SHA != b.SHA {
+		return a.SHA < b.SHA
+	}
+	return a.Experiment < b.Experiment
+}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -113,7 +113,7 @@ func Merge(projectDir, branch string) (string, error) {
 	return run(projectDir, "merge", branch, "--no-edit")
 }
 
-// DirtyPaths returns relative paths in the main checkout that differ from
+// DirtyPaths returns relative paths in the given checkout that differ from
 // HEAD, including untracked files. The list is sorted and deduplicated. If the
 // directory is not a git repo, it returns an empty list.
 func DirtyPaths(projectDir string) ([]string, error) {

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -34,6 +34,13 @@ func ResolveRef(dir, ref string) (string, error) {
 	return run(dir, "rev-parse", ref)
 }
 
+// SymbolicFullName resolves a rev-like input to its full symbolic ref name
+// (for example "main" -> "refs/heads/main"). Non-symbolic inputs such as raw
+// SHAs resolve to the empty string.
+func SymbolicFullName(dir, ref string) (string, error) {
+	return run(dir, "rev-parse", "--symbolic-full-name", ref)
+}
+
 // Add creates a new git worktree at path, checking out a new branch off baseline.
 func Add(projectDir, path, branch, baseline string) error {
 	_, err := run(projectDir, "worktree", "add", "-b", branch, path, baseline)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -79,6 +79,26 @@ func TestAddAndRemove(t *testing.T) {
 	}
 }
 
+func TestSymbolicFullName(t *testing.T) {
+	dir := gitInit(t)
+
+	got, err := worktree.SymbolicFullName(dir, "main")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "refs/heads/main" {
+		t.Fatalf("SymbolicFullName(main) = %q, want %q", got, "refs/heads/main")
+	}
+
+	got, err = worktree.SymbolicFullName(dir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "refs/heads/main" {
+		t.Fatalf("SymbolicFullName(HEAD) = %q, want %q", got, "refs/heads/main")
+	}
+}
+
 func gitCommit(t *testing.T, dir, file, body, msg string) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0o644); err != nil {


### PR DESCRIPTION
## Summary
- make `observe` idempotent by default so existing samples satisfy or top up the target instead of blindly rerunning
- add `observe check` and `--append` so agents can cheaply probe sample sufficiency and still force fresh reruns when intended
- DRY the observe execution path, update the agent-facing docs, and add regression coverage for skip/top-up/append/check behavior

## Testing
- `go test ./internal/cli -run 'TestObserve'`
- `go test ./internal/integration -run 'TestSharedDocs|TestCodexDoc'`
- `make test`

Closes #41
