### PR TITLE
Add conclusion linting

### DIFF
--- a/internal/cli/conclude.go
+++ b/internal/cli/conclude.go
@@ -402,6 +402,10 @@ lineage predecessor, and any fallback note.`,
 			if err := emitEvent(s, kind, or(author, "agent:analyst"), id, eventData); err != nil {
 				return err
 			}
+			lintReport, err := readmodel.LintConclusion(s, id)
+			if err != nil {
+				return fmt.Errorf("lint conclusion: %w", err)
+			}
 
 			// Report.
 			if w.IsJSON() {
@@ -411,6 +415,7 @@ lineage predecessor, and any fallback note.`,
 					"conclusion": concl,
 					"decision":   decision,
 					"resolution": resolution,
+					"lint":       lintReport,
 				})
 			}
 			if decision.Downgraded {
@@ -426,6 +431,7 @@ lineage predecessor, and any fallback note.`,
 				}
 				w.Textln("")
 			}
+			renderConclusionLintWarningText(w, lintReport)
 			w.Textf("wrote %s\n", id)
 			w.Textf("  hypothesis:  %s (now %s)\n", hypID, hyp.Status)
 			w.Textf("  candidate:   %s  (source=%s, n=%d)\n", candExp, resolution.CandidateSource, effect.NCandidate)

--- a/internal/cli/conclusion.go
+++ b/internal/cli/conclusion.go
@@ -15,7 +15,7 @@ func conclusionCommands() []*cobra.Command {
 		Use:   "conclusion",
 		Short: "Inspect and (for the critic) downgrade existing conclusions",
 	}
-	c.AddCommand(conclusionListCmd(), conclusionShowCmd(), conclusionDowngradeCmd(), conclusionAcceptCmd(), conclusionAppealCmd())
+	c.AddCommand(conclusionListCmd(), conclusionShowCmd(), conclusionLintCmd(), conclusionDowngradeCmd(), conclusionAcceptCmd(), conclusionAppealCmd())
 	return []*cobra.Command{c}
 }
 

--- a/internal/cli/conclusion_lint.go
+++ b/internal/cli/conclusion_lint.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/spf13/cobra"
+)
+
+func conclusionLintCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint <C-id>",
+		Short: "Lint conclusion citations, refs, constraints, and mechanism evidence",
+		Long: `Lint a persisted conclusion without mutating state. The report checks
+cited observations, candidate and baseline refs, required goal constraints,
+same-scope observations that were not cited, and mechanism/counter claims
+without supporting cited evidence artifacts.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := output.Default(globalJSON)
+			s, err := openStore()
+			if err != nil {
+				return err
+			}
+			report, err := readmodel.LintConclusion(s, args[0])
+			if err != nil {
+				return err
+			}
+			if w.IsJSON() {
+				return w.JSON(report)
+			}
+			renderConclusionLintText(w, report)
+			return nil
+		},
+	}
+}
+
+func renderConclusionLintText(w *output.Writer, report *readmodel.ConclusionLintReport) {
+	status := "ok"
+	if !report.OK {
+		status = "issues"
+	}
+	w.Textf("lint %s: %s (%d errors, %d warnings)\n", report.Conclusion, status, report.Errors, report.Warnings)
+	for _, issue := range report.Issues {
+		subject := issue.Subject
+		if subject != "" {
+			subject = " " + subject
+		}
+		w.Textf("  - [%s] %s%s: %s\n", issue.Severity, issue.Code, subject, issue.Message)
+	}
+}
+
+func renderConclusionLintWarningText(w *output.Writer, report *readmodel.ConclusionLintReport) {
+	if report == nil || report.OK {
+		return
+	}
+	w.Textln("")
+	w.Textf("LINT WARNINGS for %s (%d errors, %d warnings):\n", report.Conclusion, report.Errors, report.Warnings)
+	for _, issue := range report.Issues {
+		subject := issue.Subject
+		if subject != "" {
+			subject = " " + subject
+		}
+		w.Textf("  - [%s] %s%s: %s\n", issue.Severity, issue.Code, subject, issue.Message)
+	}
+	w.Textln(fmt.Sprintf("Run `autoresearch conclusion lint %s --json` for the structured report.", report.Conclusion))
+}

