### PR TITLE
Expose budget advisories

### DIFF
--- a/internal/cli/budget_advisory_test.go
+++ b/internal/cli/budget_advisory_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("budget advisory surfaces", func() {
+	BeforeEach(saveGlobals)
+
+	It("renders stale active experiments in status text using the advisory threshold", func() {
+		dir, s := setupGoalStore()
+		old := time.Now().UTC().Add(-2 * time.Hour)
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:        "H-0001",
+			GoalID:    "G-0001",
+			Claim:     "try the stale candidate",
+			Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease"},
+			KillIf:    []string{"no improvement"},
+			Status:    entity.StatusOpen,
+			Author:    "agent:test",
+			CreatedAt: old,
+		})).To(Succeed())
+		Expect(s.WriteExperiment(&entity.Experiment{
+			ID:          "E-0001",
+			GoalID:      "G-0001",
+			Hypothesis:  "H-0001",
+			Status:      entity.ExpImplemented,
+			Baseline:    entity.Baseline{Ref: "HEAD"},
+			Instruments: []string{"timing"},
+			Author:      "agent:test",
+			CreatedAt:   old,
+		})).To(Succeed())
+		Expect(s.AppendEvent(store.Event{
+			Ts:      old,
+			Kind:    "experiment.implement",
+			Actor:   "agent:test",
+			Subject: "E-0001",
+		})).To(Succeed())
+
+		out := runCLI(dir, "status", "--goal", "G-0001")
+
+		expectText(out,
+			"budget advisory warnings:",
+			"stale_experiment",
+			"stale experiments (>60m recommended threshold since last activity):",
+			"E-0001",
+		)
+		status := runCLIJSON[cliStatusResponse](dir, "status", "--goal", "G-0001")
+		Expect(status.StaleExperiments).To(ContainElement(HaveField("ID", "E-0001")))
+		Expect(status.BudgetAdvisory.StaleExperiments).To(ContainElement(HaveField("ID", "E-0001")))
+	})
+
+	It("reports frontier stalls in cycle-context budget_advisory", func() {
+		dir := setupObserveScenarioStore()
+		registerScenarioInstruments(dir)
+		fixture := setupLifecycleFixture(dir)
+		s, err := store.Open(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s.UpdateConfig(func(cfg *store.Config) error {
+			cfg.Budgets.FrontierStallK = 1
+			return nil
+		})).To(Succeed())
+
+		win := setupLifecycleCandidate(dir, cliLifecycleCandidateSpec{
+			Claim: "tighten the hot loop", MinEffect: "0.1",
+			RefName: "candidate/advisory-win", Message: "improve timing",
+			Timing: "80\n", Size: "900\n",
+		})
+		obs1 := observeLifecycleCandidate(dir, win)
+		concl1 := runCLIJSON[cliIDResponse](dir,
+			"conclude", win.HypothesisID,
+			"--verdict", "supported",
+			"--baseline-experiment", fixture.BaselineID,
+			"--observations", observeResultID(obs1, "timing"),
+		)
+		runCLIJSON[cliIDResponse](dir,
+			"conclusion", "accept", concl1.ID,
+			"--reviewed-by", "human:gate",
+			"--rationale", "Stats confirmed. Code matches the mechanism. No gaming or metric manipulation was detected.",
+		)
+
+		stall := setupLifecycleCandidate(dir, cliLifecycleCandidateSpec{
+			Claim: "a smaller tweak might help", MinEffect: "0.05",
+			RefName: "candidate/advisory-stall", Message: "small tweak",
+			Timing: "95\n", Size: "900\n",
+		})
+		obs2 := observeLifecycleCandidate(dir, stall)
+		runCLIJSON[cliIDResponse](dir,
+			"conclude", stall.HypothesisID,
+			"--verdict", "inconclusive",
+			"--baseline-experiment", fixture.BaselineID,
+			"--observations", observeResultID(obs2, "timing"),
+		)
+
+		ctx := runCLIJSON[cliCycleContextResponse](dir, "cycle-context", "--goal", fixture.GoalID)
+
+		Expect(ctx.BudgetAdvisory.Frontier.Applicable).To(BeTrue())
+		Expect(ctx.BudgetAdvisory.Frontier.StalledFor).To(Equal(1))
+		Expect(ctx.BudgetAdvisory.Frontier.Limit).To(Equal(1))
+		Expect(ctx.BudgetAdvisory.Frontier.StallReached).To(BeTrue())
+		Expect(budgetWarningCodes(ctx.BudgetAdvisory.Warnings)).To(ContainElement("frontier_stalled"))
+	})
+})
+
+func budgetWarningCodes(warnings []readmodel.BudgetWarning) []string {
+	out := make([]string, 0, len(warnings))
+	for _, warning := range warnings {
+		out = append(out, warning.Code)
+	}
+	return out
+}

