### PR TITLE
Add ranked lesson relevance

### DIFF
--- a/internal/cli/cycle_context.go
+++ b/internal/cli/cycle_context.go
@@ -34,15 +34,16 @@ type cycleContextGoal struct {
 }
 
 type cycleContextScope struct {
-	Goal           *entity.Goal                  `json:"goal,omitempty"`
-	FrontierBest   *frontierRow                  `json:"frontier_best"`
-	FrontierStallK int                           `json:"frontier_stall_k"`
-	StalledFor     int                           `json:"stalled_for"`
-	StallReached   bool                          `json:"stall_reached"`
-	GoalAssessment *frontierGoalAssessment       `json:"goal_assessment,omitempty"`
-	OpenHypotheses []*entity.Hypothesis          `json:"open_hypotheses"`
-	InFlight       []dashboardInFlight           `json:"in_flight"`
-	ActiveLessons  []readmodel.LessonSummaryView `json:"active_lessons"`
+	Goal            *entity.Goal                   `json:"goal,omitempty"`
+	FrontierBest    *frontierRow                   `json:"frontier_best"`
+	FrontierStallK  int                            `json:"frontier_stall_k"`
+	StalledFor      int                            `json:"stalled_for"`
+	StallReached    bool                           `json:"stall_reached"`
+	GoalAssessment  *frontierGoalAssessment        `json:"goal_assessment,omitempty"`
+	OpenHypotheses  []*entity.Hypothesis           `json:"open_hypotheses"`
+	InFlight        []dashboardInFlight            `json:"in_flight"`
+	ActiveLessons   []readmodel.LessonSummaryView  `json:"active_lessons"`
+	RelevantLessons []readmodel.RelevantLessonView `json:"relevant_lessons"`
 }
 
 type cycleContextInputs struct {
@@ -238,30 +239,48 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 	expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(exps, hyps)
 	inFlight, _ := readmodel.BuildExperimentActivity(exps, expClassByID, events, 0, inputs.now)
 
-	lessonViews, err := readmodel.ListLessonsForRead(s, lessons, readmodel.LessonListOptions{Status: entity.LessonStatusActive})
+	activeLessonViews, err := readmodel.ListLessonsForRead(s, lessons, readmodel.LessonListOptions{Status: entity.LessonStatusActive})
 	if err != nil {
 		return nil, nil, err
 	}
+	allLessonViews, err := readmodel.ListLessonsForRead(s, lessons, readmodel.LessonListOptions{Status: readmodel.LessonStatusAll})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var frontierBest *frontierRow
+	var stalledFor int
 
 	payload := &cycleContextScope{
 		Goal:           goal,
 		FrontierStallK: inputs.cfg.Budgets.FrontierStallK,
 		OpenHypotheses: openHypotheses(hyps),
 		InFlight:       nonNilInFlight(inFlight),
-		ActiveLessons:  nonNilLessonSummaries(readmodel.BuildLessonSummaryViews(lessonViews)),
+		ActiveLessons:  nonNilLessonSummaries(readmodel.BuildLessonSummaryViews(activeLessonViews)),
 	}
 
 	if goal != nil {
 		frontier := readmodel.BuildFrontierSnapshot(goal, concls, readmodel.NewObservationIndex(obs), expClassByID)
 		if len(frontier.Rows) > 0 {
 			best := frontier.Rows[0]
-			payload.FrontierBest = &best
+			frontierBest = &best
+			payload.FrontierBest = frontierBest
 		}
-		payload.StalledFor = frontier.StalledFor
-		payload.StallReached = inputs.cfg.Budgets.FrontierStallK > 0 && frontier.StalledFor >= inputs.cfg.Budgets.FrontierStallK
-		assessment := frontier.Assessment
-		payload.GoalAssessment = &assessment
+		stalledFor = frontier.StalledFor
+		payload.StalledFor = stalledFor
+		payload.StallReached = inputs.cfg.Budgets.FrontierStallK > 0 && stalledFor >= inputs.cfg.Budgets.FrontierStallK
+		frontierAssessment := frontier.Assessment
+		payload.GoalAssessment = &frontierAssessment
 	}
+	payload.RelevantLessons = nonNilRelevantLessons(readmodel.RankRelevantLessons(allLessonViews, readmodel.LessonRelevanceContext{
+		Goal:                goal,
+		OpenHypotheses:      payload.OpenHypotheses,
+		InFlightExperiments: relevantInFlightExperiments(exps),
+		FrontierBest:        frontierBest,
+		Conclusions:         concls,
+		Hypotheses:          hyps,
+		Limit:               readmodel.DefaultRelevantLessonLimit,
+	}))
 
 	counts := readmodel.BuildCountsWithLessons(len(hyps), len(exps), len(obs), len(concls), len(lessons))
 	return payload, counts, nil
@@ -294,6 +313,13 @@ func nonNilInFlight(in []dashboardInFlight) []dashboardInFlight {
 func nonNilLessonSummaries(in []readmodel.LessonSummaryView) []readmodel.LessonSummaryView {
 	if in == nil {
 		return []readmodel.LessonSummaryView{}
+	}
+	return in
+}
+
+func nonNilRelevantLessons(in []readmodel.RelevantLessonView) []readmodel.RelevantLessonView {
+	if in == nil {
+		return []readmodel.RelevantLessonView{}
 	}
 	return in
 }
@@ -349,4 +375,5 @@ func renderCycleContextGoalText(w *output.Writer, goalID string, scope *cycleCon
 	w.Textf("open hypotheses: %d\n", len(scope.OpenHypotheses))
 	w.Textf("in flight:      %d\n", len(scope.InFlight))
 	w.Textf("active lessons: %d\n", len(scope.ActiveLessons))
+	w.Textf("relevant lessons: %d\n", len(scope.RelevantLessons))
 }

--- a/internal/cli/cycle_context_test.go
+++ b/internal/cli/cycle_context_test.go
@@ -23,40 +23,42 @@ type cliCycleContextInFlight struct {
 }
 
 type cliCycleContextGoal struct {
-	GoalID         string                        `json:"goal_id"`
-	Counts         map[string]int                `json:"counts"`
-	Goal           *entity.Goal                  `json:"goal,omitempty"`
-	FrontierBest   *cliFrontierRow               `json:"frontier_best"`
-	FrontierStallK int                           `json:"frontier_stall_k"`
-	StalledFor     int                           `json:"stalled_for"`
-	StallReached   bool                          `json:"stall_reached"`
-	GoalAssessment *cliCycleContextAssessment    `json:"goal_assessment,omitempty"`
-	OpenHypotheses []entity.Hypothesis           `json:"open_hypotheses"`
-	InFlight       []cliCycleContextInFlight     `json:"in_flight"`
-	ActiveLessons  []readmodel.LessonSummaryView `json:"active_lessons"`
+	GoalID          string                         `json:"goal_id"`
+	Counts          map[string]int                 `json:"counts"`
+	Goal            *entity.Goal                   `json:"goal,omitempty"`
+	FrontierBest    *cliFrontierRow                `json:"frontier_best"`
+	FrontierStallK  int                            `json:"frontier_stall_k"`
+	StalledFor      int                            `json:"stalled_for"`
+	StallReached    bool                           `json:"stall_reached"`
+	GoalAssessment  *cliCycleContextAssessment     `json:"goal_assessment,omitempty"`
+	OpenHypotheses  []entity.Hypothesis            `json:"open_hypotheses"`
+	InFlight        []cliCycleContextInFlight      `json:"in_flight"`
+	ActiveLessons   []readmodel.LessonSummaryView  `json:"active_lessons"`
+	RelevantLessons []readmodel.RelevantLessonView `json:"relevant_lessons"`
 }
 
 type cliCycleContextResponse struct {
-	Project                string                        `json:"project"`
-	ScopeGoalID            string                        `json:"scope_goal_id,omitempty"`
-	ScopeAll               bool                          `json:"scope_all"`
-	Paused                 bool                          `json:"paused"`
-	PauseReason            string                        `json:"pause_reason,omitempty"`
-	Mode                   string                        `json:"mode"`
-	MainCheckoutDirty      bool                          `json:"main_checkout_dirty"`
-	MainCheckoutDirtyPaths []string                      `json:"main_checkout_dirty_paths"`
-	Counts                 map[string]int                `json:"counts"`
-	Instruments            map[string]store.Instrument   `json:"instruments"`
-	Goal                   *entity.Goal                  `json:"goal,omitempty"`
-	FrontierBest           *cliFrontierRow               `json:"frontier_best"`
-	FrontierStallK         int                           `json:"frontier_stall_k"`
-	StalledFor             int                           `json:"stalled_for"`
-	StallReached           bool                          `json:"stall_reached"`
-	GoalAssessment         *cliCycleContextAssessment    `json:"goal_assessment,omitempty"`
-	OpenHypotheses         []entity.Hypothesis           `json:"open_hypotheses"`
-	InFlight               []cliCycleContextInFlight     `json:"in_flight"`
-	ActiveLessons          []readmodel.LessonSummaryView `json:"active_lessons"`
-	Goals                  []cliCycleContextGoal         `json:"goals,omitempty"`
+	Project                string                         `json:"project"`
+	ScopeGoalID            string                         `json:"scope_goal_id,omitempty"`
+	ScopeAll               bool                           `json:"scope_all"`
+	Paused                 bool                           `json:"paused"`
+	PauseReason            string                         `json:"pause_reason,omitempty"`
+	Mode                   string                         `json:"mode"`
+	MainCheckoutDirty      bool                           `json:"main_checkout_dirty"`
+	MainCheckoutDirtyPaths []string                       `json:"main_checkout_dirty_paths"`
+	Counts                 map[string]int                 `json:"counts"`
+	Instruments            map[string]store.Instrument    `json:"instruments"`
+	Goal                   *entity.Goal                   `json:"goal,omitempty"`
+	FrontierBest           *cliFrontierRow                `json:"frontier_best"`
+	FrontierStallK         int                            `json:"frontier_stall_k"`
+	StalledFor             int                            `json:"stalled_for"`
+	StallReached           bool                           `json:"stall_reached"`
+	GoalAssessment         *cliCycleContextAssessment     `json:"goal_assessment,omitempty"`
+	OpenHypotheses         []entity.Hypothesis            `json:"open_hypotheses"`
+	InFlight               []cliCycleContextInFlight      `json:"in_flight"`
+	ActiveLessons          []readmodel.LessonSummaryView  `json:"active_lessons"`
+	RelevantLessons        []readmodel.RelevantLessonView `json:"relevant_lessons"`
+	Goals                  []cliCycleContextGoal          `json:"goals,omitempty"`
 }
 
 var _ = Describe("cycle-context command", func() {
@@ -147,6 +149,11 @@ var _ = Describe("cycle-context command", func() {
 		Expect(ctx.ActiveLessons).To(ContainElement(SatisfyAll(
 			HaveField("ID", lesson.ID),
 			HaveField("Status", entity.LessonStatusActive),
+			HaveField("Claim", "tightening the hot loop paid off in this fixture"),
+		)))
+		Expect(ctx.RelevantLessons).To(ContainElement(SatisfyAll(
+			HaveField("ID", lesson.ID),
+			HaveField("Score", BeNumerically(">", 0)),
 			HaveField("Claim", "tightening the hot loop paid off in this fixture"),
 		)))
 		Expect(ctx.Instruments).To(HaveKey("timing"))

--- a/internal/cli/lesson.go
+++ b/internal/cli/lesson.go
@@ -41,6 +41,7 @@ the whole point — the loop should not re-derive what it already knows.`,
 	l.AddCommand(
 		lessonAddCmd(),
 		lessonListCmd(),
+		lessonRelevantCmd(),
 		lessonShowCmd(),
 		lessonSupersedeCmd(),
 		lessonAccuracyCmd(),
@@ -178,6 +179,55 @@ If unsure, prefer scope=hypothesis.`,
 	c.Flags().Float64Var(&predictMinEffect, "predict-min-effect", 0, "minimum predicted fractional effect (required with --predict-instrument)")
 	c.Flags().Float64Var(&predictMaxEffect, "predict-max-effect", 0, "maximum predicted fractional effect (optional, 0 = unbounded)")
 	addAuthorFlag(c, &author, "")
+	return c
+}
+
+func lessonRelevantCmd() *cobra.Command {
+	var (
+		goalFlag string
+		hypID    string
+		limit    int
+	)
+	c := &cobra.Command{
+		Use:   "relevant",
+		Short: "Rank lessons for the current goal or hypothesis",
+		Long: `Return a small ranked lesson subset for the next research step.
+The ranking keeps statuses explicit, so directly relevant invalidated
+lessons can appear as cautionary context instead of being silently hidden.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			w := output.Default(globalJSON)
+			s, err := openStore()
+			if err != nil {
+				return err
+			}
+			rows, scope, err := captureRelevantLessons(s, goalFlag, hypID, limit)
+			if err != nil {
+				return err
+			}
+			if w.IsJSON() {
+				return w.JSON(mergeGoalScopePayload(map[string]any{
+					"hypothesis": strings.TrimSpace(hypID),
+					"limit":      resolvedRelevantLessonLimit(limit),
+					"lessons":    rows,
+				}, scope))
+			}
+			if len(rows) == 0 {
+				w.Textln("(no relevant lessons)")
+				return nil
+			}
+			for _, row := range rows {
+				w.Textf("  %-8s score=%-4d %-11s %-11s %s\n",
+					row.ID, row.Score, row.Scope, row.Status, row.Claim)
+				if len(row.Reasons) > 0 {
+					w.Textf("            reason: %s\n", strings.Join(row.Reasons, "; "))
+				}
+			}
+			return nil
+		},
+	}
+	c.Flags().StringVar(&goalFlag, "goal", "", "goal to scope relevance to (defaults to active goal; use 'all' for every goal)")
+	c.Flags().StringVar(&hypID, "hypothesis", "", "current hypothesis id to prioritize direct lesson links")
+	c.Flags().IntVar(&limit, "limit", readmodel.DefaultRelevantLessonLimit, "maximum lessons to return (0 uses default)")
 	return c
 }
 

--- a/internal/cli/lesson_relevance.go
+++ b/internal/cli/lesson_relevance.go
@@ -1,0 +1,160 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+func captureRelevantLessons(s *store.Store, goalFlag, hypID string, limit int) ([]readmodel.RelevantLessonView, goalScope, error) {
+	hyp, scope, err := resolveLessonRelevantScope(s, goalFlag, hypID)
+	if err != nil {
+		return nil, goalScope{}, err
+	}
+	inputs, err := loadLessonRelevanceInputs(s, scope)
+	if err != nil {
+		return nil, goalScope{}, err
+	}
+	var goal *entity.Goal
+	if scope.GoalID != "" {
+		goal, err = s.ReadGoal(scope.GoalID)
+		if err != nil {
+			return nil, goalScope{}, err
+		}
+	}
+
+	views, err := readmodel.ListLessonsForRead(s, inputs.lessons, readmodel.LessonListOptions{Status: readmodel.LessonStatusAll})
+	if err != nil {
+		return nil, goalScope{}, err
+	}
+	var frontierBest *readmodel.FrontierRow
+	if goal != nil {
+		expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(inputs.experiments, inputs.hypotheses)
+		frontier := readmodel.BuildFrontierSnapshot(goal, inputs.conclusions, readmodel.NewObservationIndex(inputs.observations), expClassByID)
+		if len(frontier.Rows) > 0 {
+			best := frontier.Rows[0]
+			frontierBest = &best
+		}
+	}
+
+	rows := readmodel.RankRelevantLessons(views, readmodel.LessonRelevanceContext{
+		Goal:                goal,
+		Hypothesis:          hyp,
+		OpenHypotheses:      openHypotheses(inputs.hypotheses),
+		InFlightExperiments: relevantInFlightExperiments(inputs.experiments),
+		FrontierBest:        frontierBest,
+		Conclusions:         inputs.conclusions,
+		Hypotheses:          inputs.hypotheses,
+		Limit:               limit,
+	})
+	return rows, scope, nil
+}
+
+type lessonRelevanceInputs struct {
+	hypotheses   []*entity.Hypothesis
+	experiments  []*entity.Experiment
+	conclusions  []*entity.Conclusion
+	observations []*entity.Observation
+	lessons      []*entity.Lesson
+}
+
+func loadLessonRelevanceInputs(s *store.Store, scope goalScope) (*lessonRelevanceInputs, error) {
+	hyps, err := s.ListHypotheses()
+	if err != nil {
+		return nil, err
+	}
+	exps, err := s.ListExperiments()
+	if err != nil {
+		return nil, err
+	}
+	concls, err := s.ListConclusions()
+	if err != nil {
+		return nil, err
+	}
+	obs, err := s.ListObservations()
+	if err != nil {
+		return nil, err
+	}
+	lessons, err := s.ListLessons()
+	if err != nil {
+		return nil, err
+	}
+	resolver := newGoalScopeResolver(s, scope)
+	hyps = resolver.filterHypotheses(hyps)
+	exps, err = resolver.filterExperiments(exps)
+	if err != nil {
+		return nil, err
+	}
+	concls, err = resolver.filterConclusions(concls)
+	if err != nil {
+		return nil, err
+	}
+	obs, err = resolver.filterObservations(obs)
+	if err != nil {
+		return nil, err
+	}
+	lessons, err = resolver.filterLessons(lessons)
+	if err != nil {
+		return nil, err
+	}
+	return &lessonRelevanceInputs{
+		hypotheses:   hyps,
+		experiments:  exps,
+		conclusions:  concls,
+		observations: obs,
+		lessons:      lessons,
+	}, nil
+}
+
+func resolveLessonRelevantScope(s *store.Store, goalFlag, hypID string) (*entity.Hypothesis, goalScope, error) {
+	hypID = strings.TrimSpace(hypID)
+	if hypID == "" {
+		scope, err := resolveGoalScope(s, goalFlag)
+		return nil, scope, err
+	}
+	hyp, err := s.ReadHypothesis(hypID)
+	if err != nil {
+		return nil, goalScope{}, err
+	}
+	if strings.TrimSpace(goalFlag) == "" {
+		if strings.TrimSpace(hyp.GoalID) == "" {
+			return hyp, goalScope{All: true}, nil
+		}
+		return hyp, goalScope{GoalID: hyp.GoalID}, nil
+	}
+	scope, err := resolveGoalScope(s, goalFlag)
+	if err != nil {
+		return nil, goalScope{}, err
+	}
+	if scope.All {
+		return nil, goalScope{}, fmt.Errorf("--goal all cannot be combined with --hypothesis %s", hypID)
+	}
+	if hyp.GoalID != "" && scope.GoalID != hyp.GoalID {
+		return nil, goalScope{}, fmt.Errorf("--hypothesis %s belongs to goal %s, not %s", hypID, hyp.GoalID, scope.GoalID)
+	}
+	return hyp, scope, nil
+}
+
+func resolvedRelevantLessonLimit(limit int) int {
+	if limit <= 0 {
+		return readmodel.DefaultRelevantLessonLimit
+	}
+	return limit
+}
+
+func relevantInFlightExperiments(exps []*entity.Experiment) []*entity.Experiment {
+	out := make([]*entity.Experiment, 0, len(exps))
+	for _, exp := range exps {
+		if exp == nil || exp.IsBaseline {
+			continue
+		}
+		switch exp.Status {
+		case entity.ExpDesigned, entity.ExpImplemented, entity.ExpMeasured:
+			out = append(out, exp)
+		}
+	}
+	return out
+}

--- a/internal/cli/lesson_relevance_test.go
+++ b/internal/cli/lesson_relevance_test.go
@@ -25,12 +25,12 @@ var _ = Describe("lesson relevant", func() {
 			"lesson", "relevant",
 			"--goal", "G-0001",
 			"--hypothesis", "H-0001",
-			"--limit", "3",
+			"--limit", "10",
 		)
 
 		Expect(got.ScopeGoalID).To(Equal("G-0001"))
 		Expect(got.Hypothesis).To(Equal("H-0001"))
-		Expect(got.Limit).To(Equal(3))
+		Expect(got.Limit).To(Equal(10))
 		Expect(got.Lessons).To(HaveLen(3))
 		Expect(got.Lessons[0].ID).To(Equal("L-0001"))
 		Expect(got.Lessons[0].Reasons).To(ContainElement("cited by current hypothesis"))

--- a/internal/cli/lesson_relevance_test.go
+++ b/internal/cli/lesson_relevance_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("lesson relevant", func() {
+	BeforeEach(saveGlobals)
+
+	It("returns a small ranked subset with active, system, and direct invalidated lessons", func() {
+		dir, _ := setupLessonRelevanceFixture()
+
+		got := runCLIJSON[struct {
+			ScopeGoalID string                         `json:"scope_goal_id"`
+			Hypothesis  string                         `json:"hypothesis"`
+			Limit       int                            `json:"limit"`
+			Lessons     []readmodel.RelevantLessonView `json:"lessons"`
+		}](dir,
+			"lesson", "relevant",
+			"--goal", "G-0001",
+			"--hypothesis", "H-0001",
+			"--limit", "3",
+		)
+
+		Expect(got.ScopeGoalID).To(Equal("G-0001"))
+		Expect(got.Hypothesis).To(Equal("H-0001"))
+		Expect(got.Limit).To(Equal(3))
+		Expect(got.Lessons).To(HaveLen(3))
+		Expect(got.Lessons[0].ID).To(Equal("L-0001"))
+		Expect(got.Lessons[0].Reasons).To(ContainElement("cited by current hypothesis"))
+		Expect(got.Lessons).To(ContainElement(SatisfyAll(
+			HaveField("ID", "L-0002"),
+			HaveField("Status", entity.LessonStatusInvalidated),
+			HaveField("Reasons", ContainElement("invalidated")),
+		)))
+		Expect(got.Lessons).To(ContainElement(SatisfyAll(
+			HaveField("ID", "L-0003"),
+			HaveField("Scope", entity.LessonScopeSystem),
+		)))
+		Expect(got.Lessons).NotTo(ContainElement(HaveField("ID", "L-0004")))
+		Expect(got.Lessons).NotTo(ContainElement(HaveField("ID", "L-0005")))
+
+		text := runCLI(dir, "lesson", "relevant", "--hypothesis", "H-0001", "--limit", "2")
+		expectText(text, "L-0001", "score=", "reason:")
+	})
+})
+
+func setupLessonRelevanceFixture() (string, *store.Store) {
+	GinkgoHelper()
+
+	dir, s := setupGoalStore()
+	now := time.Date(2026, 4, 26, 10, 0, 0, 0, time.UTC)
+	Expect(s.WriteGoal(&entity.Goal{
+		ID:        "G-0002",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "memory", Direction: "decrease"},
+	})).To(Succeed())
+	for _, h := range []*entity.Hypothesis{
+		{
+			ID:         "H-0001",
+			GoalID:     "G-0001",
+			Claim:      "try a histogram follow-up",
+			Status:     entity.StatusOpen,
+			InspiredBy: []string{"L-0001"},
+			Predicts:   entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+			Tags:       []string{"histogram"},
+			Author:     "test",
+			CreatedAt:  now,
+		},
+		{
+			ID:        "H-0002",
+			GoalID:    "G-0001",
+			Claim:     "reviewed source",
+			Status:    entity.StatusSupported,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+			Author:    "test",
+			CreatedAt: now,
+		},
+		{
+			ID:        "H-0003",
+			GoalID:    "G-0001",
+			Claim:     "dead source",
+			Status:    entity.StatusInconclusive,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+			Author:    "test",
+			CreatedAt: now,
+		},
+		{
+			ID:        "H-0004",
+			GoalID:    "G-0002",
+			Claim:     "other goal",
+			Status:    entity.StatusSupported,
+			Predicts:  entity.Predicts{Instrument: "memory", Target: "allocator", Direction: "decrease", MinEffect: 0.05},
+			Author:    "test",
+			CreatedAt: now,
+		},
+	} {
+		Expect(s.WriteHypothesis(h)).To(Succeed())
+	}
+	for _, l := range []*entity.Lesson{
+		{
+			ID:        "L-0001",
+			Claim:     "Use SINGLETON_MISS_HISTOGRAM for the timing follow-up",
+			Scope:     entity.LessonScopeHypothesis,
+			Subjects:  []string{"H-0002"},
+			Status:    entity.LessonStatusActive,
+			Tags:      []string{"histogram"},
+			Author:    "agent:analyst",
+			CreatedAt: now,
+		},
+		{
+			ID:        "L-0002",
+			Claim:     "The old cache axis is exhausted for timing",
+			Scope:     entity.LessonScopeHypothesis,
+			Subjects:  []string{"H-0003"},
+			Status:    entity.LessonStatusActive,
+			Tags:      []string{"timing"},
+			Author:    "agent:analyst",
+			CreatedAt: now.Add(time.Minute),
+			PredictedEffect: &entity.PredictedEffect{
+				Instrument: "timing",
+				Direction:  "decrease",
+				MinEffect:  0.05,
+			},
+		},
+		{
+			ID:        "L-0003",
+			Claim:     "The measurement harness has a timing-specific warmup cost",
+			Scope:     entity.LessonScopeSystem,
+			Status:    entity.LessonStatusActive,
+			Tags:      []string{"timing"},
+			Author:    "agent:analyst",
+			CreatedAt: now.Add(2 * time.Minute),
+		},
+		{
+			ID:        "L-0004",
+			Claim:     "Documentation wording is unrelated to this goal",
+			Scope:     entity.LessonScopeSystem,
+			Status:    entity.LessonStatusActive,
+			Tags:      []string{"docs"},
+			Author:    "agent:analyst",
+			CreatedAt: now.Add(3 * time.Minute),
+		},
+		{
+			ID:        "L-0005",
+			Claim:     "Other goal timing-looking lesson should be scoped out",
+			Scope:     entity.LessonScopeHypothesis,
+			Subjects:  []string{"H-0004"},
+			Status:    entity.LessonStatusActive,
+			Tags:      []string{"timing"},
+			Author:    "agent:analyst",
+			CreatedAt: now.Add(4 * time.Minute),
+		},
+	} {
+		Expect(s.WriteLesson(l)).To(Succeed())
+	}
+	return dir, s
+}

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -512,6 +512,7 @@ Verbs:
         [--predict-instrument X --predict-direction {increase|decrease} --predict-min-effect N [--predict-max-effect M]]
     autoresearch lesson list [--goal G-NNNN|all] [--scope ...] [--status active|provisional|invalidated|superseded|all] [--subject ...] [--tag ...] [--since L-NNNN]
                               [--summary | --fields id,scope,status,tags,...]
+    autoresearch lesson relevant [--goal G-NNNN] [--hypothesis H-NNNN] [--limit N]   # ranked small lesson subset
     autoresearch lesson show <L-id>
     autoresearch lesson supersede <L-old> --by <L-new> --reason "..."
     autoresearch lesson accuracy   # compare predicted effects vs actual outcomes (read-only)
@@ -560,10 +561,12 @@ example.
 
 **3. The reading contract.** Lessons are load-bearing, not decorative:
 
-- The **orchestrator** MUST read active lesson summaries at the start of
-  every cycle. ` + "`cycle-context --json`" + ` provides them in ` + "`active_lessons`" + `;
-  use ` + "`lesson list --summary --json`" + ` only when deeper active lesson
-  detail is needed. Its ` + "`--rationale`" + ` on ` + "`hypothesis add`" + ` must
+- The **orchestrator** MUST read ranked relevant lessons at the start of
+  every cycle. ` + "`cycle-context --json`" + ` provides them in ` + "`relevant_lessons`" + `
+  and keeps the legacy active-only summary in ` + "`active_lessons`" + `. Use
+  ` + "`lesson relevant --hypothesis H-XXXX --json`" + ` to focus a specific
+  proposal, and ` + "`lesson list --summary --json`" + ` only when deeper active
+  lesson detail is needed. Its ` + "`--rationale`" + ` on ` + "`hypothesis add`" + ` must
   either cite a lesson ID or explicitly note "no relevant lesson". When
   citing lessons, pass their IDs via ` + "`--inspired-by L-XXXX,L-YYYY`" + ` to
   create a structured link. ` + "`lesson accuracy`" + ` uses this link to compare

--- a/internal/readmodel/lesson_relevance.go
+++ b/internal/readmodel/lesson_relevance.go
@@ -1,0 +1,304 @@
+package readmodel
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+)
+
+const DefaultRelevantLessonLimit = 8
+
+type LessonRelevanceContext struct {
+	Goal                *entity.Goal
+	Hypothesis          *entity.Hypothesis
+	OpenHypotheses      []*entity.Hypothesis
+	InFlightExperiments []*entity.Experiment
+	FrontierBest        *FrontierRow
+	Conclusions         []*entity.Conclusion
+	Hypotheses          []*entity.Hypothesis
+	Limit               int
+}
+
+type RelevantLessonView struct {
+	ID             string   `json:"id"`
+	Score          int      `json:"score"`
+	Reasons        []string `json:"reasons"`
+	Scope          string   `json:"scope"`
+	Status         string   `json:"status"`
+	SourceChain    string   `json:"source_chain,omitempty"`
+	Tags           []string `json:"tags"`
+	Subjects       []string `json:"subjects,omitempty"`
+	Claim          string   `json:"claim"`
+	ClaimTruncated bool     `json:"claim_truncated"`
+}
+
+func RankRelevantLessons(views []*LessonReadView, ctx LessonRelevanceContext) []RelevantLessonView {
+	if ctx.Limit <= 0 {
+		ctx.Limit = DefaultRelevantLessonLimit
+	}
+	maxOrdinal := maxLessonOrdinal(views)
+	focus := buildLessonRelevanceFocus(ctx)
+	decisiveCitations := lessonDecisiveCitationCounts(ctx.Hypotheses, ctx.Conclusions)
+
+	rows := make([]RelevantLessonView, 0, len(views))
+	for _, view := range views {
+		if view == nil || view.Lesson == nil {
+			continue
+		}
+		row, direct := scoreRelevantLesson(view, focus, decisiveCitations, maxOrdinal)
+		if direct || row.Score > 0 {
+			rows = append(rows, row)
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Score != rows[j].Score {
+			return rows[i].Score > rows[j].Score
+		}
+		return lessonIDSortValue(rows[i].ID) > lessonIDSortValue(rows[j].ID)
+	})
+	if len(rows) > ctx.Limit {
+		rows = rows[:ctx.Limit]
+	}
+	if rows == nil {
+		return []RelevantLessonView{}
+	}
+	return rows
+}
+
+type lessonRelevanceFocus struct {
+	instruments       map[string]struct{}
+	tags              map[string]struct{}
+	subjectReasons    map[string]string
+	currentInspiredBy map[string]struct{}
+	openInspiredBy    map[string]struct{}
+}
+
+func buildLessonRelevanceFocus(ctx LessonRelevanceContext) lessonRelevanceFocus {
+	f := lessonRelevanceFocus{
+		instruments:       map[string]struct{}{},
+		tags:              map[string]struct{}{},
+		subjectReasons:    map[string]string{},
+		currentInspiredBy: map[string]struct{}{},
+		openInspiredBy:    map[string]struct{}{},
+	}
+	addInstrument := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return
+		}
+		f.instruments[name] = struct{}{}
+		f.tags[name] = struct{}{}
+	}
+	addTag := func(tag string) {
+		tag = strings.TrimSpace(tag)
+		if tag != "" {
+			f.tags[tag] = struct{}{}
+		}
+	}
+	addSubject := func(id, reason string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := f.subjectReasons[id]; !ok {
+			f.subjectReasons[id] = reason
+		}
+	}
+
+	if ctx.Goal != nil {
+		addInstrument(ctx.Goal.Objective.Instrument)
+		for _, c := range ctx.Goal.Constraints {
+			addInstrument(c.Instrument)
+		}
+		for _, r := range ctx.Goal.Rescuers {
+			addInstrument(r.Instrument)
+		}
+	}
+	if ctx.Hypothesis != nil {
+		addSubject(ctx.Hypothesis.ID, "current hypothesis")
+		addInstrument(ctx.Hypothesis.Predicts.Instrument)
+		addTag(ctx.Hypothesis.Predicts.Target)
+		for _, tag := range ctx.Hypothesis.Tags {
+			addTag(tag)
+		}
+		for _, id := range ctx.Hypothesis.InspiredBy {
+			f.currentInspiredBy[id] = struct{}{}
+		}
+	}
+	if ctx.FrontierBest != nil {
+		addSubject(ctx.FrontierBest.Hypothesis, "frontier hypothesis")
+		addSubject(ctx.FrontierBest.Candidate, "frontier experiment")
+		addSubject(ctx.FrontierBest.Conclusion, "frontier conclusion")
+	}
+	for _, h := range ctx.OpenHypotheses {
+		if h == nil {
+			continue
+		}
+		addSubject(h.ID, "open hypothesis")
+		addInstrument(h.Predicts.Instrument)
+		addTag(h.Predicts.Target)
+		for _, tag := range h.Tags {
+			addTag(tag)
+		}
+		for _, id := range h.InspiredBy {
+			f.openInspiredBy[id] = struct{}{}
+		}
+	}
+	for _, exp := range ctx.InFlightExperiments {
+		if exp == nil {
+			continue
+		}
+		addSubject(exp.ID, "in-flight experiment")
+		addSubject(exp.Hypothesis, "in-flight hypothesis")
+		for _, name := range exp.Instruments {
+			addInstrument(name)
+		}
+	}
+	return f
+}
+
+func scoreRelevantLesson(view *LessonReadView, focus lessonRelevanceFocus, decisiveCitations map[string]int, maxOrdinal int) (RelevantLessonView, bool) {
+	claim, truncated := SummarizeLessonClaim(view.Claim, LessonSummaryClaimLimit)
+	row := RelevantLessonView{
+		ID:             view.ID,
+		Scope:          view.Scope,
+		Status:         view.Status,
+		Tags:           copyStringSlice(view.Tags),
+		Subjects:       copyStringSlice(view.Subjects),
+		Claim:          claim,
+		ClaimTruncated: truncated,
+	}
+	if view.Provenance != nil {
+		row.SourceChain = view.Provenance.SourceChain
+	}
+
+	direct := false
+	add := func(points int, reason string) {
+		row.Score += points
+		addLessonRelevanceReason(&row, reason)
+	}
+	switch view.Status {
+	case entity.LessonStatusActive:
+		add(20, "active")
+	case entity.LessonStatusProvisional:
+		add(8, "provisional")
+	case entity.LessonStatusInvalidated:
+		add(-5, "invalidated")
+	case entity.LessonStatusSuperseded:
+		add(-20, "superseded")
+	}
+	if view.Scope == entity.LessonScopeSystem {
+		add(8, "system scope")
+	}
+	if _, ok := focus.currentInspiredBy[view.ID]; ok {
+		direct = true
+		add(100, "cited by current hypothesis")
+	}
+	if _, ok := focus.openInspiredBy[view.ID]; ok {
+		add(25, "cited by open hypothesis")
+	}
+	for _, subject := range view.Subjects {
+		if reason, ok := focus.subjectReasons[subject]; ok {
+			direct = true
+			add(60, "matches "+reason+" "+subject)
+		}
+	}
+	if view.PredictedEffect != nil {
+		if _, ok := focus.instruments[view.PredictedEffect.Instrument]; ok {
+			direct = true
+			add(25, "predicts relevant instrument "+view.PredictedEffect.Instrument)
+		}
+	}
+	matchingTags := lessonMatchingTags(view.Tags, focus.tags)
+	if len(matchingTags) > 0 {
+		direct = true
+		add(10*len(matchingTags), "tag match: "+strings.Join(matchingTags, ","))
+	}
+	if n := decisiveCitations[view.ID]; n > 0 {
+		add(8*n, fmt.Sprintf("cited by %d decisive conclusion(s)", n))
+	}
+	if n := lessonIDSortValue(view.ID); n > 0 && maxOrdinal > 0 {
+		switch age := maxOrdinal - n; {
+		case age <= 2:
+			add(5, "recent")
+		case age <= 5:
+			add(2, "recent")
+		}
+	}
+	return row, direct
+}
+
+func lessonMatchingTags(tags []string, focus map[string]struct{}) []string {
+	var matches []string
+	seen := map[string]struct{}{}
+	for _, tag := range tags {
+		tag = strings.TrimSpace(tag)
+		if tag == "" {
+			continue
+		}
+		if _, ok := focus[tag]; !ok {
+			continue
+		}
+		if _, dup := seen[tag]; dup {
+			continue
+		}
+		seen[tag] = struct{}{}
+		matches = append(matches, tag)
+	}
+	sort.Strings(matches)
+	return matches
+}
+
+func lessonDecisiveCitationCounts(hyps []*entity.Hypothesis, concls []*entity.Conclusion) map[string]int {
+	inspiredByHyp := map[string][]string{}
+	for _, h := range hyps {
+		if h == nil || len(h.InspiredBy) == 0 {
+			continue
+		}
+		inspiredByHyp[h.ID] = h.InspiredBy
+	}
+	out := map[string]int{}
+	for _, c := range concls {
+		if c == nil {
+			continue
+		}
+		if c.Verdict != entity.VerdictSupported && c.Verdict != entity.VerdictRefuted {
+			continue
+		}
+		for _, id := range inspiredByHyp[c.Hypothesis] {
+			out[id]++
+		}
+	}
+	return out
+}
+
+func addLessonRelevanceReason(row *RelevantLessonView, reason string) {
+	if strings.TrimSpace(reason) == "" || slices.Contains(row.Reasons, reason) {
+		return
+	}
+	row.Reasons = append(row.Reasons, reason)
+}
+
+func maxLessonOrdinal(views []*LessonReadView) int {
+	maxN := 0
+	for _, view := range views {
+		if view == nil {
+			continue
+		}
+		if n := lessonIDSortValue(view.ID); n > maxN {
+			maxN = n
+		}
+	}
+	return maxN
+}
+
+func lessonIDSortValue(id string) int {
+	n, err := parseLessonOrdinal(id)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/readmodel/lesson_relevance.go
+++ b/internal/readmodel/lesson_relevance.go
@@ -48,8 +48,8 @@ func RankRelevantLessons(views []*LessonReadView, ctx LessonRelevanceContext) []
 		if view == nil || view.Lesson == nil {
 			continue
 		}
-		row, direct := scoreRelevantLesson(view, focus, decisiveCitations, maxOrdinal)
-		if direct || row.Score > 0 {
+		row, eligible := scoreRelevantLesson(view, focus, decisiveCitations, maxOrdinal)
+		if eligible {
 			rows = append(rows, row)
 		}
 	}
@@ -175,7 +175,7 @@ func scoreRelevantLesson(view *LessonReadView, focus lessonRelevanceFocus, decis
 		row.SourceChain = view.Provenance.SourceChain
 	}
 
-	direct := false
+	eligible := false
 	add := func(points int, reason string) {
 		row.Score += points
 		addLessonRelevanceReason(&row, reason)
@@ -194,27 +194,28 @@ func scoreRelevantLesson(view *LessonReadView, focus lessonRelevanceFocus, decis
 		add(8, "system scope")
 	}
 	if _, ok := focus.currentInspiredBy[view.ID]; ok {
-		direct = true
+		eligible = true
 		add(100, "cited by current hypothesis")
 	}
 	if _, ok := focus.openInspiredBy[view.ID]; ok {
+		eligible = true
 		add(25, "cited by open hypothesis")
 	}
 	for _, subject := range view.Subjects {
 		if reason, ok := focus.subjectReasons[subject]; ok {
-			direct = true
+			eligible = true
 			add(60, "matches "+reason+" "+subject)
 		}
 	}
 	if view.PredictedEffect != nil {
 		if _, ok := focus.instruments[view.PredictedEffect.Instrument]; ok {
-			direct = true
+			eligible = true
 			add(25, "predicts relevant instrument "+view.PredictedEffect.Instrument)
 		}
 	}
 	matchingTags := lessonMatchingTags(view.Tags, focus.tags)
 	if len(matchingTags) > 0 {
-		direct = true
+		eligible = true
 		add(10*len(matchingTags), "tag match: "+strings.Join(matchingTags, ","))
 	}
 	if n := decisiveCitations[view.ID]; n > 0 {
@@ -228,7 +229,7 @@ func scoreRelevantLesson(view *LessonReadView, focus lessonRelevanceFocus, decis
 			add(2, "recent")
 		}
 	}
-	return row, direct
+	return row, eligible
 }
 
 func lessonMatchingTags(tags []string, focus map[string]struct{}) []string {

--- a/internal/readmodel/lesson_test.go
+++ b/internal/readmodel/lesson_test.go
@@ -153,4 +153,64 @@ var _ = Describe("lesson read views", func() {
 		_, err := ParseLessonFields("id,nope")
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("ranks direct, tagged, system, and invalidated lessons with explicit reasons", func() {
+		views := []*LessonReadView{
+			{Lesson: &entity.Lesson{
+				ID:     "L-0001",
+				Claim:  "inspired lesson",
+				Scope:  entity.LessonScopeHypothesis,
+				Status: entity.LessonStatusActive,
+				Tags:   []string{"histogram"},
+			}},
+			{Lesson: &entity.Lesson{
+				ID:     "L-0002",
+				Claim:  "invalidated timing warning",
+				Scope:  entity.LessonScopeHypothesis,
+				Status: entity.LessonStatusInvalidated,
+				Tags:   []string{"timing"},
+				PredictedEffect: &entity.PredictedEffect{
+					Instrument: "timing",
+					Direction:  "decrease",
+					MinEffect:  0.05,
+				},
+			}},
+			{Lesson: &entity.Lesson{
+				ID:     "L-0003",
+				Claim:  "system timing lesson",
+				Scope:  entity.LessonScopeSystem,
+				Status: entity.LessonStatusActive,
+				Tags:   []string{"timing"},
+			}},
+			{Lesson: &entity.Lesson{
+				ID:     "L-0004",
+				Claim:  "unrelated system lesson",
+				Scope:  entity.LessonScopeSystem,
+				Status: entity.LessonStatusActive,
+				Tags:   []string{"docs"},
+			}},
+		}
+
+		got := RankRelevantLessons(views, LessonRelevanceContext{
+			Goal: &entity.Goal{Objective: entity.Objective{Instrument: "timing", Direction: "decrease"}},
+			Hypothesis: &entity.Hypothesis{
+				ID:         "H-0001",
+				InspiredBy: []string{"L-0001"},
+				Predicts:   entity.Predicts{Instrument: "timing", Target: "kernel"},
+				Tags:       []string{"histogram"},
+			},
+			Limit: 3,
+		})
+
+		Expect(got).To(HaveLen(3))
+		Expect(got[0].ID).To(Equal("L-0001"))
+		Expect(got[0].Reasons).To(ContainElement("cited by current hypothesis"))
+		Expect(got).To(ContainElement(SatisfyAll(
+			HaveField("ID", "L-0002"),
+			HaveField("Status", entity.LessonStatusInvalidated),
+			HaveField("Reasons", ContainElement("invalidated")),
+		)))
+		Expect(got).To(ContainElement(HaveField("ID", "L-0003")))
+		Expect(got).NotTo(ContainElement(HaveField("ID", "L-0004")))
+	})
 })

--- a/internal/readmodel/lesson_test.go
+++ b/internal/readmodel/lesson_test.go
@@ -199,7 +199,7 @@ var _ = Describe("lesson read views", func() {
 				Predicts:   entity.Predicts{Instrument: "timing", Target: "kernel"},
 				Tags:       []string{"histogram"},
 			},
-			Limit: 3,
+			Limit: 10,
 		})
 
 		Expect(got).To(HaveLen(3))
@@ -212,5 +212,31 @@ var _ = Describe("lesson read views", func() {
 		)))
 		Expect(got).To(ContainElement(HaveField("ID", "L-0003")))
 		Expect(got).NotTo(ContainElement(HaveField("ID", "L-0004")))
+	})
+
+	It("does not treat status, system scope, or recency as relevance by themselves", func() {
+		views := []*LessonReadView{
+			{Lesson: &entity.Lesson{
+				ID:     "L-0001",
+				Claim:  "recent active system lesson",
+				Scope:  entity.LessonScopeSystem,
+				Status: entity.LessonStatusActive,
+				Tags:   []string{"docs"},
+			}},
+			{Lesson: &entity.Lesson{
+				ID:     "L-0002",
+				Claim:  "newer active hypothesis lesson",
+				Scope:  entity.LessonScopeHypothesis,
+				Status: entity.LessonStatusActive,
+				Tags:   []string{"unrelated"},
+			}},
+		}
+
+		got := RankRelevantLessons(views, LessonRelevanceContext{
+			Goal:  &entity.Goal{Objective: entity.Objective{Instrument: "timing", Direction: "decrease"}},
+			Limit: 10,
+		})
+
+		Expect(got).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
## Summary
- Add `lesson relevant` for ranked lesson subsets scoped by goal or hypothesis.
- Add a reusable relevance readmodel with scores, reasons, status, source, tags, and claim snippets.
- Include `relevant_lessons` in `cycle-context --json` while preserving `active_lessons`.

## Tests
- `make test`

Closes #68