--- a/internal/cli/conclusion_lint_test.go
+++ b/internal/cli/conclusion_lint_test.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"strings"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("conclusion lint", func() {
+	BeforeEach(saveGlobals)
+
+	It("works while paused and warns about same-scope appended observations that are not cited", func() {
+		dir, s := setupConclusionLintFixture()
+		writeLintObservation(s, "O-0001", "E-0001", "timing", "refs/heads/candidate", "aaaaaaaa", true, nil, nil)
+		writeLintObservation(s, "O-0002", "E-0001", "timing", "refs/heads/candidate", "aaaaaaaa", true, nil, nil)
+		writeLintObservation(s, "O-0003", "E-0000", "timing", "refs/heads/baseline", "bbbbbbbb", true, nil, nil)
+		writeLintConclusion(s, &entity.Conclusion{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			Observations: []string{"O-0001"},
+			CandidateExp: "E-0001",
+			CandidateRef: "refs/heads/candidate",
+			CandidateSHA: "aaaaaaaa",
+			BaselineExp:  "E-0000",
+			BaselineRef:  "refs/heads/baseline",
+			BaselineSHA:  "bbbbbbbb",
+			Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.1, CIMethod: "bootstrap_bca_95"},
+			Strict:       entity.Strict{Passed: true},
+		})
+
+		runCLI(dir, "pause", "--reason", "review")
+		got := runCLIJSON[readmodel.ConclusionLintReport](dir, "conclusion", "lint", "C-0001")
+		Expect(got.OK).To(BeFalse())
+		Expect(lintCodes(got)).To(ContainElement("relevant_observation_not_cited"))
+		text := runCLI(dir, "conclusion", "lint", "C-0001")
+		expectText(text, "lint C-0001: issues", "relevant_observation_not_cited", "O-0002")
+	})
+
+	It("classifies no configured, failed, and unreadable mechanism evidence separately", func() {
+		dir, s := setupConclusionLintFixture()
+		writeLintObservation(s, "O-0001", "E-0001", "timing", "refs/heads/candidate", "aaaaaaaa", true, nil, nil)
+		writeLintObservation(s, "O-0002", "E-0001", "timing", "refs/heads/candidate", "aaaaaaaa", true, nil, []entity.EvidenceFailure{{
+			Name:     "profile",
+			ExitCode: 2,
+			Error:    "profile failed",
+		}})
+		writeLintObservation(s, "O-0003", "E-0001", "timing", "refs/heads/candidate", "aaaaaaaa", true, []entity.Artifact{{
+			Name:  "evidence/profile",
+			SHA:   "abcdef123456",
+			Path:  "artifacts/ab/missing/profile.txt",
+			Bytes: 12,
+		}}, nil)
+		writeLintObservation(s, "O-0004", "E-0000", "timing", "refs/heads/baseline", "bbbbbbbb", true, nil, nil)
+
+		writeMechanismConclusion(s, "C-0001", []string{"O-0001"})
+		writeMechanismConclusion(s, "C-0002", []string{"O-0002"})
+		writeMechanismConclusion(s, "C-0003", []string{"O-0003"})
+
+		Expect(lintCodes(runCLIJSON[readmodel.ConclusionLintReport](dir, "conclusion", "lint", "C-0001"))).To(ContainElement("mechanism_evidence_not_configured"))
+		Expect(lintCodes(runCLIJSON[readmodel.ConclusionLintReport](dir, "conclusion", "lint", "C-0002"))).To(ContainElement("evidence_capture_failed"))
+		Expect(lintCodes(runCLIJSON[readmodel.ConclusionLintReport](dir, "conclusion", "lint", "C-0003"))).To(ContainElement("evidence_artifact_unreadable"))
+	})
+
+	It("reports candidate and baseline ref mismatches plus missing required constraints", func() {
+		dir, s := setupConclusionLintFixture()
+		writeLintObservation(s, "O-0001", "E-0001", "timing", "refs/heads/other-candidate", "cccccccc", true, nil, nil)
+		writeLintObservation(s, "O-0002", "E-0000", "timing", "refs/heads/other-baseline", "dddddddd", true, nil, nil)
+		writeLintConclusion(s, &entity.Conclusion{
+			ID:           "C-0001",
+			Hypothesis:   "H-0001",
+			Verdict:      entity.VerdictSupported,
+			Observations: []string{"O-0001"},
+			CandidateExp: "E-0001",
+			CandidateRef: "refs/heads/candidate",
+			CandidateSHA: "aaaaaaaa",
+			BaselineExp:  "E-0000",
+			BaselineRef:  "refs/heads/baseline",
+			BaselineSHA:  "bbbbbbbb",
+			Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.1, CIMethod: "bootstrap_bca_95"},
+			Strict:       entity.Strict{Passed: true},
+		})
+
+		got := runCLIJSON[readmodel.ConclusionLintReport](dir, "conclusion", "lint", "C-0001")
+		Expect(lintCodes(got)).To(ContainElements(
+			"candidate_ref_mismatch",
+			"candidate_sha_mismatch",
+			"baseline_ref_mismatch",
+			"baseline_sha_mismatch",
+			"required_instrument_missing",
+		))
+	})
+
+	It("includes a lint report in conclude JSON and text output", func() {
+		dir := setupObserveScenarioStore()
+		registerScenarioTimingInstrument(dir)
+		runCLIJSON[cliIDResponse](dir,
+			"goal", "set",
+			"--objective-instrument", "timing",
+			"--objective-target", "kernel",
+			"--objective-direction", "decrease",
+			"--constraint-max", "timing=1000",
+		)
+		hyp := runCLIJSON[cliIDResponse](dir,
+			"hypothesis", "add",
+			"--claim", "reduce profile hits",
+			"--predicts-instrument", "timing",
+			"--predicts-target", "kernel",
+			"--predicts-direction", "decrease",
+			"--predicts-min-effect", "0",
+			"--kill-if", "tests fail",
+		)
+		exp := runCLIJSON[cliIDResponse](dir,
+			"experiment", "design", hyp.ID,
+			"--baseline", "HEAD",
+			"--instruments", "timing",
+		)
+		impl := runCLIJSON[cliImplementResponse](dir, "experiment", "implement", exp.ID)
+		ref := commitScenarioMetricsCandidate(impl.Worktree, "candidate/lint-json", "candidate", "90\n", "900\n")
+		obs := runCLIJSON[cliObserveAllResponse](dir, "observe", exp.ID, "--all", "--candidate-ref", ref)
+
+		json := runCLIJSON[struct {
+			Lint readmodel.ConclusionLintReport `json:"lint"`
+		}](dir,
+			"conclude", hyp.ID,
+			"--verdict", "supported",
+			"--observations", strings.Join(obs.Observations, ","),
+			"--interpretation", "profile hits dropped without a stored profile artifact",
+		)
+		Expect(lintCodes(json.Lint)).To(ContainElement("mechanism_evidence_not_configured"))
+
+		hyp2 := runCLIJSON[cliIDResponse](dir,
+			"hypothesis", "add",
+			"--claim", "reduce profile hits again",
+			"--predicts-instrument", "timing",
+			"--predicts-target", "kernel",
+			"--predicts-direction", "decrease",
+			"--predicts-min-effect", "0",
+			"--kill-if", "tests fail",
+		)
+		exp2 := runCLIJSON[cliIDResponse](dir,
+			"experiment", "design", hyp2.ID,
+			"--baseline", "HEAD",
+			"--instruments", "timing",
+		)
+		impl2 := runCLIJSON[cliImplementResponse](dir, "experiment", "implement", exp2.ID)
+		ref2 := commitScenarioMetricsCandidate(impl2.Worktree, "candidate/lint-text", "candidate 2", "80\n", "900\n")
+		obs2 := runCLIJSON[cliObserveAllResponse](dir, "observe", exp2.ID, "--all", "--candidate-ref", ref2)
+		text := runCLI(dir,
+			"conclude", hyp2.ID,
+			"--verdict", "supported",
+			"--observations", strings.Join(obs2.Observations, ","),
+			"--interpretation", "profile hits dropped without a stored profile artifact",
+		)
+		expectText(text, "LINT WARNINGS", "mechanism_evidence_not_configured")
+	})
+})
+
+func setupConclusionLintFixture() (string, *store.Store) {
+	GinkgoHelper()
+	dir, s := setupGoalStore()
+	now := time.Now().UTC()
+	Expect(s.WriteHypothesis(&entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "reduce timing",
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.1},
+		KillIf:    []string{"tests fail"},
+		Status:    entity.StatusUnreviewed,
+		Author:    "agent:orchestrator",
+		CreatedAt: now,
+	})).To(Succeed())
+	for _, exp := range []*entity.Experiment{
+		{ID: "E-0001", GoalID: "G-0001", Hypothesis: "H-0001", Status: entity.ExpAnalyzed, Instruments: []string{"timing", "host_test"}, Author: "agent:orchestrator", CreatedAt: now},
+		{ID: "E-0000", GoalID: "G-0001", IsBaseline: true, Status: entity.ExpMeasured, Instruments: []string{"timing"}, Author: "system", CreatedAt: now},
+	} {
+		Expect(s.WriteExperiment(exp)).To(Succeed())
+	}
+	return dir, s
+}
+
+func writeLintObservation(s *store.Store, id, exp, instrument, ref, sha string, pass bool, artifacts []entity.Artifact, failures []entity.EvidenceFailure) {
+	GinkgoHelper()
+	now := time.Now().UTC()
+	var passPtr *bool
+	if instrument == "host_test" {
+		passPtr = &pass
+	}
+	Expect(s.WriteObservation(&entity.Observation{
+		ID:               id,
+		Experiment:       exp,
+		Instrument:       instrument,
+		MeasuredAt:       now,
+		Value:            1,
+		Unit:             "unit",
+		Samples:          1,
+		Pass:             passPtr,
+		Artifacts:        artifacts,
+		EvidenceFailures: failures,
+		CandidateRef:     ref,
+		CandidateSHA:     sha,
+		Command:          "true",
+		Author:           "agent:observer",
+	})).To(Succeed())
+}
+
+func writeLintConclusion(s *store.Store, c *entity.Conclusion) {
+	GinkgoHelper()
+	c.StatTest = "mann_whitney_u"
+	c.Author = "agent:orchestrator"
+	c.CreatedAt = time.Now().UTC()
+	Expect(s.WriteConclusion(c)).To(Succeed())
+}
+
+func writeMechanismConclusion(s *store.Store, id string, observations []string) {
+	GinkgoHelper()
+	writeLintConclusion(s, &entity.Conclusion{
+		ID:           id,
+		Hypothesis:   "H-0001",
+		Verdict:      entity.VerdictSupported,
+		Observations: observations,
+		CandidateExp: "E-0001",
+		CandidateRef: "refs/heads/candidate",
+		CandidateSHA: "aaaaaaaa",
+		BaselineExp:  "E-0000",
+		BaselineRef:  "refs/heads/baseline",
+		BaselineSHA:  "bbbbbbbb",
+		Effect:       entity.Effect{Instrument: "timing", DeltaFrac: -0.1, CIMethod: "bootstrap_bca_95"},
+		Strict:       entity.Strict{Passed: true},
+		Body:         "# Interpretation\n\nprofile hits and attempts dropped.\n",
+	})
+}
+
+func lintCodes(report readmodel.ConclusionLintReport) []string {
+	GinkgoHelper()
+	return readmodel.ConclusionLintCodes(report.Issues)
+}

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -297,6 +297,7 @@ intentionally want another fresh run even though the target is already met.
 ### Conclusions (review and gate reviewer)
     autoresearch conclusion list       [--goal G-NNNN|all] [--hypothesis H-XXXX] [--verdict X]
     autoresearch conclusion show       <C-id>