--- a/internal/cli/cycle_context.go
+++ b/internal/cli/cycle_context.go
@@ -21,6 +21,7 @@ type cycleContextSnapshot struct {
 	MainCheckoutDirty      bool                             `json:"main_checkout_dirty"`
 	MainCheckoutDirtyPaths []string                         `json:"main_checkout_dirty_paths"`
 	Budgets                readmodel.BudgetSnapshot         `json:"budgets"`
+	BudgetAdvisory         readmodel.BudgetAdvisory         `json:"budget_advisory"`
 	Counts                 map[string]int                   `json:"counts"`
 	Instruments            map[string]store.Instrument      `json:"instruments"`
 	ActiveScratch          []readmodel.ScratchWorkspaceView `json:"active_scratch"`
@@ -147,6 +148,11 @@ func captureCycleContext(s *store.Store, scope goalScope) (*cycleContextSnapshot
 				cycleContextScope: *payload,
 			})
 		}
+		advisory, err := buildCycleContextBudgetAdvisory(s, inputs, scope, nil)
+		if err != nil {
+			return nil, err
+		}
+		snap.BudgetAdvisory = advisory
 		return snap, nil
 	}
 
@@ -163,6 +169,11 @@ func captureCycleContext(s *store.Store, scope goalScope) (*cycleContextSnapshot
 	}
 	snap.Counts = counts
 	snap.cycleContextScope = payload
+	advisory, err := buildCycleContextBudgetAdvisory(s, inputs, scope, goal)
+	if err != nil {
+		return nil, err
+	}
+	snap.BudgetAdvisory = advisory
 	return snap, nil
 }
 
@@ -304,6 +315,38 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 	return payload, counts, nil
 }
 
