### PR TITLE
integration: separate gate-review stats from mechanism verification

### DIFF
--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -26,7 +26,8 @@ positives, which are far more expensive than false negatives.
 2. `autoresearch conclusion show <C-id> --json` — the verdict, effect
    (vs absolute baseline), `incremental_effect` (vs frontier best, if
    present), `strict_check` (firewall's own assessment), interpretation,
-   author, plus evidence-side join fields for cited observations:
+   author, measured candidate provenance (`candidate_ref`, `candidate_sha`),
+   plus evidence-side join fields for cited observations:
    `observation_artifacts`, `observation_evidence_failures`, and
    `observation_read_issues`.
 3. `autoresearch hypothesis show <hyp-id> --json` — the claim, predicted
@@ -34,6 +35,7 @@ positives, which are far more expensive than false negatives.
 4. Read the stats from `autoresearch analyze` yourself:
 
        autoresearch analyze <candidate-exp-id> \
+           --candidate-ref <candidate-ref> \
            --baseline <baseline-exp-id> \
            --instrument <name> --json
 
@@ -80,7 +82,8 @@ the needed flag is genuinely absent from those references.
 7. **Review the code change for correctness and gaming** — this is as
    important as the statistics:
 
-       git show autoresearch/<candidate-exp-id>
+       git show <candidate-ref>
+       git rev-parse <candidate-ref>   # should match candidate_sha from conclusion show
 
    Check:
    - **Mechanism match**: Does the diff implement what the interpretation
@@ -144,7 +147,7 @@ a reason. Good reasons:
 - **Goodharting**: "Reduction is in LOC / complexity, a static proxy.
   No runtime instrument shows improvement."
 - **Mechanism mismatch**: "Interpretation claims loop unrolling, but
-  the diff (git show autoresearch/E-NNNN) shows the inner loop is
+  the diff (git show <candidate-ref>) shows the inner loop is
   unchanged — the actual change was a deleted debug branch."
 - **Unsupported mechanism**: "Interpretation claims SIMPLIFY_TRACE
   collapsed 14 redundant expressions, but no evidence artifact was

--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -31,20 +31,28 @@ positives, which are far more expensive than false negatives.
    `observation_read_issues`.
 3. `autoresearch hypothesis show <hyp-id> --json` — the claim, predicted
    instrument, `min_effect`, `kill_if` clauses.
-4. Recompute the stats yourself:
+4. Read the stats from `autoresearch analyze` yourself:
 
        autoresearch analyze <candidate-exp-id> \
            --baseline <baseline-exp-id> \
            --instrument <name> --json
 
-   Compare your numbers against the conclusion's `effect` block. They
-   should match. If they don't, something is wrong.
-5. Inspect per-sample distributions for outliers and bimodality:
+   Treat `autoresearch analyze` as the authoritative stats source. Its
+   CI, p-value, and seed are reproducible by construction. Compare the
+   output against the conclusion's `effect` block; they should match.
+   If they don't, something is wrong.
+5. Inspect the raw samples for sanity, not for a second implementation
+   of the stats:
 
        autoresearch artifact list --experiment <candidate-exp-id>
        autoresearch artifact stat <sha>
        autoresearch artifact head <sha> --lines 100
        autoresearch artifact grep <sha> '<pattern>'
+
+   Use this pass for `n` counts, min/max, ordering, obvious outliers,
+   bimodality, and malformed capture. Do not spend tokens re-coding
+   bootstrap CI or Mann-Whitney U in Python/shell unless `analyze`
+   itself appears internally inconsistent.
 
 Do not burn turns on repetitive `--help` lookups for the routine review
 verbs. This brief plus `.claude/autoresearch.md` already covers
@@ -190,9 +198,13 @@ If a previous lesson is contradicted by new evidence, supersede it:
 - **Never propose new hypotheses.** If the evidence suggests a new
   direction, say so in the handoff — the main session decides.
 - **Never edit source files.** You have no Edit/Write tools.
-- **Never re-run `observe`, `analyze`, or `conclude`.** You read what
-  exists. If you think more samples are needed, say so — the main
-  session decides whether to run another experiment.
+- **Never re-run `observe` or `conclude`.** Those mutate state. If you
+  think more samples are needed, say so — the main session decides
+  whether to run another experiment.
+- **Do not reimplement stats outside `autoresearch analyze`.** Use
+  raw-sample inspection for sanity checks; if `analyze` and
+  `conclusion show` agree, trust the seeded CLI output and move on to
+  mechanism verification.
 - **Never re-read the orchestrator's reasoning.** Your independence
   is what makes you useful. Work from the data, not from someone
   else's interpretation.

--- a/internal/integration/evidence_contract_test.go
+++ b/internal/integration/evidence_contract_test.go
@@ -80,3 +80,47 @@ func TestEmbeddedAgents_EvidenceArtifactContract(t *testing.T) {
 		}
 	}
 }
