### PR TITLE
Preserve invalidated lesson preflight override

### DIFF
--- a/DATAMODEL.md
+++ b/DATAMODEL.md
@@ -138,6 +138,7 @@ goal and names the instrument that will measure its predicted effect.
 | `Predicts` | `Predicts` | `predicts` | What the hypothesis predicts. |
 | `KillIf` | `[]string` | `kill_if` | At least one kill criterion required. |
 | `InspiredBy` | `[]string` | `inspired_by` | Lesson IDs (`L-NNNN`). Firewall accepts only `active` lessons on `system` or `reviewed_decisive` chains. |
+| `AllowInvalidatedLessons` | `bool` | `allow_invalidated_lessons` | Records that `hypothesis add --allow-invalidated` was intentionally used for a retrospective contrast; downstream preflight preserves that narrow override. |
 | `Status` | `string` | `status` | See state machine below. |
 | `Priority` | `string` | `priority` | Set to `human` by `hypothesis promote`. Generator picks priority=human first. |
 | `Author` | `string` | `author` | |

--- a/internal/cli/experiment_preflight_test.go
+++ b/internal/cli/experiment_preflight_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"time"
+
+	"github.com/bytter/autoresearch/internal/entity"
 	"github.com/bytter/autoresearch/internal/readmodel"
+	"github.com/bytter/autoresearch/internal/store"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -71,6 +75,84 @@ var _ = Describe("experiment preflight", func() {
 
 		text := runCLI(dir, "experiment", "preflight", exp.ID)
 		expectText(text, "missing_constraint_instrument", "mechanism_evidence_unconfigured")
+	})
+
+	It("preserves the invalidated lesson override for retrospective contrasts", func() {
+		dir := setupObserveScenarioStore()
+		registerScenarioInstruments(dir)
+		setupLifecycleFixture(dir)
+		s, err := store.Open(dir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(s.WriteLesson(&entity.Lesson{
+			ID:        "L-0900",
+			Claim:     "invalidated timing lesson kept for contrast",
+			Scope:     entity.LessonScopeHypothesis,
+			Subjects:  []string{"H-0900"},
+			Status:    entity.LessonStatusInvalidated,
+			Author:    "agent:critic",
+			CreatedAt: time.Now().UTC(),
+		})).To(Succeed())
+
+		hyp := runCLIJSON[cliIDResponse](dir,
+			"hypothesis", "add",
+			"--claim", "contrast against an invalidated timing lesson",
+			"--predicts-instrument", "timing",
+			"--predicts-target", "kernel",
+			"--predicts-direction", "decrease",
+			"--predicts-min-effect", "0.1",
+			"--kill-if", "tests fail",
+			"--inspired-by", "L-0900",
+			"--allow-invalidated",
+		)
+		exp := runCLIJSON[cliIDResponse](dir,
+			"experiment", "design", hyp.ID,
+			"--baseline", "HEAD",
+			"--instruments", "timing,binary_size,host_test",
+		)
+
+		report := runCLIJSON[readmodel.ExperimentPreflightReport](dir, "experiment", "preflight", exp.ID)
+
+		Expect(report.OK).To(BeTrue())
+		Expect(preflightIssueCodes(report.Issues)).NotTo(ContainElement("lesson_not_reviewed"))
+	})
+
+	It("still rejects invalidated lessons without the persisted override", func() {
+		dir := setupObserveScenarioStore()
+		registerScenarioInstruments(dir)
+		fixture := setupLifecycleFixture(dir)
+		s, err := store.Open(dir)
+		Expect(err).NotTo(HaveOccurred())
+		now := time.Now().UTC()
+		Expect(s.WriteLesson(&entity.Lesson{
+			ID:        "L-0901",
+			Claim:     "invalidated timing lesson",
+			Scope:     entity.LessonScopeHypothesis,
+			Subjects:  []string{"H-0901"},
+			Status:    entity.LessonStatusInvalidated,
+			Author:    "agent:critic",
+			CreatedAt: now,
+		})).To(Succeed())
+		Expect(s.WriteHypothesis(&entity.Hypothesis{
+			ID:         "H-0901",
+			GoalID:     fixture.GoalID,
+			Claim:      "legacy invalidated timing lesson citation",
+			Predicts:   entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.1},
+			KillIf:     []string{"tests fail"},
+			InspiredBy: []string{"L-0901"},
+			Status:     entity.StatusOpen,
+			Author:     "agent:orchestrator",
+			CreatedAt:  now,
+		})).To(Succeed())
+		exp := runCLIJSON[cliIDResponse](dir,
+			"experiment", "design", "H-0901",
+			"--baseline", "HEAD",
+			"--instruments", "timing,binary_size,host_test",
+		)
+
+		report := runCLIJSON[readmodel.ExperimentPreflightReport](dir, "experiment", "preflight", exp.ID)
+
+		Expect(report.OK).To(BeFalse())
+		Expect(preflightIssueCodes(report.Issues)).To(ContainElement("lesson_not_reviewed"))
 	})
 })
 

