### PR TITLE
Document runtime shell discipline for research agents

### DIFF
--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -20,6 +20,20 @@ You are dispatched by the main session with a conclusion ID. You are not
 a rubber stamp — downgrades protect the research loop from false
 positives, which are far more expensive than false negatives.
 
+## Shell tool discipline
+
+The shell-execution tool name is not a shell contract. Do not assume bash,
+zsh, or any shell solely from the tool label. Prefer POSIX-safe one-liners
+for conditionals and quoting, such as `[ "$x" = y ]`; avoid fragile forms
+like `[ $x == y ]`, which fail in some shells and break on empty values.
+If you need shell-specific syntax, first identify the shell that is actually
+executing the command:
+
+    printf 'SHELL=%s argv0=%s\n' "${SHELL:-unknown}" "$0"; ps -p $$ -o comm= 2>/dev/null || true
+
+Only then use constructs that shell supports, such as `[[ "$x" == y ]]`
+in shells that implement `[[ ... ]]`.
+
 ## Read before deciding
 
 1. `@.claude/autoresearch.md` — the CLI and firewall reference.

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -25,6 +25,20 @@ the lesson if warranted, then yield to the main session with
 **gate reviewer**. That keeps the handoff unambiguous and avoids relying
 on nested child-session tool availability.
 
+## Shell tool discipline
+
+The shell-execution tool name is not a shell contract. Do not assume bash,
+zsh, or any shell solely from the tool label. Prefer POSIX-safe one-liners
+for conditionals and quoting, such as `[ "$x" = y ]`; avoid fragile forms
+like `[ $x == y ]`, which fail in some shells and break on empty values.
+If you need shell-specific syntax, first identify the shell that is actually
+executing the command:
+
+    printf 'SHELL=%s argv0=%s\n' "${SHELL:-unknown}" "$0"; ps -p $$ -o comm= 2>/dev/null || true
+
+Only then use constructs that shell supports, such as `[[ "$x" == y ]]`
+in shells that implement `[[ ... ]]`.
+
 ## Before each cycle
 
 Read in this order, every time. Do not skip steps — the notebook layer is

--- a/internal/integration/agents_test.go
+++ b/internal/integration/agents_test.go
@@ -20,6 +20,15 @@ var _ = Describe("Claude embedded agents", func() {
 		Expect(agents).To(HaveLen(2))
 	})
 
+	It("documents runtime shell discipline", func() {
+		for _, a := range mustEmbeddedAgents() {
+			content := string(a.Content)
+			for _, needle := range shellDisciplineNeedles() {
+				Expect(content).To(ContainSubstring(needle), "claude %s brief", a.Name)
+			}
+		}
+	})
+
 	It("has valid frontmatter and role-appropriate tool permissions", func() {
 		for _, a := range mustEmbeddedAgents() {
 			Expect(a.Content).NotTo(BeEmpty(), a.Name)
@@ -88,6 +97,18 @@ func mustEmbeddedCodexAgents() []integration.AgentFile {
 	agents, err := integration.EmbeddedCodexAgents()
 	Expect(err).NotTo(HaveOccurred())
 	return agents
+}
+
+func shellDisciplineNeedles() []string {
+	return []string{
+		"not a shell contract",
+		"Do not assume bash",
+		`[ "$x" = y ]`,
+		`[ $x == y ]`,
+		`printf 'SHELL=%s argv0=%s\n'`,
+		`ps -p $$ -o comm=`,
+		`[[ "$x" == y ]]`,
+	}
 }
 
 func agentContentByName(agents []integration.AgentFile) map[string]string {

--- a/internal/integration/codex_agents_test.go
+++ b/internal/integration/codex_agents_test.go
@@ -70,6 +70,15 @@ var _ = Describe("Codex embedded agents", func() {
 		}
 	})
 
+	It("propagates runtime shell discipline", func() {
+		for _, a := range mustEmbeddedCodexAgents() {
+			content := string(a.Content)
+			for _, needle := range shellDisciplineNeedles() {
+				Expect(content).To(ContainSubstring(needle), "codex %s brief", a.Name)
+			}
+		}
+	})
+
 	It("keeps delegation handoff responsibility with the parent session", func() {
 		orchestrator := agentContentByName(mustEmbeddedCodexAgents())["research-orchestrator"]
 		Expect(orchestrator).NotTo(BeEmpty())


### PR DESCRIPTION
## Summary
- add shell tool discipline guidance to both managed research agent prompts
- bias agents toward POSIX-safe conditionals and runtime shell detection instead of assuming zsh or bash
- assert the guidance is present in both Claude prompts and derived Codex custom agents

## Tests
- `go test ./internal/integration`
- `make test`

Closes #48