+    autoresearch conclusion lint       <C-id>  # read-only citation/ref/mechanism evidence lint
     autoresearch review-packet         <C-id>
     autoresearch conclusion accept     <C-id> --reviewed-by ... --rationale "..."
         # Gate reviewer's acceptance: sets reviewed_by, promotes hypothesis

--- a/internal/readmodel/conclusion_lint.go
+++ b/internal/readmodel/conclusion_lint.go
@@ -1,0 +1,365 @@
+package readmodel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const (
+	LintSeverityError   = "error"
+	LintSeverityWarning = "warning"
+)
+
+type ConclusionLintReport struct {
+	Conclusion string                `json:"conclusion"`
+	OK         bool                  `json:"ok"`
+	Errors     int                   `json:"errors"`
+	Warnings   int                   `json:"warnings"`
+	Issues     []ConclusionLintIssue `json:"issues,omitempty"`
+}
+
+type ConclusionLintIssue struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Subject  string `json:"subject,omitempty"`
+	Message  string `json:"message"`
+}
+
+func LintConclusion(s *store.Store, conclusionID string) (*ConclusionLintReport, error) {
+	c, err := s.ReadConclusion(conclusionID)
+	if err != nil {
+		return nil, err
+	}
+	report := &ConclusionLintReport{Conclusion: c.ID}
+	hyp, goal := lintConclusionContext(s, report, c)
+	observations := lintCitedObservations(s, report, c)
+	lintRelevantObservations(s, report, c, observations)
+	lintRequiredConstraints(s, report, c, goal)
+	lintMechanismEvidence(s, report, c, hyp, observations)
+	lintBaselineRefs(s, report, c)
+	report.OK = len(report.Issues) == 0
+	return report, nil
+}
+
+func lintConclusionContext(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion) (*entity.Hypothesis, *entity.Goal) {
+	if strings.TrimSpace(c.Hypothesis) == "" {
+		report.add(LintSeverityError, "missing_hypothesis", c.ID, "conclusion has no hypothesis")
+		return nil, nil
+	}
+	hyp, err := s.ReadHypothesis(c.Hypothesis)
+	if err != nil {
+		report.add(LintSeverityError, "missing_hypothesis", c.Hypothesis, err.Error())
+		return nil, nil
+	}
+	if strings.TrimSpace(hyp.GoalID) == "" {
+		return hyp, nil
+	}
+	goal, err := s.ReadGoal(hyp.GoalID)
+	if err != nil {
+		report.add(LintSeverityWarning, "missing_goal", hyp.GoalID, err.Error())
+		return hyp, nil
+	}
+	return hyp, goal
+}
+
+func lintCitedObservations(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion) map[string]*entity.Observation {
+	observations := make(map[string]*entity.Observation, len(c.Observations))
+	for _, id := range c.Observations {
+		obs, err := s.ReadObservation(id)
+		if err != nil {
+			report.add(LintSeverityError, "missing_observation", id, err.Error())
+			continue
+		}
+		observations[id] = obs
+		if c.CandidateExp != "" && obs.Experiment != c.CandidateExp {
+			report.add(LintSeverityError, "observation_wrong_experiment", id,
+				fmt.Sprintf("observation belongs to %s, conclusion candidate is %s", obs.Experiment, c.CandidateExp))
+		}
+		if c.Effect.Instrument != "" && obs.Instrument != c.Effect.Instrument {
+			report.add(LintSeverityWarning, "observation_wrong_instrument", id,
+				fmt.Sprintf("observation instrument is %s, conclusion primary instrument is %s", obs.Instrument, c.Effect.Instrument))
+		}
+		lintCandidateScope(report, c, obs)
+	}
+	return observations
+}
+
+func lintCandidateScope(report *ConclusionLintReport, c *entity.Conclusion, obs *entity.Observation) {
+	if obs.Experiment != c.CandidateExp || obs.Instrument != c.Effect.Instrument {
+		return
+	}
+	if c.CandidateAttempt > 0 && obs.Attempt > 0 && obs.Attempt != c.CandidateAttempt {
+		report.add(LintSeverityError, "candidate_attempt_mismatch", obs.ID,
+			fmt.Sprintf("observation attempt is %d, conclusion candidate attempt is %d", obs.Attempt, c.CandidateAttempt))
+	}
+	if c.CandidateRef != "" && obs.CandidateRef != "" && obs.CandidateRef != c.CandidateRef {
+		report.add(LintSeverityError, "candidate_ref_mismatch", obs.ID,
+			fmt.Sprintf("observation candidate ref is %s, conclusion candidate ref is %s", obs.CandidateRef, c.CandidateRef))
+	}
+	if c.CandidateSHA != "" && obs.CandidateSHA != "" && obs.CandidateSHA != c.CandidateSHA {
+		report.add(LintSeverityError, "candidate_sha_mismatch", obs.ID,
+			fmt.Sprintf("observation candidate sha is %s, conclusion candidate sha is %s", obs.CandidateSHA, c.CandidateSHA))
+	}
+}
+
+func lintRelevantObservations(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion, cited map[string]*entity.Observation) {
+	if c.CandidateExp == "" || c.Effect.Instrument == "" || conclusionDeclaresAuthoritativeObservation(c) {
+		return
+	}
+	all, err := s.ListObservationsForExperiment(c.CandidateExp)
+	if err != nil {
+		report.add(LintSeverityWarning, "candidate_observations_unreadable", c.CandidateExp, err.Error())
+		return
+	}
+	for _, obs := range all {
+		if obs.Instrument != c.Effect.Instrument {
+			continue
+		}
+		if !observationMatchesConclusionScope(obs, c) {
+			continue
+		}
+		if _, ok := cited[obs.ID]; ok {
+			continue
+		}
+		report.add(LintSeverityWarning, "relevant_observation_not_cited", obs.ID,
+			"same candidate experiment/instrument/scope observation is not cited; cite all appended observations or state which one is authoritative")
+	}
+}
+
+func lintRequiredConstraints(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion, goal *entity.Goal) {
+	if goal == nil || c.CandidateExp == "" {
+		return
+	}
+	all, err := s.ListObservationsForExperiment(c.CandidateExp)
+	if err != nil {
+		report.add(LintSeverityWarning, "constraint_observations_unreadable", c.CandidateExp, err.Error())
+		return
+	}
+	for _, constraint := range goal.Constraints {
+		if strings.TrimSpace(constraint.Require) == "" {
+			continue
+		}
+		matching := observationsForInstrumentAndScope(all, constraint.Instrument, c)
+		if len(matching) == 0 {
+			report.add(LintSeverityError, "required_instrument_missing", constraint.Instrument,
+				fmt.Sprintf("required instrument %s=%s has no candidate observation", constraint.Instrument, constraint.Require))
+			continue
+		}
+		if !anyObservationSatisfiesRequire(matching, constraint.Require) {
+			report.add(LintSeverityError, "required_instrument_not_passing", constraint.Instrument,
+				fmt.Sprintf("required instrument %s=%s is not satisfied by candidate observations", constraint.Instrument, constraint.Require))
+		}
+	}
+}
+
+func lintMechanismEvidence(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion, hyp *entity.Hypothesis, cited map[string]*entity.Observation) {
+	if !containsMechanismLanguage(c, hyp) {
+		return
+	}
+	evidenceArtifacts := 0
+	evidenceFailures := 0
+	for _, obs := range cited {
+		evidenceFailures += len(obs.EvidenceFailures)
+		for _, failure := range obs.EvidenceFailures {
+			report.add(LintSeverityWarning, "evidence_capture_failed", obs.ID+"/"+failure.Name, formatEvidenceFailure(failure))
+		}
+		for _, artifact := range obs.Artifacts {
+			if !isEvidenceArtifact(artifact) {
+				continue
+			}
+			evidenceArtifacts++
+			if issue := artifactReadIssue(s, artifact); issue != "" {
+				report.add(LintSeverityError, "evidence_artifact_unreadable", obs.ID+"/"+artifact.Name, issue)
+			}
+		}
+	}
+	if evidenceArtifacts == 0 && evidenceFailures == 0 {
+		report.add(LintSeverityWarning, "mechanism_evidence_not_configured", c.ID,
+			"mechanism/counter language appears in the conclusion or hypothesis, but no cited evidence artifact or evidence failure is recorded")
+	}
+}
+
+func lintBaselineRefs(s *store.Store, report *ConclusionLintReport, c *entity.Conclusion) {
+	if c.BaselineExp == "" || c.Effect.Instrument == "" {
+		return
+	}
+	all, err := s.ListObservationsForExperiment(c.BaselineExp)
+	if err != nil {
+		report.add(LintSeverityWarning, "baseline_observations_unreadable", c.BaselineExp, err.Error())
+		return
+	}
+	var baseObs []*entity.Observation
+	for _, obs := range all {
+		if obs.Instrument == c.Effect.Instrument {
+			baseObs = append(baseObs, obs)
+		}
+	}
+	if len(baseObs) == 0 {
+		report.add(LintSeverityWarning, "baseline_observation_missing", c.BaselineExp,
+			"no baseline observation matches the conclusion primary instrument")
+		return
+	}
+	for _, obs := range baseObs {
+		if c.BaselineAttempt > 0 && obs.Attempt > 0 && obs.Attempt != c.BaselineAttempt {
+			report.add(LintSeverityError, "baseline_attempt_mismatch", obs.ID,
+				fmt.Sprintf("baseline observation attempt is %d, conclusion baseline attempt is %d", obs.Attempt, c.BaselineAttempt))
+		}
+		if c.BaselineRef != "" && obs.CandidateRef != "" && obs.CandidateRef != c.BaselineRef {
+			report.add(LintSeverityError, "baseline_ref_mismatch", obs.ID,
+				fmt.Sprintf("baseline observation ref is %s, conclusion baseline ref is %s", obs.CandidateRef, c.BaselineRef))
+		}
+		if c.BaselineSHA != "" && obs.CandidateSHA != "" && obs.CandidateSHA != c.BaselineSHA {
+			report.add(LintSeverityError, "baseline_sha_mismatch", obs.ID,
+				fmt.Sprintf("baseline observation sha is %s, conclusion baseline sha is %s", obs.CandidateSHA, c.BaselineSHA))
+		}
+	}
+}
+
+func observationsForInstrumentAndScope(all []*entity.Observation, instrument string, c *entity.Conclusion) []*entity.Observation {
+	var out []*entity.Observation
+	for _, obs := range all {
+		if obs.Instrument != instrument {
+			continue
+		}
+		if !observationMatchesConclusionScope(obs, c) {
+			continue
+		}
+		out = append(out, obs)
+	}
+	return out
+}
+
+func observationMatchesConclusionScope(obs *entity.Observation, c *entity.Conclusion) bool {
+	if c.CandidateAttempt > 0 && obs.Attempt > 0 && obs.Attempt != c.CandidateAttempt {
+		return false
+	}
+	if c.CandidateRef != "" && obs.CandidateRef != "" && obs.CandidateRef != c.CandidateRef {
+		return false
+	}
+	if c.CandidateSHA != "" && obs.CandidateSHA != "" && obs.CandidateSHA != c.CandidateSHA {
+		return false
+	}
+	return true
+}
+
+func anyObservationSatisfiesRequire(observations []*entity.Observation, require string) bool {
+	require = strings.ToLower(strings.TrimSpace(require))
+	for _, obs := range observations {
+		switch require {
+		case "pass", "passed", "true":
+			if obs.Pass != nil && *obs.Pass {
+				return true
+			}
+			if obs.Pass == nil && obs.Value != 0 {
+				return true
+			}
+		case "fail", "failed", "false":
+			if obs.Pass != nil && !*obs.Pass {
+				return true
+			}
+			if obs.Pass == nil && obs.Value == 0 {
+				return true
+			}
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+func containsMechanismLanguage(c *entity.Conclusion, hyp *entity.Hypothesis) bool {
+	text := strings.ToLower(strings.Join([]string{
+		c.Body,
+		c.Effect.Instrument,
+		func() string {
+			if hyp == nil {
+				return ""
+			}
+			return hyp.Claim + "\n" + hyp.Body
+		}(),
+	}, "\n"))
+	for _, keyword := range []string{
+		"attempts", "hits", "noop", "bytes/eval", "allocs", "simplify_trace",
+		"profile", "counter", "counters", "trace", "subpass",
+	} {
+		if strings.Contains(text, keyword) {
+			return true
+		}
+	}
+	return false
+}
+
+func isEvidenceArtifact(a entity.Artifact) bool {
+	name := strings.ToLower(a.Name)
+	return strings.HasPrefix(name, "evidence/") ||
+		strings.Contains(name, "profile") ||
+		strings.Contains(name, "trace") ||
+		strings.Contains(name, "counter") ||
+		strings.Contains(name, "subpass")
+}
+
+func artifactReadIssue(s *store.Store, a entity.Artifact) string {
+	switch {
+	case strings.TrimSpace(a.Path) != "":
+		if _, err := os.Stat(filepath.Join(s.DirPath(), a.Path)); err != nil {
+			return err.Error()
+		}
+	case strings.TrimSpace(a.SHA) != "":
+		if _, _, _, err := s.ArtifactLocation(a.SHA); err != nil {
+			return err.Error()
+		}
+	default:
+		return "artifact has no path or sha"
+	}
+	return ""
+}
+
+func formatEvidenceFailure(f entity.EvidenceFailure) string {
+	label := f.Name
+	if f.ExitCode != 0 {
+		label = fmt.Sprintf("%s (exit %d)", f.Name, f.ExitCode)
+	}
+	if detail := strings.TrimSpace(f.Error); detail != "" {
+		return label + ": " + detail
+	}
+	return label
+}
+
+func conclusionDeclaresAuthoritativeObservation(c *entity.Conclusion) bool {
+	body := strings.ToLower(c.Body)
+	return strings.Contains(body, "authoritative observation") ||
+		strings.Contains(body, "authoritative observations") ||
+		strings.Contains(body, "authoritative sample")
+}
+
+func (r *ConclusionLintReport) add(severity, code, subject, message string) {
+	r.Issues = append(r.Issues, ConclusionLintIssue{
+		Severity: severity,
+		Code:     code,
+		Subject:  subject,
+		Message:  message,
+	})
+	switch severity {
+	case LintSeverityError:
+		r.Errors++
+	case LintSeverityWarning:
+		r.Warnings++
+	}
+}
+
+func ConclusionLintCodes(issues []ConclusionLintIssue) []string {
+	out := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if slices.Contains(out, issue.Code) {
+			continue
+		}
+		out = append(out, issue.Code)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
- add read-only `conclusion lint <C-id>` with structured warnings/errors
- lint observation citations, appended same-scope observations, mechanism evidence, required constraints, and ref consistency
- include additive lint reports/warnings from `conclude`

## Tests
- `go test ./internal/cli`
- `go test ./internal/readmodel ./internal/integration`
- `make test`

Closes #66