--- a/internal/cli/hypothesis.go
+++ b/internal/cli/hypothesis.go
@@ -112,13 +112,14 @@ func hypothesisAddCmd() *cobra.Command {
 					Direction:  predDirection,
 					MinEffect:  predMinEffect,
 				},
-				KillIf:     killIf,
-				InspiredBy: inspiredBy,
-				Status:     entity.StatusOpen,
-				Author:     or(author, "human"),
-				CreatedAt:  nowUTC(),
-				Tags:       tags,
-				Body:       entity.AppendMarkdownSection("", "Rationale", rationale),
+				KillIf:                  killIf,
+				InspiredBy:              inspiredBy,
+				AllowInvalidatedLessons: allowInvalidated,
+				Status:                  entity.StatusOpen,
+				Author:                  or(author, "human"),
+				CreatedAt:               nowUTC(),
+				Tags:                    tags,
+				Body:                    entity.AppendMarkdownSection("", "Rationale", rationale),
 			}
 			if err := firewall.ValidateHypothesis(h, cfg); err != nil {
 				return err
@@ -145,6 +146,9 @@ func hypothesisAddCmd() *cobra.Command {
 			}
 			if len(inspiredBy) > 0 {
 				eventData["inspired_by"] = inspiredBy
+			}
+			if allowInvalidated {
+				eventData["allow_invalidated_lessons"] = true
 			}
 			if err := emitEvent(s, "hypothesis.add", or(author, "human"), id, eventData); err != nil {
 				return err

--- a/internal/entity/hypothesis.go
+++ b/internal/entity/hypothesis.go
@@ -17,19 +17,20 @@ const (
 )
 
 type Hypothesis struct {
-	ID         string    `yaml:"id"                    json:"id"`
-	GoalID     string    `yaml:"goal_id,omitempty"     json:"goal_id,omitempty"`
-	Parent     string    `yaml:"parent,omitempty"      json:"parent,omitempty"`
-	Claim      string    `yaml:"claim"                 json:"claim"`
-	Predicts   Predicts  `yaml:"predicts"              json:"predicts"`
-	KillIf     []string  `yaml:"kill_if"               json:"kill_if"`
-	InspiredBy []string  `yaml:"inspired_by,omitempty" json:"inspired_by,omitempty"`
-	Status     string    `yaml:"status"                json:"status"`
-	Priority   string    `yaml:"priority,omitempty"    json:"priority,omitempty"`
-	Author     string    `yaml:"author"                json:"author"`
-	CreatedAt  time.Time `yaml:"created_at"            json:"created_at"`
-	Tags       []string  `yaml:"tags,omitempty"        json:"tags,omitempty"`
-	Body       string    `yaml:"-"                     json:"body,omitempty"`
+	ID                      string    `yaml:"id"                    json:"id"`
+	GoalID                  string    `yaml:"goal_id,omitempty"     json:"goal_id,omitempty"`
+	Parent                  string    `yaml:"parent,omitempty"      json:"parent,omitempty"`
+	Claim                   string    `yaml:"claim"                 json:"claim"`
+	Predicts                Predicts  `yaml:"predicts"              json:"predicts"`
+	KillIf                  []string  `yaml:"kill_if"               json:"kill_if"`
+	InspiredBy              []string  `yaml:"inspired_by,omitempty" json:"inspired_by,omitempty"`
+	AllowInvalidatedLessons bool      `yaml:"allow_invalidated_lessons,omitempty" json:"allow_invalidated_lessons,omitempty"`
+	Status                  string    `yaml:"status"                json:"status"`
+	Priority                string    `yaml:"priority,omitempty"    json:"priority,omitempty"`
+	Author                  string    `yaml:"author"                json:"author"`
+	CreatedAt               time.Time `yaml:"created_at"            json:"created_at"`
+	Tags                    []string  `yaml:"tags,omitempty"        json:"tags,omitempty"`
+	Body                    string    `yaml:"-"                     json:"body,omitempty"`
 }
 
 // Predicts is what a hypothesis claims will happen to one instrument.

--- a/internal/entity/hypothesis_test.go
+++ b/internal/entity/hypothesis_test.go
@@ -20,12 +20,14 @@ var _ = Describe("Hypothesis markdown serialization", func() {
 				Direction:  "decrease",
 				MinEffect:  0.10,
 			},
-			KillIf:    []string{"flash delta > 1024 bytes", "CI crosses zero"},
-			Status:    entity.StatusOpen,
-			Author:    "human:alice",
-			CreatedAt: time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC),
-			Tags:      []string{"perf", "unroll"},
-			Body:      "# Notes\n\nIdea from the CMSIS reference.\n",
+			KillIf:                  []string{"flash delta > 1024 bytes", "CI crosses zero"},
+			InspiredBy:              []string{"L-0001"},
+			AllowInvalidatedLessons: true,
+			Status:                  entity.StatusOpen,
+			Author:                  "human:alice",
+			CreatedAt:               time.Date(2026, 4, 11, 10, 0, 0, 0, time.UTC),
+			Tags:                    []string{"perf", "unroll"},
+			Body:                    "# Notes\n\nIdea from the CMSIS reference.\n",
 		}
 
 		data, err := h.Marshal()
@@ -37,6 +39,8 @@ var _ = Describe("Hypothesis markdown serialization", func() {
 		Expect(back.Claim).To(Equal(h.Claim))
 		Expect(back.Predicts).To(Equal(h.Predicts))
 		Expect(back.KillIf).To(Equal(h.KillIf))
+		Expect(back.InspiredBy).To(Equal(h.InspiredBy))
+		Expect(back.AllowInvalidatedLessons).To(BeTrue())
 		Expect(back.Body).To(Equal(h.Body))
 	})
 })

--- a/internal/readmodel/experiment_preflight.go
+++ b/internal/readmodel/experiment_preflight.go
@@ -118,7 +118,9 @@ func (r *ExperimentPreflightReport) checkLessons(s *store.Store, hyp *entity.Hyp
 				"confirm the design notes explain why this lesson applies")
 		}
 	}
-	if err := firewall.CheckInspiredByLessonsReviewed(s, lessons); err != nil {
+	if err := firewall.CheckInspiredByLessonsReviewedWithOptions(s, lessons, firewall.InspiredByLessonOptions{
+		AllowInvalidated: hyp.AllowInvalidatedLessons,
+	}); err != nil {
 		r.add(PreflightSeverityError, "lesson_not_reviewed", "",
 			err.Error(),
 			"use only active lessons sourced from system facts or reviewed decisive chains")


### PR DESCRIPTION
## Summary
- Persist when `hypothesis add --allow-invalidated` is intentionally used for retrospective lesson contrast.
- Reuse that persisted intent in `experiment preflight` lesson validation.
- Add regression coverage for allowed retrospective contrast and ordinary invalidated lesson rejection.

## Tests
- `make test`

Closes #79
