### PR TITLE
Add automatic lineage baseline resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ probe, and `--append` when you intentionally want another fresh run.
 | **hypothesis** | `add`, `list`, `show`, `promote`, `kill`, `reopen`, `worktree`, `diff`, `apply` |
 | **experiment** | `baseline`, `design`, `implement`, `reset`, `worktree`, `list`, `show [--worktree\|--branch\|--baseline-sha\|--env]` |
 | **observe** | `observe check <exp> --instrument <name>`, `observe <exp> --instrument <name> [--append]`, `observe <exp> --all [--append]` |
-| **analyze** | `analyze <exp> [--baseline <exp>]` |
+| **analyze** | `analyze <exp> [--baseline <exp>\|auto]` |
 | **conclude** | `conclude <hyp> --verdict ... --observations ...` |
 | **conclusion** | `list`, `show`, `accept`, `downgrade`, `appeal` |
 | **tree / frontier** | `tree [--goal G-NNNN\|all]`, `frontier [--goal G-NNNN\|all]` |
@@ -388,12 +388,15 @@ Every conclusion automatically compares against two baselines:
   `experiment baseline`). This is "how much did we improve over the
   original unoptimized code?" The strict firewall always evaluates
   against this baseline.
-- **Incremental** — the current frontier best. This is "how much did we
-  improve over the best result so far?" Informational only — it does not
-  gate the verdict.
+- **Incremental** — the nearest accepted supported predecessor on the
+  hypothesis lineage. This is "how much did we improve over the
+  direction we are building on?" Informational only — it does not gate
+  the verdict.
 
 The `conclude` command derives both automatically. `--baseline-experiment`
-overrides only the absolute baseline.
+overrides only the absolute baseline; pass `auto` to make that strict
+override use the same supported lineage predecessor. `analyze --baseline
+auto` resolves the same predecessor for read-only reviewer reruns.
 
 ### Predicted effects and diminishing returns
 

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -7,9 +7,12 @@ import (
 
 	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/stats"
 	"github.com/spf13/cobra"
 )