+
+func TestEmbeddedAgents_GateReviewerStatsAuthorityContract(t *testing.T) {
+	agents, err := integration.EmbeddedAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	codexAgents, err := integration.EmbeddedCodexAgents()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	checks := []struct {
+		label  string
+		agents []integration.AgentFile
+	}{
+		{label: "claude", agents: agents},
+		{label: "codex", agents: codexAgents},
+	}
+	for _, chk := range checks {
+		var content []byte
+		for _, a := range chk.agents {
+			if a.Name == "research-gate-reviewer" {
+				content = a.Content
+				break
+			}
+		}
+		if len(content) == 0 {
+			t.Fatalf("%s research-gate-reviewer agent missing", chk.label)
+		}
+		for _, needle := range []string{
+			"Treat `autoresearch analyze` as the authoritative stats source.",
+			"Do not spend tokens re-coding",
+			"bootstrap CI or Mann-Whitney U",
+			"Inspect the raw samples for sanity",
+		} {
+			if !bytes.Contains(content, []byte(needle)) {
+				t.Fatalf("%s research-gate-reviewer missing %q", chk.label, needle)
+			}
+		}
+		if bytes.Contains(content, []byte("Recompute the stats yourself:")) {
+			t.Fatalf("%s research-gate-reviewer still tells reviewers to recompute stats", chk.label)
+		}
+	}
+}

--- a/internal/integration/evidence_contract_test.go
+++ b/internal/integration/evidence_contract_test.go
@@ -111,9 +111,13 @@ func TestEmbeddedAgents_GateReviewerStatsAuthorityContract(t *testing.T) {
 		}
 		for _, needle := range []string{
 			"Treat `autoresearch analyze` as the authoritative stats source.",
+			"--candidate-ref <candidate-ref>",
 			"Do not spend tokens re-coding",
 			"bootstrap CI or Mann-Whitney U",
 			"Inspect the raw samples for sanity",
+			"measured candidate provenance (`candidate_ref`, `candidate_sha`)",
+			"git show <candidate-ref>",
+			"git rev-parse <candidate-ref>",
 		} {
 			if !bytes.Contains(content, []byte(needle)) {
 				t.Fatalf("%s research-gate-reviewer missing %q", chk.label, needle)
@@ -121,6 +125,9 @@ func TestEmbeddedAgents_GateReviewerStatsAuthorityContract(t *testing.T) {
 		}
 		if bytes.Contains(content, []byte("Recompute the stats yourself:")) {
 			t.Fatalf("%s research-gate-reviewer still tells reviewers to recompute stats", chk.label)
+		}
+		if bytes.Contains(content, []byte("git show autoresearch/<candidate-exp-id>")) {
+			t.Fatalf("%s research-gate-reviewer still inspects mutable experiment branches", chk.label)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- make autoresearch analyze the authoritative stats source in the gate-reviewer prompt
- limit raw artifact inspection to sample sanity checks instead of full statistical recomputation
- add an embedded-agent contract test to prevent regressions in both Claude and Codex reviewer outputs

## Testing
- go test ./internal/integration
- make test

Fixes #43