### PR TITLE
Improve baseline scope selection

### DIFF
--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -128,6 +128,9 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 				}
 				baselineRes, err = readmodel.ResolveInferredBaselineWithIndex(s, obsIdx, hyp, exp, analyzeBaselineInstrument(instName, hyp.Predicts.Instrument))
 				if err != nil {
+					if w.IsJSON() {
+						emitAnalyzeBaselineError(w, expID, "", err)
+					}
 					return err
 				}
 				if baselineRes == nil || baselineRes.ExperimentID == "" {

--- a/internal/cli/analyze.go
+++ b/internal/cli/analyze.go
@@ -20,10 +20,12 @@ func analyzeCommands() []*cobra.Command {
 
 func analyzeCmd() *cobra.Command {
 	var (
-		baselineExp  string
-		instName     string
-		iters        int
-		candidateRef string
+		baselineExp         string
+		baselineRef         string
+		baselineObservation string
+		instName            string
+		iters               int
+		candidateRef        string
 	)
 	c := &cobra.Command{
 		Use:   "analyze <exp-id>",
@@ -88,9 +90,28 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 			var baseObs []*entity.Observation
 			var baselineRes *readmodel.BaselineResolution
 			baselineExp = strings.TrimSpace(baselineExp)
+			baselineRef = strings.TrimSpace(baselineRef)
+			baselineObservation = strings.TrimSpace(baselineObservation)
+			if baselineExp == "" && baselineRef != "" {
+				return fmt.Errorf("--baseline-ref requires --baseline <baseline-exp-id>")
+			}
 			switch baselineExp {
 			case "":
+				if baselineObservation != "" {
+					obsIdx, err := readmodel.LoadObservationIndexStrict(s)
+					if err != nil {
+						return err
+					}
+					baseObs, baselineRes, err = selectAnalyzeBaselineObservations(s, obsIdx, "", instName, "", baselineObservation)
+					if err != nil {
+						return err
+					}
+					baselineExp = baselineRes.ExperimentID
+				}
 			case analyzeBaselineAuto:
+				if baselineRef != "" || baselineObservation != "" {
+					return fmt.Errorf("--baseline-ref and --baseline-observation cannot be combined with --baseline auto")
+				}
 				if exp.IsBaseline {
 					return fmt.Errorf("--baseline auto is only valid for non-baseline experiments")
 				}
@@ -105,34 +126,29 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 				if err != nil {
 					return err
 				}
-				baselineRes, err = readmodel.ResolveLineageSupportedBaselineWithIndex(s, obsIdx, hyp, hyp.Predicts.Instrument)
+				baselineRes, err = readmodel.ResolveInferredBaselineWithIndex(s, obsIdx, hyp, exp, analyzeBaselineInstrument(instName, hyp.Predicts.Instrument))
 				if err != nil {
 					return err
 				}
 				if baselineRes == nil || baselineRes.ExperimentID == "" {
-					note := "no usable lineage baseline"
+					note := "no usable baseline"
 					if baselineRes != nil && baselineRes.Note != "" {
 						note = baselineRes.Note
 					}
-					return fmt.Errorf("--baseline auto could not resolve a supported ancestor for experiment %s: %s", expID, note)
+					return fmt.Errorf("--baseline auto could not resolve a baseline for experiment %s: %s", expID, note)
 				}
 				baselineExp = baselineRes.ExperimentID
 				baseObs = obsIdx.ObservationsForScope(baselineRes.Scope())
 			default:
-				baseObs, err = s.ListObservationsForExperiment(baselineExp)
+				obsIdx, err := readmodel.LoadObservationIndexStrict(s)
 				if err != nil {
 					return err
 				}
-				if len(baseObs) == 0 {
-					return fmt.Errorf("baseline experiment %s has no observations", baselineExp)
-				}
-				if err := ensureAnalyzeObservationsSingleScope(
-					"baseline experiment",
-					baselineExp,
-					"recorded scopes",
-					baseObs,
-					"analyze requires a baseline experiment with a single recorded scope",
-				); err != nil {
+				baseObs, baselineRes, err = selectAnalyzeBaselineObservations(s, obsIdx, baselineExp, instName, baselineRef, baselineObservation)
+				if err != nil {
+					if w.IsJSON() {
+						emitAnalyzeBaselineError(w, expID, baselineExp, err)
+					}
 					return err
 				}
 			}
@@ -221,6 +237,8 @@ refs, pass --candidate-ref to analyze the specific measured candidate.`,
 		},
 	}
 	c.Flags().StringVar(&baselineExp, "baseline", "", "baseline experiment id to compare against, or 'auto' for the supported lineage predecessor")
+	c.Flags().StringVar(&baselineRef, "baseline-ref", "", "for an explicit --baseline experiment, restrict baseline observations to the stored ref")
+	c.Flags().StringVar(&baselineObservation, "baseline-observation", "", "use the baseline scope containing this observation id")
 	c.Flags().StringVar(&instName, "instrument", "", "only analyze this instrument")
 	c.Flags().IntVar(&iters, "iters", 0, "bootstrap iterations (0 uses default 2000)")
 	c.Flags().StringVar(&candidateRef, "candidate-ref", "", "for non-baseline experiments, restrict analysis to observations recorded on this candidate ref")

--- a/internal/cli/analyze_baseline.go
+++ b/internal/cli/analyze_baseline.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -175,17 +176,50 @@ func analyzeBaselineRefMatches(stored, ref string) bool {
 }
 
 func emitAnalyzeBaselineError(w *output.Writer, expID, baselineExp string, err error) {
-	selectionErr, ok := err.(*analyzeBaselineSelectionError)
-	if !ok || len(selectionErr.candidates) == 0 {
+	candidates, ok := analyzeBaselineErrorCandidates(err)
+	if !ok || len(candidates) == 0 {
 		return
 	}
+	baselineExp = inferAnalyzeBaselineErrorExperiment(baselineExp, candidates)
 	_ = w.JSON(map[string]any{
 		"status":              "error",
-		"error":               selectionErr.Error(),
+		"error":               err.Error(),
 		"experiment":          expID,
 		"baseline":            baselineExp,
-		"baseline_candidates": selectionErr.candidates,
+		"baseline_candidates": candidates,
 	})
+}
+
+func analyzeBaselineErrorCandidates(err error) ([]readmodel.BaselineCandidate, bool) {
+	var selectionErr *analyzeBaselineSelectionError
+	if errors.As(err, &selectionErr) {
+		return selectionErr.candidates, true
+	}
+	var scopeErr *readmodel.BaselineScopeAmbiguityError
+	if errors.As(err, &scopeErr) {
+		return scopeErr.Candidates, true
+	}
+	return nil, false
+}
+
+func inferAnalyzeBaselineErrorExperiment(expID string, candidates []readmodel.BaselineCandidate) string {
+	expID = strings.TrimSpace(expID)
+	if expID != "" {
+		return expID
+	}
+	seen := map[string]struct{}{}
+	for _, c := range candidates {
+		if strings.TrimSpace(c.Experiment) != "" {
+			seen[c.Experiment] = struct{}{}
+		}
+	}
+	if len(seen) != 1 {
+		return ""
+	}
+	for id := range seen {
+		return id
+	}
+	return ""
 }
 
 func analyzeBaselineInstrument(requested, fallback string) string {

--- a/internal/cli/analyze_baseline.go
+++ b/internal/cli/analyze_baseline.go
@@ -1,0 +1,196 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/output"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+type analyzeBaselineSelectionError struct {
+	message    string
+	candidates []readmodel.BaselineCandidate
+}
+
+func (e *analyzeBaselineSelectionError) Error() string { return e.message }
+
+func selectAnalyzeBaselineObservations(
+	s *store.Store,
+	obsIdx *readmodel.ObservationIndex,
+	expID string,
+	instrument string,
+	ref string,
+	observationID string,
+) ([]*entity.Observation, *readmodel.BaselineResolution, error) {
+	if expID == "" && observationID == "" {
+		return nil, nil, nil
+	}
+	if observationID != "" && ref != "" {
+		return nil, nil, fmt.Errorf("--baseline-ref and --baseline-observation are mutually exclusive")
+	}
+	if expID != "" {
+		if _, err := s.ReadExperiment(expID); err != nil {
+			return nil, nil, err
+		}
+	}
+	var (
+		baseObs []*entity.Observation
+		res     *readmodel.BaselineResolution
+		err     error
+	)
+	switch {
+	case observationID != "":
+		baseObs, res, err = selectAnalyzeBaselineObservationID(obsIdx, expID, instrument, observationID)
+	case ref != "":
+		baseObs, res, err = selectAnalyzeBaselineRef(obsIdx, expID, instrument, ref)
+	default:
+		baseObs, res, err = selectAnalyzeBaselineSingleScope(obsIdx, expID, instrument)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	if res != nil && res.ExperimentID != "" {
+		if _, err := s.ReadExperiment(res.ExperimentID); err != nil {
+			return nil, nil, err
+		}
+	}
+	return baseObs, res, nil
+}
+
+func selectAnalyzeBaselineObservationID(obsIdx *readmodel.ObservationIndex, expID, instrument, id string) ([]*entity.Observation, *readmodel.BaselineResolution, error) {
+	obs := obsIdx.ObservationByID(id)
+	if obs == nil {
+		return nil, nil, fmt.Errorf("baseline observation %s not found", id)
+	}
+	scope := readmodel.ObservationScopeFromObservation(obs)
+	if expID != "" && scope.Experiment != expID {
+		return nil, nil, fmt.Errorf("baseline observation %s belongs to experiment %s, not %s", id, scope.Experiment, expID)
+	}
+	expID = scope.Experiment
+	if expID == "" {
+		return nil, nil, fmt.Errorf("baseline observation %s does not record an experiment", id)
+	}
+	if instrument != "" && obs.Instrument != instrument {
+		return nil, nil, fmt.Errorf("baseline observation %s is on instrument %q, not %q", id, obs.Instrument, instrument)
+	}
+	baseObs := obsIdx.ObservationsForScope(scope)
+	if instrument != "" {
+		baseObs = filterObservationsByInstrument(baseObs, instrument)
+	}
+	if len(baseObs) == 0 {
+		return nil, nil, fmt.Errorf("baseline observation %s scope has no observations on instrument %q", id, instrument)
+	}
+	return baseObs, analyzeBaselineResolution(expID, scope), nil
+}
+
+func selectAnalyzeBaselineRef(obsIdx *readmodel.ObservationIndex, expID, instrument, ref string) ([]*entity.Observation, *readmodel.BaselineResolution, error) {
+	scopes := obsIdx.ScopesForExperimentInstrument(expID, instrument)
+	var matches []readmodel.ObservationScope
+	for _, scope := range scopes {
+		if analyzeBaselineRefMatches(scope.Ref, ref) {
+			matches = append(matches, scope)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, nil, fmt.Errorf("baseline experiment %s has no observations for baseline ref %s", expID, ref)
+	case 1:
+		baseObs := obsIdx.ObservationsForScope(matches[0])
+		if instrument != "" {
+			baseObs = filterObservationsByInstrument(baseObs, instrument)
+		}
+		return baseObs, analyzeBaselineResolution(expID, matches[0]), nil
+	default:
+		return nil, nil, analyzeBaselineAmbiguousError(
+			fmt.Sprintf("baseline experiment %s has multiple observation scopes for baseline ref %s", expID, ref),
+			obsIdx, expID, instrument,
+		)
+	}
+}
+
+func selectAnalyzeBaselineSingleScope(obsIdx *readmodel.ObservationIndex, expID, instrument string) ([]*entity.Observation, *readmodel.BaselineResolution, error) {
+	var scopes []readmodel.ObservationScope
+	if instrument != "" {
+		scopes = obsIdx.ScopesForExperimentInstrument(expID, instrument)
+	} else {
+		scopes = obsIdx.ScopesForExperiment(expID)
+	}
+	switch len(scopes) {
+	case 0:
+		if instrument != "" {
+			return nil, nil, fmt.Errorf("baseline experiment %s has no observations on instrument %q", expID, instrument)
+		}
+		return nil, nil, fmt.Errorf("baseline experiment %s has no observations", expID)
+	case 1:
+		baseObs := obsIdx.ObservationsForScope(scopes[0])
+		if instrument != "" {
+			baseObs = filterObservationsByInstrument(baseObs, instrument)
+		}
+		return baseObs, analyzeBaselineResolution(expID, scopes[0]), nil
+	default:
+		return nil, nil, analyzeBaselineAmbiguousError(
+			fmt.Sprintf("baseline experiment %s has observations for multiple recorded scopes (%s); analyze requires a baseline selector",
+				expID, strings.Join(readmodel.SortedObservationScopeLabels(scopes), ", ")),
+			obsIdx, expID, instrument,
+		)
+	}
+}
+
+func analyzeBaselineResolution(expID string, scope readmodel.ObservationScope) *readmodel.BaselineResolution {
+	return &readmodel.BaselineResolution{
+		ExperimentID: expID,
+		Attempt:      scope.Attempt,
+		Ref:          scope.Ref,
+		SHA:          scope.SHA,
+		Source:       readmodel.BaselineSourceExplicit,
+	}
+}
+
+func analyzeBaselineAmbiguousError(message string, obsIdx *readmodel.ObservationIndex, expID, instrument string) error {
+	return &analyzeBaselineSelectionError{
+		message:    message,
+		candidates: obsIdx.BaselineCandidatesForExperimentInstrument(expID, instrument),
+	}
+}
+
+func analyzeBaselineRefMatches(stored, ref string) bool {
+	stored = strings.TrimSpace(stored)
+	ref = strings.TrimSpace(ref)
+	if stored == "" || ref == "" {
+		return false
+	}
+	if stored == ref {
+		return true
+	}
+	if strings.TrimPrefix(stored, "refs/heads/") == ref {
+		return true
+	}
+	if strings.TrimPrefix(stored, "refs/tags/") == ref {
+		return true
+	}
+	return false
+}
+
+func emitAnalyzeBaselineError(w *output.Writer, expID, baselineExp string, err error) {
+	selectionErr, ok := err.(*analyzeBaselineSelectionError)
+	if !ok || len(selectionErr.candidates) == 0 {
+		return
+	}
+	_ = w.JSON(map[string]any{
+		"status":              "error",
+		"error":               selectionErr.Error(),
+		"experiment":          expID,
+		"baseline":            baselineExp,
+		"baseline_candidates": selectionErr.candidates,
+	})
+}
+
+func analyzeBaselineInstrument(requested, fallback string) string {
+	if strings.TrimSpace(requested) != "" {
+		return strings.TrimSpace(requested)
+	}
+	return strings.TrimSpace(fallback)
+}

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -121,6 +121,29 @@ var _ = Describe("analyze command", func() {
 		))
 	})
 
+	It("emits machine-readable baseline candidates for ambiguous inferred baselines", func() {
+		fx := setupAnalyzeScopedBaselineFixture()
+
+		stdout, _, err := runCLIResult(fx.dir,
+			"--json",
+			"analyze", fx.candidateID,
+			"--candidate-ref", fx.candidateRef,
+			"--baseline", "auto",
+			"--instrument", "timing",
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("candidate recorded baseline " + fx.baselineID + " has multiple observation scopes")))
+		var payload analyzeBaselineErrorResponse
+		Expect(json.Unmarshal([]byte(stdout), &payload)).To(Succeed(), "stdout:\n%s", stdout)
+		Expect(payload.Status).To(Equal("error"))
+		Expect(payload.Experiment).To(Equal(fx.candidateID))
+		Expect(payload.Baseline).To(Equal(fx.baselineID))
+		Expect(payload.BaselineCandidates).To(ConsistOf(
+			HaveField("Ref", fx.baselineRefA),
+			HaveField("Ref", fx.baselineRefB),
+		))
+	})
+
 	It("uses --baseline-ref to disambiguate a baseline experiment", func() {
 		fx := setupAnalyzeScopedBaselineFixture()
 
@@ -383,6 +406,21 @@ func setupAnalyzeScopedBaselineFixture() analyzeScopedBaselineFixture {
 
 	dir, s := createCLIStoreDir()
 	now := time.Now().UTC()
+	Expect(s.WriteGoal(&entity.Goal{
+		ID:        "G-0001",
+		Status:    entity.GoalStatusActive,
+		CreatedAt: &now,
+		Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+	})).To(Succeed())
+	Expect(s.WriteHypothesis(&entity.Hypothesis{
+		ID:        "H-0001",
+		GoalID:    "G-0001",
+		Claim:     "stack on the measured baseline",
+		Status:    entity.StatusOpen,
+		Author:    "test",
+		CreatedAt: now,
+		Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+	})).To(Succeed())
 	baselineRefA := "refs/heads/baseline/E-0001-a1"
 	baselineRefB := "refs/heads/baseline/E-0001-a2"
 	candidateRef := "refs/heads/candidate/E-0002-a1"

--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/bytter/autoresearch/internal/entity"
@@ -9,6 +11,14 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+type analyzeBaselineErrorResponse struct {
+	Status             string                        `json:"status"`
+	Error              string                        `json:"error"`
+	Experiment         string                        `json:"experiment"`
+	Baseline           string                        `json:"baseline"`
+	BaselineCandidates []readmodel.BaselineCandidate `json:"baseline_candidates"`
+}
 
 var _ = Describe("analyze command", func() {
 	BeforeEach(saveGlobals)
@@ -72,6 +82,82 @@ var _ = Describe("analyze command", func() {
 			"--baseline", baselineID,
 		)
 		Expect(err).To(MatchError(ContainSubstring("baseline experiment " + baselineID + " has observations for multiple recorded scopes")))
+	})
+
+	It("emits machine-readable baseline candidates for ambiguous JSON analysis", func() {
+		fx := setupAnalyzeScopedBaselineFixture()
+
+		stdout, _, err := runCLIResult(fx.dir,
+			"--json",
+			"analyze", fx.candidateID,
+			"--candidate-ref", fx.candidateRef,
+			"--baseline", fx.baselineID,
+			"--instrument", "timing",
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("baseline experiment " + fx.baselineID + " has observations for multiple recorded scopes")))
+		var payload analyzeBaselineErrorResponse
+		Expect(json.Unmarshal([]byte(stdout), &payload)).To(Succeed(), "stdout:\n%s", stdout)
+		Expect(payload.Status).To(Equal("error"))
+		Expect(payload.Experiment).To(Equal(fx.candidateID))
+		Expect(payload.Baseline).To(Equal(fx.baselineID))
+		Expect(payload.BaselineCandidates).To(ConsistOf(
+			SatisfyAll(
+				HaveField("Experiment", fx.baselineID),
+				HaveField("Attempt", 1),
+				HaveField("Ref", fx.baselineRefA),
+				HaveField("Observations", ConsistOf("O-0001")),
+				HaveField("Instruments", ConsistOf("timing")),
+				HaveField("Samples", 3),
+			),
+			SatisfyAll(
+				HaveField("Experiment", fx.baselineID),
+				HaveField("Attempt", 2),
+				HaveField("Ref", fx.baselineRefB),
+				HaveField("Observations", ConsistOf("O-0002")),
+				HaveField("Instruments", ConsistOf("timing")),
+				HaveField("Samples", 3),
+			),
+		))
+	})
+
+	It("uses --baseline-ref to disambiguate a baseline experiment", func() {
+		fx := setupAnalyzeScopedBaselineFixture()
+
+		resp := runCLIJSON[cliAnalyzeResponse](fx.dir,
+			"analyze", fx.candidateID,
+			"--candidate-ref", fx.candidateRef,
+			"--baseline", fx.baselineID,
+			"--baseline-ref", strings.TrimPrefix(fx.baselineRefB, "refs/heads/"),
+			"--instrument", "timing",
+		)
+
+		Expect(resp.Baseline).To(Equal(fx.baselineID))
+		Expect(resp.BaselineResolution).NotTo(BeNil())
+		Expect(resp.BaselineResolution.Source).To(Equal(readmodel.BaselineSourceExplicit))
+		Expect(resp.BaselineResolution.Attempt).To(Equal(2))
+		Expect(resp.BaselineResolution.Ref).To(Equal(fx.baselineRefB))
+		Expect(resp.Rows).To(HaveLen(1))
+		Expect(resp.Rows[0].Comparison).NotTo(BeNil())
+	})
+
+	It("uses --baseline-observation to infer and disambiguate the baseline scope", func() {
+		fx := setupAnalyzeScopedBaselineFixture()
+
+		resp := runCLIJSON[cliAnalyzeResponse](fx.dir,
+			"analyze", fx.candidateID,
+			"--candidate-ref", fx.candidateRef,
+			"--baseline-observation", "O-0001",
+			"--instrument", "timing",
+		)
+
+		Expect(resp.Baseline).To(Equal(fx.baselineID))
+		Expect(resp.BaselineResolution).NotTo(BeNil())
+		Expect(resp.BaselineResolution.Source).To(Equal(readmodel.BaselineSourceExplicit))
+		Expect(resp.BaselineResolution.Attempt).To(Equal(1))
+		Expect(resp.BaselineResolution.Ref).To(Equal(fx.baselineRefA))
+		Expect(resp.Rows).To(HaveLen(1))
+		Expect(resp.Rows[0].Comparison).NotTo(BeNil())
 	})
 
 	It("rejects a candidate ref that maps to multiple recorded scopes", func() {
@@ -173,7 +259,172 @@ var _ = Describe("analyze command", func() {
 		Expect(resp.Rows).To(HaveLen(1))
 		Expect(resp.Rows[0].Comparison).NotTo(BeNil())
 	})
+
+	It("resolves --baseline auto through a candidate-recorded supported predecessor", func() {
+		dir, s := createCLIStoreDir()
+		now := time.Now().UTC()
+		Expect(s.WriteGoal(&entity.Goal{
+			ID:        "G-0001",
+			Status:    entity.GoalStatusActive,
+			CreatedAt: &now,
+			Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0001",
+			GoalID:    "G-0001",
+			Claim:     "first win",
+			Status:    entity.StatusSupported,
+			Author:    "test",
+			CreatedAt: now,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0002",
+			GoalID:    "G-0001",
+			Parent:    "H-0001",
+			Claim:     "stacked win",
+			Status:    entity.StatusOpen,
+			Author:    "test",
+			CreatedAt: now,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+		})).To(Succeed())
+		for _, exp := range []*entity.Experiment{
+			{ID: "E-0001", GoalID: "G-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured, Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+			{ID: "E-0002", GoalID: "G-0001", Hypothesis: "H-0002", Status: entity.ExpMeasured, Baseline: entity.Baseline{Ref: "HEAD", Experiment: "E-0001"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+		} {
+			Expect(s.WriteExperiment(exp)).To(Succeed())
+		}
+		Expect(s.WriteObservation(&entity.Observation{
+			ID: "O-0001", Experiment: "E-0001", Instrument: "timing",
+			MeasuredAt: now, Value: 100, Unit: "ns", PerSample: []float64{100, 101, 99}, Samples: 3,
+			CandidateRef: "refs/heads/candidate/E-0001-a1", CandidateSHA: strings.Repeat("1", 40), Attempt: 1, Author: "test",
+		})).To(Succeed())
+		ref := "refs/heads/candidate/E-0002-a1"
+		Expect(s.WriteObservation(&entity.Observation{
+			ID: "O-0002", Experiment: "E-0002", Instrument: "timing",
+			MeasuredAt: now, Value: 90, Unit: "ns", PerSample: []float64{90, 91, 89}, Samples: 3,
+			CandidateRef: ref, CandidateSHA: strings.Repeat("2", 40), Attempt: 1, Author: "test",
+		})).To(Succeed())
+		Expect(s.WriteConclusion(&entity.Conclusion{
+			ID: "C-0001", Hypothesis: "H-0001", Verdict: entity.VerdictSupported,
+			Observations: []string{"O-0001"}, CandidateExp: "E-0001",
+			CandidateAttempt: 1, CandidateRef: "refs/heads/candidate/E-0001-a1", CandidateSHA: strings.Repeat("1", 40),
+			Effect: entity.Effect{Instrument: "timing", DeltaFrac: -0.1}, StatTest: "mann_whitney_u",
+			Author: "test", ReviewedBy: "human:gate", CreatedAt: now,
+		})).To(Succeed())
+
+		resp := runCLIJSON[cliAnalyzeResponse](dir,
+			"analyze", "E-0002",
+			"--candidate-ref", ref,
+			"--baseline", "auto",
+			"--instrument", "timing",
+		)
+
+		Expect(resp.Baseline).To(Equal("E-0001"))
+		Expect(resp.BaselineResolution).NotTo(BeNil())
+		Expect(resp.BaselineResolution.ExperimentID).To(Equal("E-0001"))
+		Expect(resp.BaselineResolution.Source).To(Equal(readmodel.BaselineSourceCandidateRecorded))
+		Expect(resp.BaselineResolution.Attempt).To(Equal(1))
+		Expect(resp.Rows[0].Comparison).NotTo(BeNil())
+	})
+
+	It("reports when --baseline auto has no compatible baseline", func() {
+		dir, s := createCLIStoreDir()
+		now := time.Now().UTC()
+		Expect(s.WriteGoal(&entity.Goal{
+			ID:        "G-0001",
+			Status:    entity.GoalStatusActive,
+			CreatedAt: &now,
+			Objective: entity.Objective{Instrument: "timing", Direction: "decrease"},
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0001",
+			GoalID:    "G-0001",
+			Claim:     "candidate without baseline",
+			Status:    entity.StatusOpen,
+			Author:    "test",
+			CreatedAt: now,
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.05},
+		})).To(Succeed())
+		Expect(s.WriteExperiment(&entity.Experiment{
+			ID: "E-0001", GoalID: "G-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured,
+			Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now,
+		})).To(Succeed())
+		ref := "refs/heads/candidate/E-0001-a1"
+		Expect(s.WriteObservation(&entity.Observation{
+			ID: "O-0001", Experiment: "E-0001", Instrument: "timing",
+			MeasuredAt: now, Value: 90, Unit: "ns", PerSample: []float64{90, 91, 89}, Samples: 3,
+			CandidateRef: ref, CandidateSHA: strings.Repeat("1", 40), Attempt: 1, Author: "test",
+		})).To(Succeed())
+
+		_, _, err := runCLIResult(dir,
+			"analyze", "E-0001",
+			"--candidate-ref", ref,
+			"--baseline", "auto",
+			"--instrument", "timing",
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("--baseline auto could not resolve")))
+		Expect(err).To(MatchError(ContainSubstring("goal G-0001 has no recorded baseline experiment")))
+	})
 })
+
+type analyzeScopedBaselineFixture struct {
+	dir          string
+	baselineID   string
+	baselineRefA string
+	baselineRefB string
+	candidateID  string
+	candidateRef string
+}
+
+func setupAnalyzeScopedBaselineFixture() analyzeScopedBaselineFixture {
+	GinkgoHelper()
+
+	dir, s := createCLIStoreDir()
+	now := time.Now().UTC()
+	baselineRefA := "refs/heads/baseline/E-0001-a1"
+	baselineRefB := "refs/heads/baseline/E-0001-a2"
+	candidateRef := "refs/heads/candidate/E-0002-a1"
+	for _, exp := range []*entity.Experiment{
+		{ID: "E-0001", GoalID: "G-0001", IsBaseline: true, Status: entity.ExpMeasured, Baseline: entity.Baseline{Ref: "HEAD"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+		{ID: "E-0002", GoalID: "G-0001", Hypothesis: "H-0001", Status: entity.ExpMeasured, Baseline: entity.Baseline{Ref: "HEAD", Experiment: "E-0001"}, Instruments: []string{"timing"}, Author: "test", CreatedAt: now},
+	} {
+		Expect(s.WriteExperiment(exp)).To(Succeed())
+	}
+	for _, o := range []*entity.Observation{
+		{
+			ID: "O-0001", Experiment: "E-0001", Instrument: "timing", Attempt: 1,
+			CandidateRef: baselineRefA, CandidateSHA: strings.Repeat("a", 40),
+			Value: 100, PerSample: []float64{100, 101, 99},
+		},
+		{
+			ID: "O-0002", Experiment: "E-0001", Instrument: "timing", Attempt: 2,
+			CandidateRef: baselineRefB, CandidateSHA: strings.Repeat("b", 40),
+			Value: 120, PerSample: []float64{120, 121, 119},
+		},
+		{
+			ID: "O-0003", Experiment: "E-0002", Instrument: "timing", Attempt: 1,
+			CandidateRef: candidateRef, CandidateSHA: strings.Repeat("c", 40),
+			Value: 90, PerSample: []float64{90, 91, 89},
+		},
+	} {
+		o.MeasuredAt = now
+		o.Unit = "ns"
+		o.Samples = len(o.PerSample)
+		o.Author = "test"
+		Expect(s.WriteObservation(o)).To(Succeed())
+	}
+
+	return analyzeScopedBaselineFixture{
+		dir:          dir,
+		baselineID:   "E-0001",
+		baselineRefA: baselineRefA,
+		baselineRefB: baselineRefB,
+		candidateID:  "E-0002",
+		candidateRef: candidateRef,
+	}
+}
 
 func setupAnalyzeAmbiguousBaseline() (string, string) {
 	GinkgoHelper()

--- a/internal/cli/cycle_context.go
+++ b/internal/cli/cycle_context.go
@@ -238,6 +238,8 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 
 	expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(exps, hyps)
 	inFlight, _ := readmodel.BuildExperimentActivity(exps, expClassByID, events, 0, inputs.now)
+	obsIdx := readmodel.NewObservationIndex(obs)
+	inFlight = addCycleContextBaselineRecommendations(s, inFlight, exps, hyps, obsIdx)
 
 	activeLessonViews, err := readmodel.ListLessonsForRead(s, lessons, readmodel.LessonListOptions{Status: entity.LessonStatusActive})
 	if err != nil {
@@ -260,7 +262,7 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 	}
 
 	if goal != nil {
-		frontier := readmodel.BuildFrontierSnapshot(goal, concls, readmodel.NewObservationIndex(obs), expClassByID)
+		frontier := readmodel.BuildFrontierSnapshot(goal, concls, obsIdx, expClassByID)
 		if len(frontier.Rows) > 0 {
 			best := frontier.Rows[0]
 			frontierBest = &best
@@ -284,6 +286,46 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 
 	counts := readmodel.BuildCountsWithLessons(len(hyps), len(exps), len(obs), len(concls), len(lessons))
 	return payload, counts, nil
+}
+
+func addCycleContextBaselineRecommendations(
+	s *store.Store,
+	inFlight []dashboardInFlight,
+	exps []*entity.Experiment,
+	hyps []*entity.Hypothesis,
+	obsIdx *readmodel.ObservationIndex,
+) []dashboardInFlight {
+	expByID := make(map[string]*entity.Experiment, len(exps))
+	for _, exp := range exps {
+		if exp != nil {
+			expByID[exp.ID] = exp
+		}
+	}
+	hypByID := make(map[string]*entity.Hypothesis, len(hyps))
+	for _, hyp := range hyps {
+		if hyp != nil {
+			hypByID[hyp.ID] = hyp
+		}
+	}
+	out := make([]dashboardInFlight, len(inFlight))
+	copy(out, inFlight)
+	for i := range out {
+		exp := expByID[out[i].ID]
+		if exp == nil {
+			continue
+		}
+		hyp := hypByID[exp.Hypothesis]
+		if hyp == nil {
+			continue
+		}
+		instrument := analyzeBaselineInstrument("", hyp.Predicts.Instrument)
+		res, err := readmodel.ResolveInferredBaselineWithIndex(s, obsIdx, hyp, exp, instrument)
+		if err != nil {
+			res = &readmodel.BaselineResolution{Note: err.Error()}
+		}
+		out[i].RecommendedBaseline = res
+	}
+	return out
 }
 
 func openHypotheses(hyps []*entity.Hypothesis) []*entity.Hypothesis {

--- a/internal/cli/cycle_context_test.go
+++ b/internal/cli/cycle_context_test.go
@@ -16,10 +16,11 @@ type cliCycleContextAssessment struct {
 }
 
 type cliCycleContextInFlight struct {
-	ID          string   `json:"id"`
-	Hypothesis  string   `json:"hypothesis"`
-	Status      string   `json:"status"`
-	Instruments []string `json:"instruments"`
+	ID                  string                        `json:"id"`
+	Hypothesis          string                        `json:"hypothesis"`
+	Status              string                        `json:"status"`
+	Instruments         []string                      `json:"instruments"`
+	RecommendedBaseline *readmodel.BaselineResolution `json:"recommended_baseline,omitempty"`
 }
 
 type cliCycleContextGoal struct {
@@ -146,6 +147,17 @@ var _ = Describe("cycle-context command", func() {
 		Expect(ctx.GoalAssessment.MetByConclusion).To(Equal(concl.ID))
 		Expect(ctx.OpenHypotheses).To(ContainElement(HaveField("ID", open.HypothesisID)))
 		Expect(ctx.InFlight).To(ContainElement(HaveField("ID", open.ExperimentID)))
+		var openInFlight *cliCycleContextInFlight
+		for i := range ctx.InFlight {
+			if ctx.InFlight[i].ID == open.ExperimentID {
+				openInFlight = &ctx.InFlight[i]
+				break
+			}
+		}
+		Expect(openInFlight).NotTo(BeNil())
+		Expect(openInFlight.RecommendedBaseline).NotTo(BeNil())
+		Expect(openInFlight.RecommendedBaseline.ExperimentID).To(Equal(fixture.BaselineID))
+		Expect(openInFlight.RecommendedBaseline.Source).To(Equal(readmodel.BaselineSourceGoalBaseline))
 		Expect(ctx.ActiveLessons).To(ContainElement(SatisfyAll(
 			HaveField("ID", lesson.ID),
 			HaveField("Status", entity.LessonStatusActive),

--- a/internal/cli/scenario_helpers_test.go
+++ b/internal/cli/scenario_helpers_test.go
@@ -34,9 +34,13 @@ type cliAnalyzeResponse struct {
 	Baseline           string `json:"baseline"`
 	BaselineResolution *struct {
 		ExperimentID       string `json:"experiment"`
+		Attempt            int    `json:"attempt"`
+		Ref                string `json:"ref"`
+		SHA                string `json:"sha"`
 		Source             string `json:"source"`
 		AncestorHypothesis string `json:"ancestor_hypothesis"`
 		AncestorConclusion string `json:"ancestor_conclusion"`
+		Note               string `json:"note"`
 	} `json:"baseline_resolution,omitempty"`
 	Rows []struct {
 		Instrument string `json:"instrument"`

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -155,7 +155,7 @@ before you reach for `--help`:
     autoresearch experiment design <H-id> --baseline HEAD --instruments ... --design-notes "..." --author agent:orchestrator --json
     autoresearch experiment implement <E-id> --impl-notes "..." --json
     autoresearch observe <E-id> --all --candidate-ref <ref> --json
-    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto] --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto|--baseline <E-id> [--baseline-ref <ref>]|--baseline-observation O-XXXX] --json
     autoresearch conclude <H-id> --verdict ... --observations O-... --interpretation "..." --author agent:orchestrator --json
     autoresearch lesson add ... --from <C-id> --author agent:orchestrator --json   # decisive conclusions
     # then yield to the main session with review pending so it can dispatch research-gate-reviewer
@@ -382,9 +382,16 @@ If an instrument fails, stop and report — do not retry or fix.
 autoresearch analyze <exp-id> --candidate-ref <candidate-ref> --baseline auto --json
 ```
 
-Use `--baseline auto` when the hypothesis has accepted supported ancestry;
-for a root hypothesis with no supported predecessor yet, omit `--baseline`
-and let `conclude` resolve the absolute baseline fallback.
+Use `--baseline auto` when the tool can infer the comparison from the
+candidate-recorded baseline, accepted supported ancestry, or goal baseline.
+For a root hypothesis with no compatible measured baseline yet, omit
+`--baseline` and let `conclude` resolve the absolute baseline fallback.
+If an explicit baseline experiment has multiple measured scopes, pass
+`--baseline-ref <stored-ref>` or `--baseline-observation O-XXXX`; JSON
+ambiguity errors include `baseline_candidates` with refs, SHAs,
+observation IDs, instruments, and sample counts. `cycle-context --json`
+reports `recommended_baseline` on in-flight work when the tool can infer
+one.
 
 Read the `comparison` object: `delta_frac`, `ci_low_frac`,
 `ci_high_frac`, `p_value`. Then decide:

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -140,7 +140,7 @@ For the routine optimization loop, the canonical command spine is:
     autoresearch experiment implement <E-id> --impl-notes "..." --json
     # create a unique reviewable git ref for the measured candidate, then:
     autoresearch observe <E-id> --all --candidate-ref <ref> --json
-    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto] --json
+    autoresearch analyze <E-id> --candidate-ref <ref> [--baseline auto|--baseline <E-id> [--baseline-ref <ref>]|--baseline-observation O-XXXX] --json
     # when drift is a risk, use a paired measurement unit:
     autoresearch observe-pair <E-id> --baseline <baseline-E-id> --instrument NAME --candidate-ref <ref> --samples N --mode interleave --json
     autoresearch analyze-pair <P-id> --json
@@ -293,7 +293,7 @@ observations in the conclusion as usual.
     autoresearch observe  <exp-id> --all --candidate-ref REF [--samples N] [--append]         # all instruments in dependency order
     autoresearch observe-pair <candidate-exp> --baseline <baseline-exp> --instrument NAME --candidate-ref REF [--baseline-ref REF] [--samples N] [--mode interleave|bracket]
     autoresearch observation show <O-id> [--include-raw]                    # read-only; raw samples are bounded
-    autoresearch analyze  <exp-id> [--candidate-ref REF] [--baseline <baseline-exp-id>|auto] [--instrument NAME] [--iters N]
+    autoresearch analyze  <exp-id> [--candidate-ref REF] [--baseline <baseline-exp-id>|auto] [--baseline-ref REF] [--baseline-observation O-XXXX] [--instrument NAME] [--iters N]
     autoresearch analyze-pair <P-id> [--iters N]                            # read-only paired delta + drift diagnostics
     autoresearch review-packet <C-id>                                       # read-only gate-review evidence bundle
     autoresearch conclude <hyp-id> \
@@ -301,6 +301,11 @@ observations in the conclusion as usual.
         --observations O-XXXX,O-YYYY \
         [--baseline-experiment E-XXXX|auto] \   # strict override; otherwise auto-derive baseline
         [--interpretation "..."]
+        # analyze --baseline auto uses the same inferred absolute baseline order
+        # as conclude. If an explicit baseline experiment has multiple measured
+        # scopes, use --baseline-ref or --baseline-observation; JSON errors include
+        # baseline_candidates with refs, SHAs, observation IDs, instruments, samples.
+        # cycle-context --json also reports recommended_baseline on in-flight work.
         # Dual baseline: absolute prefers candidate-recorded baseline, then the
         # nearest accepted supported ancestor, then the goal baseline; incremental
         # uses the nearest accepted supported lineage predecessor. Output reports

--- a/internal/readmodel/baseline.go
+++ b/internal/readmodel/baseline.go
@@ -210,7 +210,11 @@ func resolveAncestorSupportedBaseline(s *store.Store, hyp *entity.Hypothesis, in
 			for scope := range usableByScope {
 				scopeLabels = append(scopeLabels, scope)
 			}
-			return nil, "", fmt.Errorf("ancestor %s has multiple accepted supported candidate scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(SortedObservationScopeLabels(scopeLabels), ", "))
+			message := fmt.Sprintf("ancestor %s has multiple accepted supported candidate scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", parentID, instrument, strings.Join(SortedObservationScopeLabels(scopeLabels), ", "))
+			return nil, "", &BaselineScopeAmbiguityError{
+				Message:    message,
+				Candidates: obs.BaselineCandidatesForScopes(scopeLabels, instrument),
+			}
 		}
 
 		parentID = strings.TrimSpace(parent.Parent)
@@ -261,7 +265,11 @@ func resolveGoalBaseline(s *store.Store, goalID, instrument string, obs *Observa
 			Source:       BaselineSourceGoalBaseline,
 		}, joinNotes(notes...), nil
 	default:
-		return nil, "", fmt.Errorf("goal %s has multiple baseline scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", goalID, instrument, strings.Join(SortedObservationScopeLabels(usable), ", "))
+		message := fmt.Sprintf("goal %s has multiple baseline scopes with observations on instrument %q: %s; pass --baseline-experiment explicitly", goalID, instrument, strings.Join(SortedObservationScopeLabels(usable), ", "))
+		return nil, "", &BaselineScopeAmbiguityError{
+			Message:    message,
+			Candidates: obs.BaselineCandidatesForScopes(usable, instrument),
+		}
 	}
 }
 
@@ -305,7 +313,11 @@ func ResolveExperimentInstrumentScope(s *store.Store, obs *ObservationIndex, exp
 	case 1:
 		return scopes[0], true, "", nil
 	default:
-		return ObservationScope{}, false, "", fmt.Errorf("%s %s has multiple observation scopes on instrument %q: %s", label, expID, instrument, strings.Join(SortedObservationScopeLabels(scopes), ", "))
+		message := fmt.Sprintf("%s %s has multiple observation scopes on instrument %q: %s", label, expID, instrument, strings.Join(SortedObservationScopeLabels(scopes), ", "))
+		return ObservationScope{}, false, "", &BaselineScopeAmbiguityError{
+			Message:    message,
+			Candidates: obs.BaselineCandidatesForScopes(scopes, instrument),
+		}
 	}
 }
 

--- a/internal/readmodel/experiment.go
+++ b/internal/readmodel/experiment.go
@@ -40,12 +40,13 @@ type StaleExperimentView struct {
 // InFlightExperimentView is the read model shared by dashboard/TUI for active
 // experiments that still need human or agent attention.
 type InFlightExperimentView struct {
-	ID            string     `json:"id"`
-	Hypothesis    string     `json:"hypothesis"`
-	Status        string     `json:"status"`
-	Instruments   []string   `json:"instruments"`
-	ImplementedAt *time.Time `json:"implemented_at,omitempty"`
-	ElapsedS      float64    `json:"elapsed_s"`
+	ID                  string              `json:"id"`
+	Hypothesis          string              `json:"hypothesis"`
+	Status              string              `json:"status"`
+	Instruments         []string            `json:"instruments"`
+	RecommendedBaseline *BaselineResolution `json:"recommended_baseline,omitempty"`
+	ImplementedAt       *time.Time          `json:"implemented_at,omitempty"`
+	ElapsedS            float64             `json:"elapsed_s"`
 }
 
 func normalizeExperimentReadClass(class ExperimentReadClass) ExperimentReadClass {

--- a/internal/readmodel/observation_scope.go
+++ b/internal/readmodel/observation_scope.go
@@ -51,6 +51,13 @@ type BaselineCandidate struct {
 	Samples      int      `json:"samples"`
 }
 
+type BaselineScopeAmbiguityError struct {
+	Message    string              `json:"-"`
+	Candidates []BaselineCandidate `json:"baseline_candidates"`
+}
+
+func (e *BaselineScopeAmbiguityError) Error() string { return e.Message }
+
 func LoadObservationIndex(s *store.Store) *ObservationIndex {
 	idx, err := LoadObservationIndexStrict(s)
 	if err != nil {
@@ -193,6 +200,14 @@ func (idx *ObservationIndex) BaselineCandidatesForExperimentInstrument(expID, in
 		return []BaselineCandidate{}
 	}
 	scopes := idx.ScopesForExperimentInstrument(expID, instrument)
+	return idx.BaselineCandidatesForScopes(scopes, instrument)
+}
+
+func (idx *ObservationIndex) BaselineCandidatesForScopes(scopes []ObservationScope, instrument string) []BaselineCandidate {
+	if idx == nil {
+		return []BaselineCandidate{}
+	}
+	instrument = strings.TrimSpace(instrument)
 	out := make([]BaselineCandidate, 0, len(scopes))
 	for _, scope := range scopes {
 		obs := idx.ObservationsForScope(scope)

--- a/internal/readmodel/observation_scope.go
+++ b/internal/readmodel/observation_scope.go
@@ -40,6 +40,17 @@ type ObservationIndex struct {
 	scopesByExperiment map[string][]ObservationScope
 }
 
+type BaselineCandidate struct {
+	Experiment   string   `json:"experiment"`
+	Attempt      int      `json:"attempt,omitempty"`
+	Ref          string   `json:"ref,omitempty"`
+	SHA          string   `json:"sha,omitempty"`
+	Label        string   `json:"label"`
+	Observations []string `json:"observations"`
+	Instruments  []string `json:"instruments"`
+	Samples      int      `json:"samples"`
+}
+
 func LoadObservationIndex(s *store.Store) *ObservationIndex {
 	idx, err := LoadObservationIndexStrict(s)
 	if err != nil {
@@ -143,6 +154,13 @@ func (idx *ObservationIndex) ObservationsForScope(scope ObservationScope) []*ent
 	return idx.byScope[scope]
 }
 
+func (idx *ObservationIndex) ObservationByID(id string) *entity.Observation {
+	if idx == nil {
+		return nil
+	}
+	return idx.byID[strings.TrimSpace(id)]
+}
+
 func (idx *ObservationIndex) ScopesForExperiment(expID string) []ObservationScope {
 	if idx == nil {
 		return nil
@@ -166,6 +184,44 @@ func (idx *ObservationIndex) ScopesForExperimentInstrument(expID, instrument str
 			continue
 		}
 		out = append(out, scope)
+	}
+	return out
+}
+
+func (idx *ObservationIndex) BaselineCandidatesForExperimentInstrument(expID, instrument string) []BaselineCandidate {
+	if idx == nil {
+		return []BaselineCandidate{}
+	}
+	scopes := idx.ScopesForExperimentInstrument(expID, instrument)
+	out := make([]BaselineCandidate, 0, len(scopes))
+	for _, scope := range scopes {
+		obs := idx.ObservationsForScope(scope)
+		var ids []string
+		instruments := map[string]struct{}{}
+		samples := 0
+		for _, o := range obs {
+			if o == nil {
+				continue
+			}
+			if instrument != "" && o.Instrument != instrument {
+				continue
+			}
+			ids = append(ids, o.ID)
+			if o.Instrument != "" {
+				instruments[o.Instrument] = struct{}{}
+			}
+			samples += observationSampleCount(o)
+		}
+		out = append(out, BaselineCandidate{
+			Experiment:   scope.Experiment,
+			Attempt:      scope.Attempt,
+			Ref:          scope.Ref,
+			SHA:          scope.SHA,
+			Label:        FormatObservationScope(scope),
+			Observations: ids,
+			Instruments:  sortedInstrumentKeys(instruments),
+			Samples:      samples,
+		})
 	}
 	return out
 }
@@ -270,6 +326,28 @@ func observationsContainInstrument(obs []*entity.Observation, instrument string)
 		}
 	}
 	return false
+}
+
+func observationSampleCount(o *entity.Observation) int {
+	if o == nil {
+		return 0
+	}
+	if len(o.PerSample) > 0 {
+		return len(o.PerSample)
+	}
+	if o.Samples > 0 {
+		return o.Samples
+	}
+	return 1
+}
+
+func sortedInstrumentKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func shortScopeSHA(sha string) string {


### PR DESCRIPTION
## Summary
- Add explicit baseline selectors for `analyze`: `--baseline-ref` and `--baseline-observation`, including JSON `baseline_candidates` for ambiguous baseline scopes.
- Reuse inferred baseline resolution for `analyze --baseline auto`, covering candidate-recorded baselines, supported ancestors, and goal baselines.
- Surface best-effort `recommended_baseline` data for in-flight experiments in `cycle-context --json` and update agent docs.

## Tests
- `make test`

Closes #69