+
+const analyzeBaselineAuto = "auto"
 
 func analyzeCommands() []*cobra.Command {
 	return []*cobra.Command{analyzeCmd()}
@@ -30,7 +33,9 @@ reports sample count, mean, BCa 95% CI, stddev, min/max.
 
 If --baseline is provided, also compares each instrument's samples against
 the baseline experiment's samples for the same instrument using percentile
-bootstrap (for the delta CI) and Mann–Whitney U (for p-value).
+bootstrap (for the delta CI) and Mann–Whitney U (for p-value). Use
+--baseline auto on hypothesis-backed experiments to resolve the nearest
+accepted supported lineage predecessor.
 
 analyze is read-only: no store writes, no state transitions. Use conclude
 to persist a verdict.
@@ -81,7 +86,39 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 
 			// Optional baseline.
 			var baseObs []*entity.Observation
-			if baselineExp != "" {
+			var baselineRes *readmodel.BaselineResolution
+			baselineExp = strings.TrimSpace(baselineExp)
+			switch baselineExp {
+			case "":
+			case analyzeBaselineAuto:
+				if exp.IsBaseline {
+					return fmt.Errorf("--baseline auto is only valid for non-baseline experiments")
+				}
+				if strings.TrimSpace(exp.Hypothesis) == "" {
+					return fmt.Errorf("--baseline auto requires experiment %s to be linked to a hypothesis", expID)
+				}
+				hyp, err := s.ReadHypothesis(exp.Hypothesis)
+				if err != nil {
+					return err
+				}
+				obsIdx, err := readmodel.LoadObservationIndexStrict(s)
+				if err != nil {
+					return err
+				}
+				baselineRes, err = readmodel.ResolveLineageSupportedBaselineWithIndex(s, obsIdx, hyp, hyp.Predicts.Instrument)
+				if err != nil {
+					return err
+				}
+				if baselineRes == nil || baselineRes.ExperimentID == "" {
+					note := "no usable lineage baseline"
+					if baselineRes != nil && baselineRes.Note != "" {
+						note = baselineRes.Note
+					}
+					return fmt.Errorf("--baseline auto could not resolve a supported ancestor for experiment %s: %s", expID, note)
+				}
+				baselineExp = baselineRes.ExperimentID
+				baseObs = obsIdx.ObservationsForScope(baselineRes.Scope())
+			default:
 				baseObs, err = s.ListObservationsForExperiment(baselineExp)
 				if err != nil {
 					return err
@@ -138,17 +175,24 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 			}
 
 			if w.IsJSON() {
-				return w.JSON(map[string]any{
+				payload := map[string]any{
 					"experiment": expID,
 					"baseline":   baselineExp,
 					"limits":     limits,
 					"rows":       rows,
-				})
+				}
+				if baselineRes != nil {
+					payload["baseline_resolution"] = baselineRes
+				}
+				return w.JSON(payload)
 			}
 			printLimits(w, limits)
 			w.Textf("[experiment: %s", expID)
 			if baselineExp != "" {
 				w.Textf(", baseline: %s", baselineExp)
+				if baselineRes != nil && baselineRes.Source != "" {
+					w.Textf(" (source=%s)", baselineRes.Source)
+				}
 			}
 			w.Textln("]")
 			if len(rows) == 0 {
@@ -176,7 +220,7 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 			return nil
 		},
 	}
-	c.Flags().StringVar(&baselineExp, "baseline", "", "baseline experiment id to compare against")
+	c.Flags().StringVar(&baselineExp, "baseline", "", "baseline experiment id to compare against, or 'auto' for the supported lineage predecessor")
 	c.Flags().StringVar(&instName, "instrument", "", "only analyze this instrument")
 	c.Flags().IntVar(&iters, "iters", 0, "bootstrap iterations (0 uses default 2000)")
 	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "for non-baseline experiments, restrict analysis to observations recorded on this candidate ref")

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
 	"github.com/bytter/autoresearch/internal/store"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -106,6 +107,72 @@ var _ = Describe("analyze command", func() {
 		Expect(err).To(MatchError(ContainSubstring("candidate ref " + ref + " maps to multiple recorded candidate scopes")))
 	})
 
+	It("resolves --baseline auto to the supported lineage predecessor", func() {
+		dir, s := createCLIStoreDir()
+		now := time.Now().UTC()
+		Expect(s.WriteGoal(&entity.Goal{
+			ID:        "G-0001",
+			Status:    entity.GoalStatusActive,
+			CreatedAt: &now,
+			Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0001",
+			GoalID:    "G-0001",
+			Claim:     "first win",
+			Status:    entity.StatusSupported,
+			Author:    "test",
+			CreatedAt: now,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0002",
+			GoalID:    "G-0001",
+			Parent:    "H-0001",
+			Claim:     "second win",
+			Status:    entity.StatusOpen,
+			Author:    "test",
+			CreatedAt: now,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+		})).To(Succeed())
+		for _, exp := range []*entity.Experiment{
+			{ID: "E-0001", GoalID: "G-0001", Hypothesis: "H-0001", Status: entity.ExpAnalyzed, Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+			{ID: "E-0002", GoalID: "G-0001", Hypothesis: "H-0002", Status: entity.ExpMeasured, Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+		} {
+			Expect(s.WriteExperiment(exp)).To(Succeed())
+		}
+		Expect(s.WriteObservation(&entity.Observation{
+			ID: "O-0001", Experiment: "E-0001", Instrument: "timing",
+			MeasuredAt: now, Value: 100, Unit: "ns", PerSample: []float64{100, 101, 99}, Samples: 3, Author: "test",
+		})).To(Succeed())
+		ref := "refs/heads/candidate/E-0002"
+		Expect(s.WriteObservation(&entity.Observation{
+			ID: "O-0002", Experiment: "E-0002", Instrument: "timing",
+			MeasuredAt: now, Value: 90, Unit: "ns", PerSample: []float64{90, 91, 89}, Samples: 3,
+			CandidateRef: ref, CandidateSHA: "2222222222222222222222222222222222222222", Author: "test",
+		})).To(Succeed())
+		Expect(s.WriteConclusion(&entity.Conclusion{
+			ID: "C-0001", Hypothesis: "H-0001", Verdict: entity.VerdictSupported,
+			Observations: []string{"O-0001"}, CandidateExp: "E-0001",
+			Effect:   entity.Effect{Instrument: "timing", DeltaFrac: -0.1},
+			StatTest: "mann_whitney_u", Author: "test", ReviewedBy: "human:gate", CreatedAt: now,
+		})).To(Succeed())
+
+		resp := runCLIJSON[cliAnalyzeResponse](dir,
+			"analyze", "E-0002",
+			"--candidate-ref", ref,
+			"--baseline", "auto",
+		)
+
+		Expect(resp.Baseline).To(Equal("E-0001"))
+		Expect(resp.BaselineResolution).NotTo(BeNil())
+		Expect(resp.BaselineResolution.ExperimentID).To(Equal("E-0001"))
+		Expect(resp.BaselineResolution.Source).To(Equal(readmodel.BaselineSourceAncestorSupported))
+		Expect(resp.BaselineResolution.AncestorHypothesis).To(Equal("H-0001"))
+		Expect(resp.BaselineResolution.AncestorConclusion).To(Equal("C-0001"))
+		Expect(resp.Rows).To(HaveLen(1))
+		Expect(resp.Rows[0].Comparison).NotTo(BeNil())
+	})
 })
 
 func setupAnalyzeAmbiguousBaseline() (string, string) {

--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -18,6 +18,7 @@ import (
 const (
 	concludeCandidateSourceObservations = "observations"
 	concludeBaselineSourceNone          = "none"
+	concludeBaselineAuto                = "auto"
 )
 
 type concludeIgnoredObservation struct {
@@ -81,9 +82,11 @@ The absolute baseline is resolved in this order: explicit
 --baseline-experiment (strict; no fallback), the candidate's recorded
 baseline if it has matching instrument data, the nearest accepted
 supported ancestor conclusion candidate, then the current goal's mapped
-baseline. If no usable comparator can be inferred, "supported" is
+baseline. The explicit value "auto" resolves to that nearest accepted
+supported lineage predecessor. If no usable comparator can be inferred, "supported" is
 automatically downgraded since there is no comparison. CLI and JSON
-output report which baseline source was used and any fallback note.`,
+output report which baseline source was used, the automatic incremental
+lineage predecessor, and any fallback note.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			w := output.Default(globalJSON)
@@ -141,12 +144,8 @@ output report which baseline source was used and any fallback note.`,
 				baseObs     []*entity.Observation
 				baselineRes *readmodel.BaselineResolution
 			)
-			if baselineExp = strings.TrimSpace(baselineExp); baselineExp != "" {
-				baseObs, baselineRes, err = baselineObservationsForExperiment(s, obsIdx, baselineExp, hyp.Predicts.Instrument)
-				if err != nil {
-					return err
-				}
-			} else {
+			switch baselineExp = strings.TrimSpace(baselineExp); baselineExp {
+			case "":
 				baselineRes, err = readmodel.ResolveInferredBaselineWithIndex(s, obsIdx, hyp, candExpRec, hyp.Predicts.Instrument)
 				if err != nil {
 					return err
@@ -157,31 +156,39 @@ output report which baseline source was used and any fallback note.`,
 				if baselineExp != "" {
 					baseObs = filterObservationsByInstrument(obsIdx.ObservationsForScope(baselineRes.Scope()), hyp.Predicts.Instrument)
 				}
+			case concludeBaselineAuto:
+				baselineRes, err = readmodel.ResolveLineageSupportedBaselineWithIndex(s, obsIdx, hyp, hyp.Predicts.Instrument)
+				if err != nil {
+					return err
+				}
+				if baselineRes == nil || baselineRes.ExperimentID == "" {
+					note := "no usable lineage baseline"
+					if baselineRes != nil && baselineRes.Note != "" {
+						note = baselineRes.Note
+					}
+					return fmt.Errorf("--baseline-experiment auto could not resolve a supported ancestor for %s: %s", hypID, note)
+				}
+				baselineExp = baselineRes.ExperimentID
+				baseObs = filterObservationsByInstrument(obsIdx.ObservationsForScope(baselineRes.Scope()), hyp.Predicts.Instrument)
+			default:
+				baseObs, baselineRes, err = baselineObservationsForExperiment(s, obsIdx, baselineExp, hyp.Predicts.Instrument)
+				if err != nil {
+					return err
+				}
 			}
 			applyBaselineResolution(&resolution, baselineRes, hyp.Predicts.Instrument)
 
-			// Resolve incremental baseline: the frontier best within the same goal.
+			// Resolve incremental baseline: the accepted supported predecessor
+			// on this hypothesis lineage.
 			var incrementalExp string
 			var incrObs []*entity.Observation
-			if goal != nil {
-				concls, err := s.ListConclusions()
-				if err != nil {
-					return err
-				}
-				scopedConcls, err := conclusionsForGoal(s, hyp.GoalID, concls)
-				if err != nil {
-					return err
-				}
-				frontierRows, _ := readmodel.ComputeFrontier(s, goal, scopedConcls)
-				if len(frontierRows) > 0 {
-					bestConcl := conclusionByID(scopedConcls, frontierRows[0].Conclusion)
-					bestObs, bestScope, ok := obsIdx.ObservationsForConclusionCandidate(bestConcl)
-					baseScope := baselineRes.Scope()
-					if ok && bestScope != candScope && bestScope != baseScope {
-						incrementalExp = bestScope.Experiment
-						incrObs = filterObservationsByInstrument(bestObs, hyp.Predicts.Instrument)
-					}
-				}
+			incrementalRes, err := readmodel.ResolveLineageSupportedBaselineWithIndex(s, obsIdx, hyp, hyp.Predicts.Instrument)
+			if err != nil {
+				return err
+			}
+			if incrementalRes != nil && incrementalRes.ExperimentID != "" && incrementalRes.Scope() != candScope {
+				incrementalExp = incrementalRes.ExperimentID
+				incrObs = filterObservationsByInstrument(obsIdx.ObservationsForScope(incrementalRes.Scope()), hyp.Predicts.Instrument)
 			}
 			if incrementalExp != "" {
 				resolution.IncrementalExperiment = incrementalExp
@@ -196,7 +203,7 @@ output report which baseline source was used and any fallback note.`,
 				cmp = &v
 			}
 
-			// Compute comparison against incremental baseline (frontier best).
+			// Compute comparison against incremental baseline (lineage predecessor).
 			var incrCmp *stats.Comparison
 			if len(incrObs) > 0 {
 				incrSamples := flattenSamples(incrObs)
@@ -465,7 +472,7 @@ output report which baseline source was used and any fallback note.`,
 			}
 			if concl.IncrementalEffect != nil {
 				ie := concl.IncrementalEffect
-				w.Textf("  incremental: %s  delta_frac=%+.4f  CI [%+.4f, %+.4f]  (vs frontier best)\n",
+				w.Textf("  incremental: %s  delta_frac=%+.4f  CI [%+.4f, %+.4f]  (vs lineage predecessor)\n",
 					incrementalExp, ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac)
 			}
 			if len(decision.Reasons) > 0 && !decision.Downgraded {
@@ -479,7 +486,7 @@ output report which baseline source was used and any fallback note.`,
 	}
 	c.Flags().StringVar(&verdict, "verdict", "", "supported | refuted | inconclusive (required)")
 	c.Flags().StringSliceVar(&obsList, "observations", nil, "comma-separated observation ids (required)")
-	c.Flags().StringVar(&baselineExp, "baseline-experiment", "", "baseline experiment id (strict override; no fallback if it lacks the predicted instrument)")
+	c.Flags().StringVar(&baselineExp, "baseline-experiment", "", "baseline experiment id, or 'auto' for the supported lineage predecessor (strict override; no fallback if unusable)")
 	c.Flags().StringVar(&interpretation, "interpretation", "", "optional prose interpretation")
 	addAuthorFlag(c, &author, "")
 	c.Flags().StringVar(&reviewedBy, "reviewed-by", "", "critic or human who reviewed")
@@ -664,15 +671,6 @@ func formatBaselineSource(res concludeResolution) string {
 	return res.BaselineSource
 }
 
-func conclusionByID(concls []*entity.Conclusion, id string) *entity.Conclusion {
-	for _, c := range concls {
-		if c != nil && c.ID == id {
-			return c
-		}
-	}
-	return nil
-}
-
 func filterObservationsByInstrument(obs []*entity.Observation, instrument string) []*entity.Observation {
 	var filtered []*entity.Observation
 	for _, o := range obs {
@@ -681,32 +679,6 @@ func filterObservationsByInstrument(obs []*entity.Observation, instrument string
 		}
 	}
 	return filtered
-}
-
-func conclusionsForGoal(s *store.Store, goalID string, concls []*entity.Conclusion) ([]*entity.Conclusion, error) {
-	if goalID == "" {
-		return nil, nil
-	}
-	goalByHypothesis := map[string]string{}
-	out := make([]*entity.Conclusion, 0, len(concls))
-	for _, c := range concls {
-		if c == nil || c.Hypothesis == "" {
-			continue
-		}
-		gid, ok := goalByHypothesis[c.Hypothesis]
-		if !ok {
-			h, err := s.ReadHypothesis(c.Hypothesis)
-			if err != nil {
-				return nil, err
-			}
-			gid = h.GoalID
-			goalByHypothesis[c.Hypothesis] = gid
-		}
-		if gid == goalID {
-			out = append(out, c)
-		}
-	}
-	return out, nil
 }
 
 // samplesForInstrument flattens every per-sample slice across observations

--- a/internal/cli/conclude_test.go
+++ b/internal/cli/conclude_test.go
@@ -18,19 +18,20 @@ type concludeResolutionJSON struct {
 		ID     string `json:"id"`
 		Reason string `json:"reason"`
 	} `json:"ignored_observations"`
-	CandidateExperiment string `json:"candidate_experiment"`
-	CandidateAttempt    int    `json:"candidate_attempt,omitempty"`
-	CandidateRef        string `json:"candidate_ref,omitempty"`
-	CandidateSHA        string `json:"candidate_sha,omitempty"`
-	CandidateSource     string `json:"candidate_source"`
-	BaselineExperiment  string `json:"baseline_experiment,omitempty"`
-	BaselineAttempt     int    `json:"baseline_attempt,omitempty"`
-	BaselineRef         string `json:"baseline_ref,omitempty"`
-	BaselineSHA         string `json:"baseline_sha,omitempty"`
-	BaselineSource      string `json:"baseline_source"`
-	BaselineNote        string `json:"baseline_note,omitempty"`
-	AncestorHypothesis  string `json:"ancestor_hypothesis,omitempty"`
-	AncestorConclusion  string `json:"ancestor_conclusion,omitempty"`
+	CandidateExperiment   string `json:"candidate_experiment"`
+	CandidateAttempt      int    `json:"candidate_attempt,omitempty"`
+	CandidateRef          string `json:"candidate_ref,omitempty"`
+	CandidateSHA          string `json:"candidate_sha,omitempty"`
+	CandidateSource       string `json:"candidate_source"`
+	BaselineExperiment    string `json:"baseline_experiment,omitempty"`
+	BaselineAttempt       int    `json:"baseline_attempt,omitempty"`
+	BaselineRef           string `json:"baseline_ref,omitempty"`
+	BaselineSHA           string `json:"baseline_sha,omitempty"`
+	BaselineSource        string `json:"baseline_source"`
+	BaselineNote          string `json:"baseline_note,omitempty"`
+	AncestorHypothesis    string `json:"ancestor_hypothesis,omitempty"`
+	AncestorConclusion    string `json:"ancestor_conclusion,omitempty"`
+	IncrementalExperiment string `json:"incremental_experiment,omitempty"`
 }
 
 type concludeJSONResponse struct {
@@ -275,6 +276,9 @@ var _ = Describe("conclude command", func() {
 			Expect(resp.Resolution.AncestorHypothesis).To(Equal(fx.ancestorHypothesis))
 			Expect(resp.Resolution.AncestorConclusion).To(Equal(fx.ancestorConclusion))
 			Expect(resp.Resolution.BaselineNote).To(ContainSubstring(fx.goalBaseline))
+			Expect(resp.Resolution.IncrementalExperiment).To(Equal(fx.ancestorExperiment))
+			Expect(resp.Conclusion.IncrementalExp).To(Equal(fx.ancestorExperiment))
+			Expect(resp.Conclusion.IncrementalEffect).NotTo(BeNil())
 
 			s, err := store.Open(fx.dir)
 			Expect(err).NotTo(HaveOccurred())
@@ -293,6 +297,7 @@ var _ = Describe("conclude command", func() {
 			Expect(payload).To(HaveKeyWithValue("baseline_attempt", float64(1)))
 			Expect(payload).To(HaveKeyWithValue("ancestor_hypothesis", fx.ancestorHypothesis))
 			Expect(payload).To(HaveKeyWithValue("ancestor_conclusion", fx.ancestorConclusion))
+			Expect(payload).To(HaveKeyWithValue("incremental_experiment", fx.ancestorExperiment))
 			Expect(payload["observations"]).To(Equal([]any{fx.timingObservation}))
 			Expect(payload["requested_observations"]).To(Equal([]any{fx.timingObservation, fx.sizeObservation}))
 			Expect(payload["ignored_observations"]).To(ConsistOf(HaveKeyWithValue("id", fx.sizeObservation)))
@@ -327,6 +332,23 @@ var _ = Describe("conclude command", func() {
 				"--observations", strings.Join([]string{fx.timingObservation, fx.sizeObservation}, ","),
 			)
 			Expect(err).To(MatchError(ContainSubstring("baseline experiment " + fx.goalBaseline + " has no observations on instrument \"timing\"")))
+		})
+
+		It("accepts --baseline-experiment auto as a strict lineage predecessor override", func() {
+			fx := setupConcludeFallbackFixture()
+
+			resp := runCLIJSON[concludeJSONResponse](fx.dir,
+				"conclude", fx.currentHypothesis,
+				"--verdict", "supported",
+				"--baseline-experiment", "auto",
+				"--observations", fx.timingObservation,
+			)
+
+			Expect(resp.Resolution.BaselineExperiment).To(Equal(fx.ancestorExperiment))
+			Expect(resp.Resolution.BaselineSource).To(Equal(readmodel.BaselineSourceAncestorSupported))
+			Expect(resp.Resolution.AncestorHypothesis).To(Equal(fx.ancestorHypothesis))
+			Expect(resp.Resolution.AncestorConclusion).To(Equal(fx.ancestorConclusion))
+			Expect(resp.Conclusion.BaselineExp).To(Equal(fx.ancestorExperiment))
 		})
 	})
 

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -167,7 +167,7 @@ func conclusionShowCmd() *cobra.Command {
 			w.Textf("  p-value:    %.4g  (%s)\n", c.Effect.PValue, c.StatTest)
 			if c.IncrementalExp != "" && c.IncrementalEffect != nil {
 				ie := c.IncrementalEffect
-				w.Textf("incremental:  %s  (vs frontier best)\n", c.IncrementalExp)
+				w.Textf("incremental:  %s  (vs lineage predecessor)\n", c.IncrementalExp)
 				w.Textf("  delta_frac: %+.4f  95%% CI [%+.4f, %+.4f]\n", ie.DeltaFrac, ie.CILowFrac, ie.CIHighFrac)
 				w.Textf("  delta_abs:  %+.6g  95%% CI [%+.6g, %+.6g]\n", ie.DeltaAbs, ie.CILowAbs, ie.CIHighAbs)
 				w.Textf("  p-value:    %.4g\n", ie.PValue)

--- a/internal/cli/scenario_helpers_test.go
+++ b/internal/cli/scenario_helpers_test.go
@@ -31,6 +31,13 @@ type cliObserveAllResponse struct {
 }
 
 type cliAnalyzeResponse struct {
+	Baseline           string `json:"baseline"`
+	BaselineResolution *struct {
+		ExperimentID       string `json:"experiment"`
+		Source             string `json:"source"`
+		AncestorHypothesis string `json:"ancestor_hypothesis"`
+		AncestorConclusion string `json:"ancestor_conclusion"`
+	} `json:"baseline_resolution,omitempty"`
 	Rows []struct {
 		Instrument string `json:"instrument"`
 		Comparison *struct {

--- a/internal/entity/conclusion.go
+++ b/internal/entity/conclusion.go
@@ -27,11 +27,11 @@ type Conclusion struct {
 	BaselineRef      string   `yaml:"baseline_ref,omitempty"          json:"baseline_ref,omitempty"`
 	BaselineSHA      string   `yaml:"baseline_sha,omitempty"          json:"baseline_sha,omitempty"`
 	Effect           Effect   `yaml:"effect"                          json:"effect"`
-	// IncrementalExp is the frontier-best experiment at the time this
-	// conclusion was written. Together with IncrementalEffect it answers
-	// "how much did this improve over the current best?" as opposed to
-	// the absolute baseline which answers "how much did this improve
-	// over the original unoptimized code?"
+	// IncrementalExp is the accepted supported lineage predecessor at the
+	// time this conclusion was written. Together with IncrementalEffect it
+	// answers "how much did this improve over the direction it builds on?"
+	// as opposed to the absolute baseline which answers "how much did this
+	// improve over the original unoptimized code?"
 	IncrementalExp    string        `yaml:"incremental_experiment,omitempty" json:"incremental_experiment,omitempty"`
 	IncrementalEffect *Effect       `yaml:"incremental_effect,omitempty"     json:"incremental_effect,omitempty"`
 	SecondaryChecks   []ClauseCheck `yaml:"secondary_checks,omitempty"       json:"secondary_checks,omitempty"`

--- a/internal/integration/agents/research-gate-reviewer.md
+++ b/internal/integration/agents/research-gate-reviewer.md
@@ -38,9 +38,9 @@ in shells that implement `[[ ... ]]`.
 
 1. `@.claude/autoresearch.md` — the CLI and firewall reference.
 2. `autoresearch conclusion show <C-id> --json` — the verdict, effect
-   (vs absolute baseline), `incremental_effect` (vs frontier best, if
-   present), `strict_check` (firewall's own assessment), interpretation,
-   author, measured candidate provenance (`candidate_ref`, `candidate_sha`),
+   (vs absolute baseline), `incremental_effect` (vs the supported
+   lineage predecessor, if present), `strict_check` (firewall's own
+   assessment), interpretation, author, measured candidate provenance (`candidate_ref`, `candidate_sha`),
    plus evidence-side join fields for cited observations:
    `observation_artifacts`, `observation_evidence_failures`, and
    `observation_read_issues`.
@@ -57,6 +57,9 @@ in shells that implement `[[ ... ]]`.
    CI, p-value, and seed are reproducible by construction. Compare the
    output against the conclusion's `effect` block; they should match.
    If they don't, something is wrong.
+   To reproduce `incremental_effect`, rerun the same command with
+   `--baseline auto`; it resolves the accepted supported lineage
+   predecessor recorded as the incremental comparator.
 5. Inspect the raw samples for sanity, not for a second implementation
    of the stats:
 

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -144,7 +144,7 @@ before you reach for `--help`:
     autoresearch experiment design <H-id> --baseline HEAD --instruments ... --design-notes "..." --author agent:orchestrator --json
     autoresearch experiment implement <E-id> --impl-notes "..." --json
     autoresearch observe <E-id> --all --candidate-ref <ref> --json
-    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline <baseline-exp-id>] --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto] --json
     autoresearch conclude <H-id> --verdict ... --observations O-... --interpretation "..." --author agent:orchestrator --json
     autoresearch lesson add ... --from <C-id> --author agent:orchestrator --json   # decisive conclusions
     # then yield to the main session with review pending so it can dispatch research-gate-reviewer
@@ -365,8 +365,12 @@ If an instrument fails, stop and report — do not retry or fix.
 ### 5. Analyze and conclude
 
 ```sh
-autoresearch analyze <exp-id> --candidate-ref <candidate-ref> --baseline <baseline-exp-id> --json
+autoresearch analyze <exp-id> --candidate-ref <candidate-ref> --baseline auto --json
 ```
+
+Use `--baseline auto` when the hypothesis has accepted supported ancestry;
+for a root hypothesis with no supported predecessor yet, omit `--baseline`
+and let `conclude` resolve the absolute baseline fallback.
 
 Read the `comparison` object: `delta_frac`, `ci_low_frac`,
 `ci_high_frac`, `p_value`. Then decide:
@@ -391,12 +395,12 @@ autoresearch conclude <hyp-id> \
 The CLI auto-derives two baselines. Absolute resolution prefers the
 candidate's recorded baseline when it has matching instrument data, then
 the nearest accepted supported ancestor candidate, then the goal
-baseline. Incremental resolution uses the current frontier best within
-the same goal. JSON and text output report the chosen absolute-baseline
-source, any ignored off-instrument observations, and both `effect`
-(vs absolute) and `incremental_effect` (vs frontier best, when
-available). The strict firewall always evaluates against the absolute
-baseline.
+baseline. Incremental resolution uses the nearest accepted supported
+predecessor on this hypothesis lineage. JSON and text output report the
+chosen absolute-baseline source, any ignored off-instrument observations,
+and both `effect` (vs absolute) and `incremental_effect` (vs lineage
+predecessor, when available). The strict firewall always evaluates
+against the absolute baseline.
 
 If the firewall downgrades your verdict, **the downgrade is
 authoritative**. Report it in the yield summary.

--- a/internal/integration/agents_test.go
+++ b/internal/integration/agents_test.go
@@ -36,6 +36,13 @@ var _ = Describe("Claude embedded agents", func() {
 		Expect(orchestrator).To(ContainSubstring("Use specialized read surfaces"))
 	})
 
+	It("documents automatic lineage baseline resolution", func() {
+		byName := agentContentByName(mustEmbeddedAgents())
+		Expect(byName["research-orchestrator"]).To(ContainSubstring("--baseline auto"))
+		Expect(byName["research-orchestrator"]).To(ContainSubstring("predecessor on this hypothesis lineage"))
+		Expect(byName["research-gate-reviewer"]).To(ContainSubstring("--baseline auto"))
+	})
+
 	It("has valid frontmatter and role-appropriate tool permissions", func() {
 		for _, a := range mustEmbeddedAgents() {
 			Expect(a.Content).NotTo(BeEmpty(), a.Name)

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -140,7 +140,7 @@ For the routine optimization loop, the canonical command spine is:
     autoresearch experiment implement <E-id> --impl-notes "..." --json
     # create a unique reviewable git ref for the measured candidate, then:
     autoresearch observe <E-id> --all --candidate-ref <ref> --json
-    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline <baseline-exp-id>] --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto] --json
     autoresearch conclude <H-id> --verdict ... --observations O-... --interpretation "..." --author agent:orchestrator --json
     autoresearch lesson add ... --from <C-id> --author agent:orchestrator --json   # decisive conclusions
     # then yield with review pending so the parent/main session can dispatch research-gate-reviewer
@@ -280,16 +280,17 @@ intentionally want another fresh run even though the target is already met.
     autoresearch observe  check <exp-id> --instrument NAME --candidate-ref REF [--samples N]  # required for non-baseline experiments
     autoresearch observe  <exp-id> --instrument NAME --candidate-ref REF [--samples N] [--append]
     autoresearch observe  <exp-id> --all --candidate-ref REF [--samples N] [--append]         # all instruments in dependency order
-    autoresearch analyze  <exp-id> [--candidate-ref REF] [--baseline <baseline-exp-id>] [--instrument NAME] [--iters N]
+    autoresearch analyze  <exp-id> [--candidate-ref REF] [--baseline <baseline-exp-id>|auto] [--instrument NAME] [--iters N]
     autoresearch conclude <hyp-id> \
         --verdict {supported|refuted|inconclusive} \
         --observations O-XXXX,O-YYYY \
-        [--baseline-experiment E-XXXX] \   # strict override; otherwise auto-derive baseline
+        [--baseline-experiment E-XXXX|auto] \   # strict override; otherwise auto-derive baseline
         [--interpretation "..."]
         # Dual baseline: absolute prefers candidate-recorded baseline, then the
         # nearest accepted supported ancestor, then the goal baseline; incremental
-        # uses the same goal's frontier best. Output reports the chosen source,
-        # ignored off-instrument observations, and both effect + incremental_effect.
+        # uses the nearest accepted supported lineage predecessor. Output reports
+        # the chosen source, ignored off-instrument observations, and both effect
+        # + incremental_effect.
 
 ### Conclusions (review and gate reviewer)
     autoresearch conclusion list       [--goal G-NNNN|all] [--hypothesis H-XXXX] [--verdict X]

--- a/internal/integration/claude_doc_test.go
+++ b/internal/integration/claude_doc_test.go
@@ -37,6 +37,14 @@ var _ = Describe("shared generated agent docs", func() {
 			}
 		}
 	})
+
+	It("documents automatic lineage baseline resolution", func() {
+		for name, doc := range sharedDocs() {
+			Expect(doc).To(ContainSubstring("[--baseline <baseline-exp-id>|auto]"), name)
+			Expect(doc).To(ContainSubstring("[--baseline-experiment E-XXXX|auto]"), name)
+			Expect(doc).To(ContainSubstring("nearest accepted supported lineage predecessor"), name)
+		}
+	})
 })
 
 func sharedDocs() map[string]string {

--- a/internal/integration/codex_agents_test.go
+++ b/internal/integration/codex_agents_test.go
@@ -54,6 +54,8 @@ var _ = Describe("Codex embedded agents", func() {
 				"main checkout cleanliness",
 				"main_checkout_dirty_paths",
 				"bootstrap scripts",
+				"--baseline auto",
+				"predecessor on this hypothesis lineage",
 			},
 			"research-gate-reviewer": {
 				"autoresearch lesson add",
@@ -61,6 +63,7 @@ var _ = Describe("Codex embedded agents", func() {
 				"repetitive `--help` lookups",
 				"sandbox_mode = \"read-only\"",
 				"leaf autoresearch role",
+				"--baseline auto",
 			},
 		} {
 			content, ok := byName[role]

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -111,6 +111,45 @@ func ResolveInferredBaselineWithIndex(s *store.Store, obs *ObservationIndex, hyp
 	return &BaselineResolution{Note: joinNotes(notes...)}, nil
 }
 
+// ResolveLineageSupportedBaseline resolves the canonical incremental
+// comparator for a hypothesis: the nearest accepted supported ancestor
+// candidate on the hypothesis lineage with observations for instrument.
+func ResolveLineageSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, instrument string) (*BaselineResolution, error) {
+	obs, err := LoadObservationIndexStrict(s)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveLineageSupportedBaselineWithIndex(s, obs, hyp, instrument)
+}
+
+// ResolveLineageSupportedBaselineWithIndex is ResolveLineageSupportedBaseline
+// using a preloaded observation index.
+func ResolveLineageSupportedBaselineWithIndex(s *store.Store, obs *ObservationIndex, hyp *entity.Hypothesis, instrument string) (*BaselineResolution, error) {
+	if s == nil || hyp == nil {
+		return nil, nil
+	}
+	instrument = strings.TrimSpace(instrument)
+	if instrument == "" {
+		return nil, nil
+	}
+	concls, err := s.ListConclusions()
+	if err != nil {
+		return nil, err
+	}
+	ancestor, note, err := resolveAncestorSupportedBaseline(s, hyp, instrument, concls, obs)
+	if err != nil {
+		return nil, err
+	}
+	if ancestor != nil {
+		ancestor.Note = note
+		return ancestor, nil
+	}
+	if note == "" {
+		note = fmt.Sprintf("no accepted supported ancestor on hypothesis lineage has observations on instrument %q", instrument)
+	}
+	return &BaselineResolution{Note: note}, nil
+}
+
 func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, instrument string, concls []*entity.Conclusion, obs *ObservationIndex) (*BaselineResolution, string, error) {
 	if hyp == nil || strings.TrimSpace(hyp.Parent) == "" {
 		return nil, "", nil

--- a/internal/readmodel/baseline_test.go
+++ b/internal/readmodel/baseline_test.go
@@ -350,3 +350,48 @@ var _ = Describe("inferred baseline resolution", func() {
 		Expect(err).To(MatchError(ContainSubstring("parse observation")))
 	})
 })
+
+var _ = Describe("lineage supported baseline resolution", func() {
+	It("uses the nearest reviewed supported ancestor without falling back to the goal baseline", func() {
+		f := newBaselineFixture()
+		f.writeGoal("G-0001")
+
+		root := f.writeHypothesis("H-0001", "G-0001", "")
+		mid := f.writeHypothesis("H-0002", "G-0001", root.ID)
+		current := f.writeHypothesis("H-0003", "G-0001", mid.ID)
+
+		goalBaseline := f.writeExperiment("E-0001", "", "G-0001", "", true)
+		f.writeObservation("O-0001", goalBaseline.ID, "timing")
+
+		rootExp := f.writeExperiment("E-0002", root.ID, "", "", false)
+		midExp := f.writeExperiment("E-0003", mid.ID, "", "", false)
+		f.writeObservation("O-0002", rootExp.ID, "timing")
+		f.writeObservation("O-0003", midExp.ID, "timing")
+		f.writeConclusion("C-0001", root.ID, rootExp.ID, true)
+		f.writeConclusion("C-0002", mid.ID, midExp.ID, true)
+
+		got, err := ResolveLineageSupportedBaseline(f.s, current, "timing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeNil())
+		Expect(got.ExperimentID).To(Equal(midExp.ID))
+		Expect(got.Source).To(Equal(BaselineSourceAncestorSupported))
+		Expect(got.AncestorHypothesis).To(Equal(mid.ID))
+		Expect(got.AncestorConclusion).To(Equal("C-0002"))
+	})
+
+	It("returns an explanatory note when no accepted ancestor is usable", func() {
+		f := newBaselineFixture()
+		f.writeGoal("G-0001")
+		parent := f.writeHypothesis("H-0001", "G-0001", "")
+		current := f.writeHypothesis("H-0002", "G-0001", parent.ID)
+
+		goalBaseline := f.writeExperiment("E-0001", "", "G-0001", "", true)
+		f.writeObservation("O-0001", goalBaseline.ID, "timing")
+
+		got, err := ResolveLineageSupportedBaseline(f.s, current, "timing")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(got).NotTo(BeNil())
+		Expect(got.ExperimentID).To(BeEmpty())
+		Expect(got.Note).To(ContainSubstring("no accepted supported ancestor"))
+	})
+})


### PR DESCRIPTION
## Summary
- add a shared readmodel resolver for the nearest accepted supported lineage predecessor
- add `analyze --baseline auto` and report the resolved baseline in JSON/text
- use the same resolver for conclude incremental comparisons and support `--baseline-experiment auto`
- update generated Claude/Codex docs and research agent prompts

Fixes #44

## Testing
- `go test ./internal/readmodel ./internal/cli ./internal/integration`
- `make test`