+func buildCycleContextBudgetAdvisory(s *store.Store, inputs *cycleContextInputs, scope goalScope, goal *entity.Goal) (readmodel.BudgetAdvisory, error) {
+	resolver := newGoalScopeResolver(s, scope)
+	hyps := resolver.filterHypotheses(inputs.hypotheses)
+	exps, err := resolver.filterExperiments(inputs.experiments)
+	if err != nil {
+		return readmodel.BudgetAdvisory{}, err
+	}
+	concls, err := resolver.filterConclusions(inputs.conclusions)
+	if err != nil {
+		return readmodel.BudgetAdvisory{}, err
+	}
+	obs, err := resolver.filterObservations(inputs.observations)
+	if err != nil {
+		return readmodel.BudgetAdvisory{}, err
+	}
+	events, err := resolver.filterEvents(inputs.events)
+	if err != nil {
+		return readmodel.BudgetAdvisory{}, err
+	}
+	return readmodel.BuildBudgetAdvisory(readmodel.BudgetAdvisoryInputs{
+		Config:       inputs.cfg,
+		State:        inputs.state,
+		Goal:         goal,
+		Hypotheses:   hyps,
+		Experiments:  exps,
+		Observations: obs,
+		Conclusions:  concls,
+		Events:       events,
+		Now:          inputs.now,
+	}), nil
+}
+
 func addCycleContextBaselineRecommendations(
 	s *store.Store,
 	inFlight []dashboardInFlight,
@@ -397,6 +440,7 @@ func renderCycleContextText(w *output.Writer, snap *cycleContextSnapshot) {
 		w.Textln("main checkout:  clean")
 	}
 	w.Textf("instruments:    %d\n", len(snap.Instruments))
+	w.Textf("budget warnings: %d\n", len(snap.BudgetAdvisory.Warnings))
 	w.Textf("active scratch: %d\n", len(snap.ActiveScratch))
 	if snap.ScopeAll {
 		w.Textf("goals:          %d\n", len(snap.Goals))

--- a/internal/cli/cycle_context_test.go
+++ b/internal/cli/cycle_context_test.go
@@ -48,6 +48,7 @@ type cliCycleContextResponse struct {
 	MainCheckoutDirty      bool                             `json:"main_checkout_dirty"`
 	MainCheckoutDirtyPaths []string                         `json:"main_checkout_dirty_paths"`
 	Counts                 map[string]int                   `json:"counts"`
+	BudgetAdvisory         readmodel.BudgetAdvisory         `json:"budget_advisory"`
 	Instruments            map[string]store.Instrument      `json:"instruments"`
 	ActiveScratch          []readmodel.ScratchWorkspaceView `json:"active_scratch"`
 	StaleScratch           []readmodel.ScratchWorkspaceView `json:"stale_scratch,omitempty"`
@@ -81,6 +82,10 @@ var _ = Describe("cycle-context command", func() {
 		Expect(ctx.Counts).To(HaveKeyWithValue("observations", 0))
 		Expect(ctx.Counts).To(HaveKeyWithValue("conclusions", 0))
 		Expect(ctx.Counts).To(HaveKeyWithValue("lessons", 0))
+		Expect(ctx.BudgetAdvisory.EffectiveLimits.MaxExperiments).To(Equal(0))
+		Expect(ctx.BudgetAdvisory.LimitSources.MaxExperiments).To(Equal("unlimited"))
+		Expect(ctx.BudgetAdvisory.EffectiveLimits.StaleExperimentMinutes).To(Equal(readmodel.DefaultBudgetAdvisoryStaleExperimentMinutes))
+		Expect(ctx.BudgetAdvisory.Warnings).To(BeEmpty())
 		Expect(ctx.Instruments).To(BeEmpty())
 		Expect(ctx.Goals).To(BeEmpty())
 	})

--- a/internal/cli/lifecycle.go
+++ b/internal/cli/lifecycle.go
@@ -456,7 +456,34 @@ func statusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			allEvents, err := s.Events(0)
+			if err != nil {
+				return err
+			}
+			events, err := resolver.filterEvents(allEvents)
+			if err != nil {
+				return err
+			}
+			var goal *entity.Goal
+			if !scope.All && scope.GoalID != "" {
+				goal, err = s.ReadGoal(scope.GoalID)
+				if err != nil {
+					return err
+				}
+			}
 			counts := readmodel.BuildCounts(len(hyps), len(exps), len(obs), len(concls))
+			now := time.Now().UTC()
+			advisory := readmodel.BuildBudgetAdvisory(readmodel.BudgetAdvisoryInputs{
+				Config:       cfg,
+				State:        st,
+				Goal:         goal,
+				Hypotheses:   hyps,
+				Experiments:  exps,
+				Observations: obs,
+				Conclusions:  concls,
+				Events:       events,
+				Now:          now,
+			})
 
 			payload := mergeGoalScopePayload(map[string]any{
 				"root":                      s.Root(),
@@ -466,12 +493,12 @@ func statusCmd() *cobra.Command {
 				"pause_reason":              st.PauseReason,
 				"current_goal_id":           st.CurrentGoalID,
 				"counts":                    counts,
+				"budget_advisory":           advisory,
 				"last_event_at":             st.LastEventAt,
 				"main_checkout_dirty":       mainCheckout.Dirty,
 				"main_checkout_dirty_paths": mainCheckout.Paths,
 			}, scope)
 
-			now := time.Now().UTC()
 			activeScratch, staleScratch, err := activeScratchForRead(s, now)
 			if err != nil {
 				return err
@@ -483,19 +510,7 @@ func statusCmd() *cobra.Command {
 				payload["stale_scratch"] = staleScratch
 			}
 
-			// Stale experiment detection: reuse the same read-side
-			// actionability policy as dashboard/frontier instead of open-coding
-			// another "live enough to steer from" definition here.
-			var stale []staleExperimentView
-			if staleMinutes := cfg.Budgets.StaleExperimentMinutes; staleMinutes > 0 {
-				allEvents, err := s.Events(0)
-				if err != nil {
-					return err
-				}
-				expClassByID := readmodel.ClassifyExperimentsForReadFromHypotheses(exps, hyps)
-				threshold := time.Duration(staleMinutes) * time.Minute
-				_, stale = readmodel.BuildExperimentActivity(exps, expClassByID, allEvents, threshold, now)
-			}
+			stale := advisory.StaleExperiments
 			if len(stale) > 0 {
 				payload["stale_experiments"] = stale
 			}
@@ -505,10 +520,8 @@ func statusCmd() *cobra.Command {
 			// observations anywhere. A nudge for the orchestrator that it
 			// may be skipping a required measurement.
 			var unobservedInstruments []string
-			if !scope.All && scope.GoalID != "" {
-				if goal, err := s.ReadGoal(scope.GoalID); err == nil {
-					unobservedInstruments = readmodel.FindUnobservedGoalInstruments(goal, obs)
-				}
+			if goal != nil {
+				unobservedInstruments = readmodel.FindUnobservedGoalInstruments(goal, obs)
 			}
 			if len(unobservedInstruments) > 0 {
 				payload["unobserved_goal_instruments"] = unobservedInstruments
@@ -550,9 +563,22 @@ func statusCmd() *cobra.Command {
 			} else {
 				w.Textln("last event:     (none)")
 			}
+			if len(advisory.Warnings) > 0 {
+				w.Textln("")
+				w.Textln("budget advisory warnings:")
+				for _, warning := range advisory.Warnings {
+					subject := ""
+					if warning.Subject != "" {
+						subject = " [" + warning.Subject + "]"
+					}
+					w.Textf("  %-30s %-8s%s %s\n", warning.Code, warning.Severity, subject, warning.Message)
+				}
+			}
 			if len(stale) > 0 {
 				w.Textln("")
-				w.Textf("stale experiments (>%dm since last activity):\n", cfg.Budgets.StaleExperimentMinutes)
+				w.Textf("stale experiments (>%dm %s threshold since last activity):\n",
+					advisory.EffectiveLimits.StaleExperimentMinutes,
+					advisory.LimitSources.StaleExperimentMinutes)
 				for _, se := range stale {
 					w.Textf("  %-8s  %-12s  hyp=%-8s  %s ago  (last: %s)\n",
 						se.ID, se.Status, se.Hypothesis,

--- a/internal/cli/lifecycle_scenario_test.go
+++ b/internal/cli/lifecycle_scenario_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"github.com/bytter/autoresearch/internal/readmodel"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -37,9 +38,11 @@ type cliDashboardResponse struct {
 }
 
 type cliStatusResponse struct {
-	ScopeGoalID       string         `json:"scope_goal_id,omitempty"`
-	MainCheckoutDirty bool           `json:"main_checkout_dirty"`
-	Counts            map[string]int `json:"counts"`
+	ScopeGoalID       string                          `json:"scope_goal_id,omitempty"`
+	MainCheckoutDirty bool                            `json:"main_checkout_dirty"`
+	Counts            map[string]int                  `json:"counts"`
+	BudgetAdvisory    readmodel.BudgetAdvisory        `json:"budget_advisory"`
+	StaleExperiments  []readmodel.StaleExperimentView `json:"stale_experiments,omitempty"`
 }
 
 type cliLifecycleFixture struct {

--- a/internal/integration/agents/research-orchestrator.md
+++ b/internal/integration/agents/research-orchestrator.md
@@ -60,6 +60,10 @@ notebook layers are load-bearing.
    pause state, main checkout cleanliness, active goal, frontier best,
    open hypotheses, active lesson summaries, registered instruments,
    in-flight work, active/stale scratch probes, and budget/count status.
+   Read `budget_advisory.warnings` before proposing work. Frontier stalls,
+   stale experiments, repeated observations without a conclusion, or hard
+   budget near-limit/reached warnings are stop/re-steer signals unless the
+   human explicitly raises or clears a budget.
    If `main_checkout_dirty` is true, stop. Research assumes the target
    project's main checkout stays read-only. Do not patch
    bootstrap/harness/instrument-definition files

--- a/internal/integration/claude_doc.go
+++ b/internal/integration/claude_doc.go
@@ -175,6 +175,13 @@ only when this reference does not answer the question you have.
         # when no high-value next experiment remains or review is still pending.
         # stale-experiment-minutes: when > 0, status and dashboard flag idle experiments.
 
+` + "`cycle-context --json`" + ` and ` + "`status --json`" + ` include ` + "`budget_advisory`" + `:
+configured limits, effective advisory thresholds, current usage, frontier
+stall state, stale experiments, and warnings. Unset ` + "`max_experiments`" + ` /
+` + "`max_wall_time_h`" + ` remain unlimited for hard enforcement; recommended
+thresholds only produce read-side warnings. Treat warnings as stop/re-steer
+signals unless the human explicitly raises or clears a budget.
+
 ### Goal lifecycle (serialized, one active at a time)
 
 Goals are the top-level unit of research. At most one is active; every

--- a/internal/readmodel/budget_advisory.go
+++ b/internal/readmodel/budget_advisory.go
@@ -1,0 +1,286 @@
+package readmodel
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
+	"github.com/bytter/autoresearch/internal/store"
+)
+
+const (
+	DefaultBudgetAdvisoryFrontierStallK                = 5
+	DefaultBudgetAdvisoryStaleExperimentMinutes        = 60
+	DefaultBudgetAdvisoryObservationsWithoutConclusion = 5
+)
+
+const (
+	budgetLimitSourceConfigured  = "configured"
+	budgetLimitSourceRecommended = "recommended"
+	budgetLimitSourceUnlimited   = "unlimited"
+)
+
+type BudgetAdvisoryInputs struct {
+	Config       *store.Config
+	State        *store.State
+	Goal         *entity.Goal
+	Hypotheses   []*entity.Hypothesis
+	Experiments  []*entity.Experiment
+	Observations []*entity.Observation
+	Conclusions  []*entity.Conclusion
+	Events       []store.Event
+	Now          time.Time
+}
+
+type BudgetAdvisory struct {
+	ConfiguredLimits BudgetAdvisoryLimits       `json:"configured_limits"`
+	EffectiveLimits  BudgetAdvisoryLimits       `json:"effective_limits"`
+	LimitSources     BudgetAdvisoryLimitSources `json:"limit_sources"`
+	Usage            BudgetAdvisoryUsage        `json:"usage"`
+	Frontier         BudgetAdvisoryFrontier     `json:"frontier"`
+	StaleExperiments []StaleExperimentView      `json:"stale_experiments"`
+	Warnings         []BudgetWarning            `json:"warnings"`
+}
+
+type BudgetAdvisoryLimits struct {
+	MaxExperiments                int `json:"max_experiments"`
+	MaxWallTimeH                  int `json:"max_wall_time_h"`
+	FrontierStallK                int `json:"frontier_stall_k"`
+	StaleExperimentMinutes        int `json:"stale_experiment_minutes"`
+	ObservationsWithoutConclusion int `json:"observations_without_conclusion"`
+}
+
+type BudgetAdvisoryLimitSources struct {
+	MaxExperiments                string `json:"max_experiments"`
+	MaxWallTimeH                  string `json:"max_wall_time_h"`
+	FrontierStallK                string `json:"frontier_stall_k"`
+	StaleExperimentMinutes        string `json:"stale_experiment_minutes"`
+	ObservationsWithoutConclusion string `json:"observations_without_conclusion"`
+}
+
+type BudgetAdvisoryUsage struct {
+	Experiments                   int        `json:"experiments"`
+	ElapsedH                      float64    `json:"elapsed_h"`
+	ResearchStartedAt             *time.Time `json:"research_started_at,omitempty"`
+	LastEventAt                   *time.Time `json:"last_event_at,omitempty"`
+	TimeSinceLastEventS           float64    `json:"time_since_last_event_s"`
+	ObservationsWithoutConclusion int        `json:"observations_without_conclusion"`
+}
+
+type BudgetAdvisoryFrontier struct {
+	Applicable   bool   `json:"applicable"`
+	StalledFor   int    `json:"stalled_for"`
+	Limit        int    `json:"limit"`
+	LimitSource  string `json:"limit_source"`
+	StallReached bool   `json:"stall_reached"`
+}
+
+type BudgetWarning struct {
+	Code           string `json:"code"`
+	Severity       string `json:"severity"`
+	Subject        string `json:"subject,omitempty"`
+	Message        string `json:"message"`
+	Recommendation string `json:"recommendation,omitempty"`
+}
+
+func BuildBudgetAdvisory(in BudgetAdvisoryInputs) BudgetAdvisory {
+	now := in.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	advisory := BudgetAdvisory{
+		ConfiguredLimits: configuredBudgetAdvisoryLimits(in.Config),
+		StaleExperiments: []StaleExperimentView{},
+		Warnings:         []BudgetWarning{},
+	}
+	advisory.EffectiveLimits, advisory.LimitSources = effectiveBudgetAdvisoryLimits(advisory.ConfiguredLimits)
+	advisory.Usage = budgetAdvisoryUsage(in.State, in.Events, now)
+
+	classByID := ClassifyExperimentsForReadFromHypotheses(in.Experiments, in.Hypotheses)
+	staleThreshold := time.Duration(advisory.EffectiveLimits.StaleExperimentMinutes) * time.Minute
+	advisory.StaleExperiments = FindStaleExperimentsForRead(in.Experiments, classByID, in.Events, staleThreshold, now)
+
+	advisory.Frontier = BudgetAdvisoryFrontier{
+		Applicable:  in.Goal != nil,
+		Limit:       advisory.EffectiveLimits.FrontierStallK,
+		LimitSource: advisory.LimitSources.FrontierStallK,
+	}
+	if in.Goal != nil {
+		frontier := BuildFrontierSnapshot(in.Goal, in.Conclusions, NewObservationIndex(in.Observations), classByID)
+		advisory.Frontier.StalledFor = frontier.StalledFor
+		advisory.Frontier.StallReached = advisory.EffectiveLimits.FrontierStallK > 0 &&
+			frontier.StalledFor >= advisory.EffectiveLimits.FrontierStallK
+	}
+
+	advisory.Warnings = budgetAdvisoryWarnings(advisory)
+	return advisory
+}
+
+func configuredBudgetAdvisoryLimits(cfg *store.Config) BudgetAdvisoryLimits {
+	if cfg == nil {
+		return BudgetAdvisoryLimits{}
+	}
+	return BudgetAdvisoryLimits{
+		MaxExperiments:                cfg.Budgets.MaxExperiments,
+		MaxWallTimeH:                  cfg.Budgets.MaxWallTimeH,
+		FrontierStallK:                cfg.Budgets.FrontierStallK,
+		StaleExperimentMinutes:        cfg.Budgets.StaleExperimentMinutes,
+		ObservationsWithoutConclusion: 0,
+	}
+}
+
+func effectiveBudgetAdvisoryLimits(configured BudgetAdvisoryLimits) (BudgetAdvisoryLimits, BudgetAdvisoryLimitSources) {
+	effective := configured
+	sources := BudgetAdvisoryLimitSources{
+		MaxExperiments:                positiveLimitSource(configured.MaxExperiments),
+		MaxWallTimeH:                  positiveLimitSource(configured.MaxWallTimeH),
+		FrontierStallK:                budgetLimitSourceConfigured,
+		StaleExperimentMinutes:        budgetLimitSourceConfigured,
+		ObservationsWithoutConclusion: budgetLimitSourceRecommended,
+	}
+	if effective.FrontierStallK <= 0 {
+		effective.FrontierStallK = DefaultBudgetAdvisoryFrontierStallK
+		sources.FrontierStallK = budgetLimitSourceRecommended
+	}
+	if effective.StaleExperimentMinutes <= 0 {
+		effective.StaleExperimentMinutes = DefaultBudgetAdvisoryStaleExperimentMinutes
+		sources.StaleExperimentMinutes = budgetLimitSourceRecommended
+	}
+	if effective.ObservationsWithoutConclusion <= 0 {
+		effective.ObservationsWithoutConclusion = DefaultBudgetAdvisoryObservationsWithoutConclusion
+		sources.ObservationsWithoutConclusion = budgetLimitSourceRecommended
+	}
+	return effective, sources
+}
+
+func positiveLimitSource(value int) string {
+	if value > 0 {
+		return budgetLimitSourceConfigured
+	}
+	return budgetLimitSourceUnlimited
+}
+
+func budgetAdvisoryUsage(st *store.State, events []store.Event, now time.Time) BudgetAdvisoryUsage {
+	usage := BudgetAdvisoryUsage{
+		ObservationsWithoutConclusion: observationsWithoutConclusion(events),
+	}
+	if st != nil {
+		usage.Experiments = st.Counters["E"]
+		if st.ResearchStartedAt != nil {
+			started := *st.ResearchStartedAt
+			usage.ResearchStartedAt = &started
+			usage.ElapsedH = now.Sub(started).Hours()
+		}
+	}
+	if last := latestEventAt(events); last != nil {
+		usage.LastEventAt = last
+		usage.TimeSinceLastEventS = nonNegativeDurationSeconds(now.Sub(*last))
+	} else if st != nil && st.LastEventAt != nil {
+		last := *st.LastEventAt
+		usage.LastEventAt = &last
+		usage.TimeSinceLastEventS = nonNegativeDurationSeconds(now.Sub(last))
+	}
+	return usage
+}
+
+func observationsWithoutConclusion(events []store.Event) int {
+	count := 0
+	for i := len(events) - 1; i >= 0; i-- {
+		switch events[i].Kind {
+		case "conclusion.write", "conclusion.downgrade":
+			return count
+		case "observation.record":
+			count++
+		}
+	}
+	return count
+}
+
+func latestEventAt(events []store.Event) *time.Time {
+	if len(events) == 0 {
+		return nil
+	}
+	last := events[0].Ts
+	for _, ev := range events[1:] {
+		if ev.Ts.After(last) {
+			last = ev.Ts
+		}
+	}
+	return &last
+}
+
+func nonNegativeDurationSeconds(d time.Duration) float64 {
+	if d < 0 {
+		return 0
+	}
+	return d.Seconds()
+}
+
+func budgetAdvisoryWarnings(advisory BudgetAdvisory) []BudgetWarning {
+	warnings := []BudgetWarning{}
+	if limit := advisory.ConfiguredLimits.MaxExperiments; limit > 0 {
+		used := advisory.Usage.Experiments
+		switch {
+		case used >= limit:
+			warnings = append(warnings, BudgetWarning{
+				Code:           "max_experiments_reached",
+				Severity:       "critical",
+				Message:        fmt.Sprintf("max_experiments=%d reached after %d experiments", limit, used),
+				Recommendation: "finish in-flight work or ask the human to raise the experiment budget before designing more experiments",
+			})
+		case used*100 >= limit*80:
+			warnings = append(warnings, BudgetWarning{
+				Code:           "max_experiments_near_limit",
+				Severity:       "warning",
+				Message:        fmt.Sprintf("experiment budget is %d/%d used", used, limit),
+				Recommendation: "prioritize high-value hypotheses and avoid opening low-confidence experiments",
+			})
+		}
+	}
+	if limit := advisory.ConfiguredLimits.MaxWallTimeH; limit > 0 {
+		elapsed := advisory.Usage.ElapsedH
+		switch {
+		case elapsed >= float64(limit):
+			warnings = append(warnings, BudgetWarning{
+				Code:           "max_wall_time_reached",
+				Severity:       "critical",
+				Message:        fmt.Sprintf("max_wall_time_h=%d reached after %.2f hours", limit, elapsed),
+				Recommendation: "finish in-flight work or ask the human to raise the wall-time budget before designing more experiments",
+			})
+		case elapsed >= float64(limit)*0.8:
+			warnings = append(warnings, BudgetWarning{
+				Code:           "max_wall_time_near_limit",
+				Severity:       "warning",
+				Message:        fmt.Sprintf("wall-time budget is %.2f/%d hours used", elapsed, limit),
+				Recommendation: "prefer conclusions or cleanup over starting speculative work",
+			})
+		}
+	}
+	if advisory.Frontier.Applicable && advisory.Frontier.StallReached {
+		warnings = append(warnings, BudgetWarning{
+			Code:           "frontier_stalled",
+			Severity:       "warning",
+			Message:        fmt.Sprintf("frontier has stalled for %d conclusion(s), meeting the %s threshold of %d", advisory.Frontier.StalledFor, advisory.Frontier.LimitSource, advisory.Frontier.Limit),
+			Recommendation: "stop or re-steer unless there is a strong, distinct next hypothesis",
+		})
+	}
+	for _, stale := range advisory.StaleExperiments {
+		warnings = append(warnings, BudgetWarning{
+			Code:           "stale_experiment",
+			Severity:       "warning",
+			Subject:        stale.ID,
+			Message:        fmt.Sprintf("%s has had no recorded activity for %.1f minutes", stale.ID, stale.StaleMinutes),
+			Recommendation: "finish, reset, or explicitly abandon this in-flight work before opening more fronts",
+		})
+	}
+	if limit := advisory.EffectiveLimits.ObservationsWithoutConclusion; limit > 0 &&
+		advisory.Usage.ObservationsWithoutConclusion >= limit {
+		warnings = append(warnings, BudgetWarning{
+			Code:           "observations_without_conclusion",
+			Severity:       "warning",
+			Message:        fmt.Sprintf("%d observation(s) have been recorded since the last conclusion", advisory.Usage.ObservationsWithoutConclusion),
+			Recommendation: "write a conclusion or explain why additional measurement is still necessary",
+		})
+	}
+	return warnings
+}

--- a/internal/readmodel/budget_advisory_test.go
+++ b/internal/readmodel/budget_advisory_test.go
@@ -1,0 +1,54 @@
+package readmodel
+
+import (
+	"time"
+
+	"github.com/bytter/autoresearch/internal/store"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("budget advisory read model", func() {
+	It("keeps unset experiment and wall-time budgets advisory-only", func() {
+		now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+		advisory := BuildBudgetAdvisory(BudgetAdvisoryInputs{
+			Config: &store.Config{},
+			State:  &store.State{Counters: map[string]int{"E": 999}},
+			Now:    now,
+		})
+
+		Expect(advisory.ConfiguredLimits.MaxExperiments).To(Equal(0))
+		Expect(advisory.EffectiveLimits.MaxExperiments).To(Equal(0))
+		Expect(advisory.LimitSources.MaxExperiments).To(Equal("unlimited"))
+		Expect(advisory.EffectiveLimits.MaxWallTimeH).To(Equal(0))
+		Expect(advisory.LimitSources.MaxWallTimeH).To(Equal("unlimited"))
+		Expect(advisory.EffectiveLimits.FrontierStallK).To(Equal(DefaultBudgetAdvisoryFrontierStallK))
+		Expect(advisory.LimitSources.FrontierStallK).To(Equal("recommended"))
+		Expect(advisory.EffectiveLimits.StaleExperimentMinutes).To(Equal(DefaultBudgetAdvisoryStaleExperimentMinutes))
+		Expect(advisory.LimitSources.StaleExperimentMinutes).To(Equal("recommended"))
+		Expect(advisory.Warnings).NotTo(ContainElement(HaveField("Code", ContainSubstring("max_experiments"))))
+		Expect(advisory.Warnings).NotTo(ContainElement(HaveField("Code", ContainSubstring("max_wall_time"))))
+	})
+
+	It("counts observations since the last conclusion and warns at the advisory threshold", func() {
+		now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+		events := []store.Event{
+			{Ts: now.Add(-10 * time.Minute), Kind: "conclusion.write", Subject: "C-0001"},
+			{Ts: now.Add(-9 * time.Minute), Kind: "observation.record", Subject: "O-0001"},
+			{Ts: now.Add(-8 * time.Minute), Kind: "observation.record", Subject: "O-0002"},
+			{Ts: now.Add(-7 * time.Minute), Kind: "observation.record", Subject: "O-0003"},
+			{Ts: now.Add(-6 * time.Minute), Kind: "observation.record", Subject: "O-0004"},
+			{Ts: now.Add(-5 * time.Minute), Kind: "observation.record", Subject: "O-0005"},
+		}
+
+		advisory := BuildBudgetAdvisory(BudgetAdvisoryInputs{
+			Config: &store.Config{},
+			State:  &store.State{Counters: map[string]int{}},
+			Events: events,
+			Now:    now,
+		})
+
+		Expect(advisory.Usage.ObservationsWithoutConclusion).To(Equal(5))
+		Expect(advisory.Warnings).To(ContainElement(HaveField("Code", "observations_without_conclusion")))
+	})
+})


### PR DESCRIPTION
## Summary
- Add a shared budget advisory read model with configured limits, effective advisory thresholds, usage, frontier stall state, stale experiments, and warning records.
- Surface `budget_advisory` in `cycle-context --json` and `status --json`, and render advisory warnings/stale active experiments in status text.
- Update agent-facing docs so orchestrators treat advisory warnings as stop/re-steer signals.

## Tests
- `go test ./internal/readmodel`
- `go test ./internal/cli`
- `make test`

Closes #71
