### PR TITLE
Order downgrade signals by event time

### DIFF
--- a/internal/cli/cycle_context.go
+++ b/internal/cli/cycle_context.go
@@ -302,7 +302,7 @@ func buildCycleContextScope(s *store.Store, inputs *cycleContextInputs, scope go
 		InFlight:                 nonNilInFlight(inFlight),
 		ActiveLessons:            nonNilLessonSummaries(readmodel.BuildLessonSummaryViews(activeLessonViews)),
 		ReviewPendingConclusions: reviewPendingConclusionSignals(concls),
-		RecentDowngrades:         recentDowngradeSignals(concls, 5),
+		RecentDowngrades:         recentDowngradeSignals(concls, events, 5),
 	}
 
 	if goal != nil {
@@ -432,20 +432,62 @@ func reviewPendingConclusionSignals(concls []*entity.Conclusion) []cycleContextC
 	return out
 }
 
-func recentDowngradeSignals(concls []*entity.Conclusion, limit int) []cycleContextConclusionSignal {
-	out := make([]cycleContextConclusionSignal, 0)
+func recentDowngradeSignals(concls []*entity.Conclusion, events []store.Event, limit int) []cycleContextConclusionSignal {
+	eventTimes := latestDowngradeEventTimes(events)
+	type rankedSignal struct {
+		signal cycleContextConclusionSignal
+		sortAt time.Time
+	}
+	rows := make([]rankedSignal, 0)
 	for _, c := range concls {
 		if c == nil || c.Strict.RequestedFrom == "" {
 			continue
 		}
-		out = append(out, conclusionSignal(c, "classify downgrade reason before proposing another hypothesis"))
+		sortAt := c.CreatedAt
+		if ts, ok := eventTimes[c.ID]; ok {
+			sortAt = ts
+		}
+		rows = append(rows, rankedSignal{
+			signal: conclusionSignal(c, "classify downgrade reason before proposing another hypothesis"),
+			sortAt: sortAt,
+		})
 	}
-	sortConclusionSignalsNewestFirst(out)
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].sortAt.Equal(rows[j].sortAt) {
+			if rows[i].signal.CreatedAt.Equal(rows[j].signal.CreatedAt) {
+				return rows[i].signal.ID > rows[j].signal.ID
+			}
+			return rows[i].signal.CreatedAt.After(rows[j].signal.CreatedAt)
+		}
+		return rows[i].sortAt.After(rows[j].sortAt)
+	})
+	if limit > 0 && len(rows) > limit {
+		rows = rows[:limit]
+	}
+	out := make([]cycleContextConclusionSignal, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.signal)
 	}
 	if out == nil {
 		return []cycleContextConclusionSignal{}
+	}
+	return out
+}
+
+func latestDowngradeEventTimes(events []store.Event) map[string]time.Time {
+	out := map[string]time.Time{}
+	for _, ev := range events {
+		switch ev.Kind {
+		case "conclusion.downgrade", "conclusion.critic_downgrade":
+		default:
+			continue
+		}
+		if ev.Subject == "" {
+			continue
+		}
+		if prev, ok := out[ev.Subject]; !ok || ev.Ts.After(prev) {
+			out[ev.Subject] = ev.Ts
+		}
 	}
 	return out
 }

--- a/internal/cli/cycle_context_test.go
+++ b/internal/cli/cycle_context_test.go
@@ -153,6 +153,85 @@ var _ = Describe("cycle-context command", func() {
 		)))
 	})
 
+	It("orders recent downgrades by reviewer event time", func() {
+		dir, s := createCLIStoreDir()
+		now := time.Now().UTC()
+		Expect(s.WriteGoal(&entity.Goal{
+			ID:        "G-0001",
+			Status:    entity.GoalStatusActive,
+			CreatedAt: &now,
+			Objective: entity.Objective{Instrument: "timing", Target: "kernel", Direction: "decrease"},
+			Constraints: []entity.Constraint{
+				{Instrument: "host_test", Require: "pass"},
+			},
+		})).To(Succeed())
+		Expect(s.UpdateState(func(st *store.State) error {
+			st.CurrentGoalID = "G-0001"
+			st.Counters["G"] = 1
+			return nil
+		})).To(Succeed())
+		for _, h := range []*entity.Hypothesis{
+			{
+				ID:        "H-0001",
+				GoalID:    "G-0001",
+				Claim:     "older conclusion",
+				Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.1},
+				KillIf:    []string{"tests fail"},
+				Status:    entity.StatusInconclusive,
+				Author:    "agent:orchestrator",
+				CreatedAt: now.Add(-4 * time.Hour),
+			},
+			{
+				ID:        "H-0002",
+				GoalID:    "G-0001",
+				Claim:     "newer conclusion",
+				Predicts:  entity.Predicts{Instrument: "timing", Target: "kernel", Direction: "decrease", MinEffect: 0.1},
+				KillIf:    []string{"tests fail"},
+				Status:    entity.StatusInconclusive,
+				Author:    "agent:orchestrator",
+				CreatedAt: now.Add(-3 * time.Hour),
+			},
+		} {
+			Expect(s.WriteHypothesis(h)).To(Succeed())
+		}
+		Expect(s.WriteConclusion(&entity.Conclusion{
+			ID:         "C-0001",
+			Hypothesis: "H-0001",
+			Verdict:    entity.VerdictInconclusive,
+			Strict:     entity.Strict{RequestedFrom: entity.VerdictSupported, Reasons: []string{"critic downgrade: latest reviewer finding"}},
+			ReviewedBy: "agent:gate-reviewer",
+			Author:     "agent:orchestrator",
+			CreatedAt:  now.Add(-4 * time.Hour),
+		})).To(Succeed())
+		Expect(s.WriteConclusion(&entity.Conclusion{
+			ID:         "C-0002",
+			Hypothesis: "H-0002",
+			Verdict:    entity.VerdictInconclusive,
+			Strict:     entity.Strict{RequestedFrom: entity.VerdictSupported, Reasons: []string{"critic downgrade: earlier reviewer finding"}},
+			ReviewedBy: "agent:gate-reviewer",
+			Author:     "agent:orchestrator",
+			CreatedAt:  now.Add(-1 * time.Hour),
+		})).To(Succeed())
+		Expect(s.AppendEvent(store.Event{
+			Kind:    "conclusion.critic_downgrade",
+			Subject: "C-0002",
+			Actor:   "agent:gate-reviewer",
+			Ts:      now.Add(-30 * time.Minute),
+		})).To(Succeed())
+		Expect(s.AppendEvent(store.Event{
+			Kind:    "conclusion.critic_downgrade",
+			Subject: "C-0001",
+			Actor:   "agent:gate-reviewer",
+			Ts:      now,
+		})).To(Succeed())
+
+		ctx := runCLIJSON[cliCycleContextResponse](dir, "cycle-context", "--goal", "G-0001")
+
+		Expect(ctx.RecentDowngrades).To(HaveLen(2))
+		Expect(ctx.RecentDowngrades[0].ID).To(Equal("C-0001"))
+		Expect(ctx.RecentDowngrades[1].ID).To(Equal("C-0002"))
+	})
+
 	It("captures frontier best, open work, active lessons, and instruments for the active goal", func() {
 		dir := setupObserveScenarioStore()
 		registerScenarioInstruments(dir)


### PR DESCRIPTION
## Summary
- Sort `cycle-context` recent downgrade signals by latest downgrade event timestamp.
- Preserve conclusion creation time in the JSON signal while using event time only for recency ranking.
- Add regression coverage for an older conclusion downgraded after a newer one.

## Tests
- `make test`

Closes #80
